### PR TITLE
[WB-1958.2] Add theming support to Cell

### DIFF
--- a/.changeset/cool-parents-grow.md
+++ b/.changeset/cool-parents-grow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+Refactors Cell structure by removing Strut in favor of CSS's gap property

--- a/.changeset/late-days-join.md
+++ b/.changeset/late-days-join.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": minor
+---
+
+Creates a Cell theme that supports CSS variables

--- a/packages/wonder-blocks-cell/package.json
+++ b/packages/wonder-blocks-cell/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@khanacademy/wonder-blocks-cell",
   "version": "4.1.19",
-  "design": "v1",
   "publishConfig": {
     "access": "public"
   },
@@ -16,7 +15,6 @@
   "dependencies": {
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
-    "@khanacademy/wonder-blocks-layout": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },

--- a/packages/wonder-blocks-cell/package.json
+++ b/packages/wonder-blocks-cell/package.json
@@ -8,7 +8,16 @@
   "main": "dist/index.js",
   "module": "dist/es/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/es/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./styles.css": "./dist/css/vars.css"
+  },
   "scripts": {
+    "build:css": "pnpm exec wonder-blocks-tokens .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },

--- a/packages/wonder-blocks-cell/src/components/__tests__/compact-cell.test.tsx
+++ b/packages/wonder-blocks-cell/src/components/__tests__/compact-cell.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";
+import {Heading} from "@khanacademy/wonder-blocks-typography";
 import caretRightIcon from "@phosphor-icons/core/regular/caret-right.svg";
 
 import CompactCell from "../compact-cell";
@@ -22,9 +22,7 @@ describe("CompactCell", () => {
         // Arrange
 
         // Act
-        render(
-            <CompactCell title={<HeadingMedium>Compact cell</HeadingMedium>} />,
-        );
+        render(<CompactCell title={<Heading>Compact cell</Heading>} />);
 
         // Assert
         expect(

--- a/packages/wonder-blocks-cell/src/components/__tests__/detail-cell.test.tsx
+++ b/packages/wonder-blocks-cell/src/components/__tests__/detail-cell.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import {HeadingMedium} from "@khanacademy/wonder-blocks-typography";
+import {Heading} from "@khanacademy/wonder-blocks-typography";
 
 import DetailCell from "../detail-cell";
 
@@ -20,11 +20,7 @@ describe("DetailCell", () => {
         // Arrange
 
         // Act
-        render(
-            <DetailCell
-                title={<HeadingMedium>Detail cell title</HeadingMedium>}
-            />,
-        );
+        render(<DetailCell title={<Heading>Detail cell title</Heading>} />);
 
         // Assert
         expect(
@@ -54,9 +50,7 @@ describe("DetailCell", () => {
         render(
             <DetailCell
                 title="Detail cell"
-                subtitle1={
-                    <HeadingMedium>Detail cell subtitle 1</HeadingMedium>
-                }
+                subtitle1={<Heading>Detail cell subtitle 1</Heading>}
             />,
         );
 
@@ -88,9 +82,7 @@ describe("DetailCell", () => {
         render(
             <DetailCell
                 title="Detail cell"
-                subtitle2={
-                    <HeadingMedium>Detail cell subtitle 2</HeadingMedium>
-                }
+                subtitle2={<Heading>Detail cell subtitle 2</Heading>}
             />,
         );
 

--- a/packages/wonder-blocks-cell/src/components/compact-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/compact-cell.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import CellCore from "./internal/cell-core";
 
@@ -31,11 +31,7 @@ const CompactCell = function (props: CellProps): React.ReactElement {
 
     return (
         <CellCore {...coreProps}>
-            {typeof title === "string" ? (
-                <LabelMedium>{title}</LabelMedium>
-            ) : (
-                title
-            )}
+            {typeof title === "string" ? <BodyText>{title}</BodyText> : title}
         </CellCore>
     );
 };

--- a/packages/wonder-blocks-cell/src/components/detail-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import CellCore from "./internal/cell-core";
@@ -79,14 +78,11 @@ const DetailCell = function (props: DetailCellProps): React.ReactElement {
     return (
         <CellCore {...coreProps} innerStyle={styles.innerWrapper}>
             <Subtitle subtitle={subtitle1} disabled={coreProps.disabled} />
-            {subtitle1 && <Strut size={spacing.xxxxSmall_2} />}
             {typeof title === "string" ? (
                 <LabelMedium>{title}</LabelMedium>
             ) : (
                 title
             )}
-            {/* Add a vertical spacing between the title and the subtitle */}
-            {subtitle2 && <Strut size={spacing.xxxxSmall_2} />}
             <Subtitle subtitle={subtitle2} disabled={coreProps.disabled} />
         </CellCore>
     );
@@ -99,6 +95,7 @@ const styles = StyleSheet.create({
 
     // This is to override the default padding of the CellCore innerWrapper.
     innerWrapper: {
+        gap: sizing.size_020,
         padding: `${CellMeasurements.detailCellPadding.paddingVertical}px ${CellMeasurements.detailCellPadding.paddingHorizontal}px`,
     },
 });

--- a/packages/wonder-blocks-cell/src/components/detail-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import CellCore from "./internal/cell-core";
 
@@ -26,9 +26,9 @@ const Subtitle = ({subtitle, disabled}: SubtitleProps): React.ReactElement => {
 
     if (typeof subtitle === "string") {
         return (
-            <LabelSmall style={!disabled && styles.subtitle}>
+            <BodyText size="small" style={!disabled && styles.subtitle}>
                 {subtitle}
-            </LabelSmall>
+            </BodyText>
         );
     }
 
@@ -82,11 +82,7 @@ const DetailCell = function (props: DetailCellProps): React.ReactElement {
             contentStyle={{gap: sizing.size_020, ...contentStyle}}
         >
             <Subtitle subtitle={subtitle1} disabled={coreProps.disabled} />
-            {typeof title === "string" ? (
-                <LabelMedium>{title}</LabelMedium>
-            ) : (
-                title
-            )}
+            {typeof title === "string" ? <BodyText>{title}</BodyText> : title}
             <Subtitle subtitle={subtitle2} disabled={coreProps.disabled} />
         </CellCore>
     );

--- a/packages/wonder-blocks-cell/src/components/detail-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.tsx
@@ -73,10 +73,14 @@ type DetailCellProps = CellProps & {
  * ```
  */
 const DetailCell = function (props: DetailCellProps): React.ReactElement {
-    const {title, subtitle1, subtitle2, ...coreProps} = props;
+    const {contentStyle, title, subtitle1, subtitle2, ...coreProps} = props;
 
     return (
-        <CellCore {...coreProps} innerStyle={styles.innerWrapper}>
+        <CellCore
+            {...coreProps}
+            innerStyle={styles.innerWrapper}
+            contentStyle={{gap: sizing.size_020, ...contentStyle}}
+        >
             <Subtitle subtitle={subtitle1} disabled={coreProps.disabled} />
             {typeof title === "string" ? (
                 <LabelMedium>{title}</LabelMedium>
@@ -92,10 +96,8 @@ const styles = StyleSheet.create({
     subtitle: {
         color: semanticColor.text.secondary,
     },
-
     // This is to override the default padding of the CellCore innerWrapper.
     innerWrapper: {
-        gap: sizing.size_020,
         padding: `${CellMeasurements.detailCellPadding.paddingVertical}px ${CellMeasurements.detailCellPadding.paddingHorizontal}px`,
     },
 });

--- a/packages/wonder-blocks-cell/src/components/detail-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.tsx
@@ -5,9 +5,9 @@ import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import CellCore from "./internal/cell-core";
-import {CellMeasurements} from "./internal/common";
 
 import type {CellProps, TypographyText} from "../util/types";
+import theme from "../theme";
 
 type SubtitleProps = {
     subtitle?: TypographyText;
@@ -98,7 +98,8 @@ const styles = StyleSheet.create({
     },
     // This is to override the default padding of the CellCore innerWrapper.
     innerWrapper: {
-        padding: `${CellMeasurements.detailCellPadding.paddingVertical}px ${CellMeasurements.detailCellPadding.paddingHorizontal}px`,
+        paddingBlock: theme.root.layout.padding.block.detail,
+        paddingInline: theme.root.layout.padding.inline.detail,
     },
 });
 

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -333,20 +333,21 @@ const styles = StyleSheet.create({
         // have overflow: hidden on the inner wrapper instead of the clickable element
         // because setting it on the clickable element causes issues with existing
         // cases.
-        [":active:not([aria-current=true]) .inner-wrapper" as any]: {
-            position: "relative",
-            ":before": {
-                content: "''",
-                position: "absolute",
-                top: 0,
-                left: 0,
-                bottom: 0,
-                width: theme.root.border.width.default,
-                // We use the border token as this element acts like a border
-                // when the cell is pressed.
-                backgroundColor: theme.root.color.press.border,
+        [":active[aria-disabled=false]:not([aria-current=true]) .inner-wrapper" as any]:
+            {
+                position: "relative",
+                ":before": {
+                    content: "''",
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    bottom: 0,
+                    width: theme.root.border.width.default,
+                    // We use the border token as this element acts like a border
+                    // when the cell is pressed.
+                    backgroundColor: theme.root.color.press.border,
+                },
             },
-        },
     },
 
     active: {

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -5,7 +5,6 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {
     border,
     color,
@@ -38,18 +37,15 @@ const LeftAccessory = ({
     }
 
     return (
-        <>
-            <View
-                style={[
-                    styles.accessory,
-                    disabled && styles.accessoryDisabled,
-                    {...leftAccessoryStyle},
-                ]}
-            >
-                {leftAccessory}
-            </View>
-            <Strut size={CellMeasurements.accessoryHorizontalSpacing} />
-        </>
+        <View
+            style={[
+                styles.accessory,
+                disabled && styles.accessoryDisabled,
+                {...leftAccessoryStyle},
+            ]}
+        >
+            {leftAccessory}
+        </View>
     );
 };
 
@@ -76,20 +72,17 @@ const RightAccessory = ({
     }
 
     return (
-        <>
-            <Strut size={CellMeasurements.accessoryHorizontalSpacing} />
-            <View
-                style={[
-                    styles.accessory,
-                    styles.accessoryRight,
-                    disabled && styles.accessoryDisabled,
-                    {...rightAccessoryStyle},
-                    active && styles.accessoryActive,
-                ]}
-            >
-                {rightAccessory}
-            </View>
-        </>
+        <View
+            style={[
+                styles.accessory,
+                styles.accessoryRight,
+                disabled && styles.accessoryDisabled,
+                {...rightAccessoryStyle},
+                active && styles.accessoryActive,
+            ]}
+        >
+            {rightAccessory}
+        </View>
     );
 };
 
@@ -283,6 +276,7 @@ const styles = StyleSheet.create({
 
     innerWrapper: {
         minHeight: CellMeasurements.cellMinHeight,
+        gap: CellMeasurements.accessoryHorizontalSpacing,
         padding: `${CellMeasurements.cellPadding.paddingVertical}px ${CellMeasurements.cellPadding.paddingHorizontal}px`,
         flexDirection: "row",
         flex: 1,

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -5,16 +5,11 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {
-    border,
-    color,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
 
-import {CellMeasurements, getHorizontalRuleStyles} from "./common";
+import {getHorizontalRuleStyles} from "./common";
 
 import type {CellProps} from "../../util/types";
+import theme from "../../theme";
 
 type LeftAccessoryProps = {
     leftAccessory?: CellProps["leftAccessory"];
@@ -222,62 +217,22 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
     );
 };
 
-const cellTokens = {
-    root: {
-        default: {
-            background: semanticColor.surface.primary,
-            foreground: semanticColor.text.primary,
-        },
-        hover: {
-            background: color.fadedBlue8,
-        },
-        press: {
-            background: color.fadedBlue8,
-            border: semanticColor.surface.emphasis,
-        },
-        selected: {
-            background: color.fadedBlue8,
-            foreground: color.activeBlue,
-            border: semanticColor.surface.emphasis,
-        },
-        focus: {
-            border: semanticColor.focus.outer,
-        },
-        disabled: {
-            foreground: semanticColor.text.disabled,
-            border: semanticColor.focus.outer,
-        },
-    },
-    accessory: {
-        default: {
-            foreground: semanticColor.icon.primary,
-        },
-        selected: {
-            foreground: semanticColor.icon.action,
-        },
-        disabled: {
-            // Use secondary icon color for disabled state because opacity is
-            // also applied to the accessory. Opacity is used so it is applied
-            // to images also
-            foreground: semanticColor.icon.secondary,
-        },
-    },
-};
-
 const styles = StyleSheet.create({
     wrapper: {
-        background: cellTokens.root.default.background,
-        color: cellTokens.root.default.foreground,
+        background: theme.root.color.rest.background,
+        color: theme.root.color.rest.foreground,
         display: "flex",
-        minHeight: CellMeasurements.cellMinHeight,
+        minHeight: theme.root.sizing.minHeight,
         textAlign: "left",
         width: "100%",
     },
 
     innerWrapper: {
-        minHeight: CellMeasurements.cellMinHeight,
-        gap: CellMeasurements.accessoryHorizontalSpacing,
-        padding: `${CellMeasurements.cellPadding.paddingVertical}px ${CellMeasurements.cellPadding.paddingHorizontal}px`,
+        minHeight: theme.root.sizing.minHeight,
+        // The spacing between the left and right accessories.
+        gap: theme.root.layout.gap,
+        paddingBlock: theme.root.layout.padding.block.default,
+        paddingInline: theme.root.layout.padding.inline.default,
         flexDirection: "row",
         flex: 1,
         borderRadius: "inherit",
@@ -290,9 +245,8 @@ const styles = StyleSheet.create({
         // Reduce the padding of the innerWrapper when the focus ring is
         // visible.
         ":focus-visible": {
-            padding: `${CellMeasurements.cellPadding.paddingVertical - 2}px ${
-                CellMeasurements.cellPadding.paddingHorizontal - 2
-            }px`,
+            paddingBlock: `calc(${theme.root.layout.padding.block.default} - ${theme.root.border.width.default})`,
+            paddingInline: `calc(${theme.root.layout.padding.inline.default} - ${theme.root.border.width.default})`,
         },
     },
     activeInnerWrapper: {
@@ -304,8 +258,8 @@ const styles = StyleSheet.create({
             top: 0,
             left: 0,
             bottom: 0,
-            width: border.width.thick,
-            backgroundColor: cellTokens.root.selected.border,
+            width: theme.root.border.width.selected,
+            backgroundColor: theme.root.color.selected.border,
         },
     },
 
@@ -328,7 +282,7 @@ const styles = StyleSheet.create({
     accessoryRight: {
         // The right accessory will have this color by default. Unless the
         // accessory element overrides that color internally.
-        color: cellTokens.accessory.default.foreground,
+        color: theme.accessory.color.default.foreground,
     },
 
     /**
@@ -339,16 +293,9 @@ const styles = StyleSheet.create({
         /**
          * States
          */
-        // disabled
-        // NOTE: We use `aria-disabled` instead of `disabled` because we want
-        // to allow the cell to be focusable even when it's disabled.
-        [":hover[aria-disabled=true]" as any]: {
-            cursor: "not-allowed",
-        },
-
         // focus (only visible when using keyboard navigation)
         ":focus-visible": {
-            borderRadius: border.radius.radius_040,
+            borderRadius: theme.root.border.radius,
             // To hide the internal corners of the cell.
             overflow: "hidden",
             // To display the focus ring based on the cell's border.
@@ -368,23 +315,16 @@ const styles = StyleSheet.create({
             zIndex: 1,
             // We remove the border width from the width/height to ensure
             // that the focus ring is drawn inside the cell.
-            width: `calc(100% - ${spacing.xxxSmall_4}px)`,
-            height: `calc(100% - ${spacing.xxxSmall_4}px)`,
-            border: `${spacing.xxxxSmall_2}px solid ${cellTokens.root.focus.border}`,
-            borderRadius: border.radius.radius_040,
+            width: `calc(100% - ${theme.root.border.width.default} * 2)`,
+            height: `calc(100% - ${theme.root.border.width.default} * 2)`,
+            border: `${theme.root.border.width.default} solid ${theme.root.color.focus.border}`,
+            borderRadius: theme.root.border.radius,
         },
-        [":focus-visible[aria-disabled=true]:after" as any]: {
-            borderColor: cellTokens.root.disabled.border,
+        ":hover": {
+            background: theme.root.color.hover.background,
         },
-
-        // hover + enabled
-        [":hover[aria-disabled=false]" as any]: {
-            background: cellTokens.root.hover.background,
-        },
-
-        // pressed + enabled
-        [":active[aria-disabled=false]" as any]: {
-            background: cellTokens.root.press.background,
+        ":active": {
+            background: theme.root.color.press.background,
         },
         // press + enabled + not currently selected (active prop: false)
         // We apply the left bar indicator styles on the inner-wrapper element
@@ -393,42 +333,58 @@ const styles = StyleSheet.create({
         // have overflow: hidden on the inner wrapper instead of the clickable element
         // because setting it on the clickable element causes issues with existing
         // cases.
-        [":active[aria-disabled=false]:not([aria-current=true]) .inner-wrapper" as any]:
-            {
-                position: "relative",
-                ":before": {
-                    content: "''",
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    bottom: 0,
-                    width: border.width.medium,
-                    backgroundColor: semanticColor.surface.emphasis,
-                },
+        [":active:not([aria-current=true]) .inner-wrapper" as any]: {
+            position: "relative",
+            ":before": {
+                content: "''",
+                position: "absolute",
+                top: 0,
+                left: 0,
+                bottom: 0,
+                width: theme.root.border.width.default,
+                // We use the border token as this element acts like a border
+                // when the cell is pressed.
+                backgroundColor: theme.root.color.press.border,
             },
+        },
     },
 
     active: {
-        background: cellTokens.root.selected.background,
-        color: cellTokens.root.selected.foreground,
+        background: theme.root.color.selected.background,
+        color: theme.root.color.selected.foreground,
         cursor: "default",
     },
 
     disabled: {
-        color: cellTokens.root.disabled.foreground,
+        background: theme.root.color.disabled.background,
+        color: theme.root.color.disabled.foreground,
+        ":hover": {
+            background: theme.root.color.disabled.background,
+            cursor: "not-allowed",
+        },
         ":focus-visible": {
             // Prevent the focus ring from being displayed when the cell is
             // disabled.
             outline: "none",
         },
+        ":active": {
+            background: theme.root.color.disabled.background,
+        },
+        [".inner-wrapper" as any]: {
+            ":before": {
+                // Prevent the left bar indicator from being displayed when the
+                // cell is disabled.
+                content: "none",
+            },
+        },
     },
 
     accessoryActive: {
-        color: cellTokens.accessory.selected.foreground,
+        color: theme.accessory.color.selected.foreground,
     },
 
     accessoryDisabled: {
-        color: cellTokens.accessory.disabled.foreground,
+        color: theme.accessory.color.disabled.foreground,
         opacity: 0.32,
     },
 });

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -6,6 +6,7 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {getHorizontalRuleStyles} from "./common";
 
 import type {CellProps} from "../../util/types";
@@ -219,8 +220,8 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
 
 const styles = StyleSheet.create({
     wrapper: {
-        background: theme.root.color.rest.background,
-        color: theme.root.color.rest.foreground,
+        background: semanticColor.surface.primary,
+        color: semanticColor.core.foreground.neutral.strong,
         display: "flex",
         minHeight: theme.root.sizing.minHeight,
         textAlign: "left",
@@ -293,6 +294,12 @@ const styles = StyleSheet.create({
         /**
          * States
          */
+        ":hover": {
+            background: semanticColor.core.background.instructive.subtle,
+        },
+        ":active": {
+            background: semanticColor.core.background.instructive.subtle,
+        },
         // focus (only visible when using keyboard navigation)
         ":focus-visible": {
             borderRadius: theme.root.border.radius,
@@ -317,14 +324,8 @@ const styles = StyleSheet.create({
             // that the focus ring is drawn inside the cell.
             width: `calc(100% - ${theme.root.border.width.default} * 2)`,
             height: `calc(100% - ${theme.root.border.width.default} * 2)`,
-            border: `${theme.root.border.width.default} solid ${theme.root.color.focus.border}`,
+            border: `${theme.root.border.width.default} solid ${semanticColor.focus.outer}`,
             borderRadius: theme.root.border.radius,
-        },
-        ":hover": {
-            background: theme.root.color.hover.background,
-        },
-        ":active": {
-            background: theme.root.color.press.background,
         },
         // press + enabled + not currently selected (active prop: false)
         // We apply the left bar indicator styles on the inner-wrapper element
@@ -343,24 +344,24 @@ const styles = StyleSheet.create({
                     left: 0,
                     bottom: 0,
                     width: theme.root.border.width.default,
-                    // We use the border token as this element acts like a border
-                    // when the cell is pressed.
+                    // We use the border token as this element acts like a
+                    // border when the cell is pressed.
                     backgroundColor: theme.root.color.press.border,
                 },
             },
     },
 
     active: {
-        background: theme.root.color.selected.background,
+        background: semanticColor.core.background.instructive.subtle,
         color: theme.root.color.selected.foreground,
         cursor: "default",
     },
 
     disabled: {
-        background: theme.root.color.disabled.background,
-        color: theme.root.color.disabled.foreground,
+        background: semanticColor.surface.primary,
+        color: semanticColor.core.foreground.inverse.subtle,
         ":hover": {
-            background: theme.root.color.disabled.background,
+            background: semanticColor.surface.primary,
             cursor: "not-allowed",
         },
         ":focus-visible": {
@@ -369,7 +370,7 @@ const styles = StyleSheet.create({
             outline: "none",
         },
         ":active": {
-            background: theme.root.color.disabled.background,
+            background: semanticColor.surface.primary,
         },
         [".inner-wrapper" as any]: {
             ":before": {

--- a/packages/wonder-blocks-cell/src/components/internal/common.ts
+++ b/packages/wonder-blocks-cell/src/components/internal/common.ts
@@ -1,34 +1,10 @@
 import {StyleSheet} from "aphrodite";
 
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import type {HorizontalRuleVariant} from "../../util/types";
-
-export const CellMeasurements = {
-    cellMinHeight: spacing.xxLarge_48,
-
-    /**
-     * The cell wrapper's gap.
-     */
-    cellPadding: {
-        paddingVertical: spacing.small_12,
-        paddingHorizontal: spacing.medium_16,
-    },
-
-    /**
-     * The DetailCell wrapper's gap.
-     */
-    detailCellPadding: {
-        paddingVertical: spacing.medium_16,
-        paddingHorizontal: spacing.medium_16,
-    },
-
-    /**
-     * The horizontal spacing between the left and right accessory.
-     */
-    accessoryHorizontalSpacing: spacing.medium_16,
-} as const;
+import theme from "../../theme";
 
 /**
  * Gets the horizontalRule style based on the variant.
@@ -60,15 +36,15 @@ const styles = StyleSheet.create({
             bottom: 0,
             // align border to the right of the cell
             right: 0,
-            height: spacing.xxxxSmall_2,
-            boxShadow: `inset 0px -1px 0px ${color.offBlack8}`,
+            height: sizing.size_020,
+            boxShadow: theme.rule.shadow,
         },
     },
 
     horizontalRuleInset: {
         ":after": {
             // Inset doesn't include the left padding of the cell.
-            width: `calc(100% - ${CellMeasurements.cellPadding.paddingHorizontal}px)`,
+            width: `calc(100% - ${theme.root.layout.padding.inline})`,
         },
     },
 });

--- a/packages/wonder-blocks-cell/src/components/internal/common.ts
+++ b/packages/wonder-blocks-cell/src/components/internal/common.ts
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
     horizontalRuleInset: {
         ":after": {
             // Inset doesn't include the left padding of the cell.
-            width: `calc(100% - ${theme.root.layout.padding.inline})`,
+            width: `calc(100% - ${theme.root.layout.padding.inline.default})`,
         },
     },
 });

--- a/packages/wonder-blocks-cell/src/components/internal/common.ts
+++ b/packages/wonder-blocks-cell/src/components/internal/common.ts
@@ -1,10 +1,8 @@
 import {StyleSheet} from "aphrodite";
-
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
-
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import type {HorizontalRuleVariant} from "../../util/types";
 import theme from "../../theme";
+
+import type {HorizontalRuleVariant} from "../../util/types";
 
 /**
  * Gets the horizontalRule style based on the variant.
@@ -36,7 +34,7 @@ const styles = StyleSheet.create({
             bottom: 0,
             // align border to the right of the cell
             right: 0,
-            height: sizing.size_020,
+            height: theme.rule.sizing.height,
             boxShadow: theme.rule.shadow,
         },
     },

--- a/packages/wonder-blocks-cell/src/theme/default.ts
+++ b/packages/wonder-blocks-cell/src/theme/default.ts
@@ -1,0 +1,74 @@
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+
+export default {
+    root: {
+        border: {
+            width: {
+                default: border.width.medium,
+                selected: border.width.thick,
+            },
+            radius: border.radius.radius_040,
+        },
+        color: {
+            rest: {
+                background: semanticColor.surface.primary,
+                foreground: semanticColor.text.primary,
+            },
+            hover: {
+                background: semanticColor.core.background.instructive.subtle,
+            },
+            press: {
+                background: semanticColor.core.background.instructive.subtle,
+                border: semanticColor.core.border.instructive.default,
+            },
+            selected: {
+                background: semanticColor.core.background.instructive.subtle,
+                foreground: semanticColor.core.foreground.instructive.default,
+                border: semanticColor.core.border.instructive.default,
+            },
+            focus: {
+                border: semanticColor.focus.outer,
+            },
+            disabled: {
+                background: semanticColor.surface.primary,
+                foreground: semanticColor.text.disabled,
+                border: semanticColor.focus.outer,
+            },
+        },
+        layout: {
+            gap: sizing.size_160,
+            padding: {
+                block: {
+                    default: sizing.size_120,
+                    detail: sizing.size_160,
+                },
+                inline: {
+                    default: sizing.size_160,
+                    detail: sizing.size_160,
+                },
+            },
+        },
+        sizing: {
+            minHeight: sizing.size_480,
+        },
+    },
+    accessory: {
+        color: {
+            default: {
+                foreground: semanticColor.icon.primary,
+            },
+            selected: {
+                foreground: semanticColor.icon.action,
+            },
+            disabled: {
+                // Use secondary icon color for disabled state because opacity
+                // is also applied to the accessory. Opacity is used so it is
+                // applied to images also
+                foreground: semanticColor.icon.secondary,
+            },
+        },
+    },
+    rule: {
+        shadow: `inset 0px -1px 0px ${semanticColor.core.border.inverse.default}`,
+    },
+};

--- a/packages/wonder-blocks-cell/src/theme/default.ts
+++ b/packages/wonder-blocks-cell/src/theme/default.ts
@@ -9,30 +9,14 @@ export default {
             },
             radius: border.radius.radius_040,
         },
+        // NOTE: These colors will change in TB.
         color: {
-            rest: {
-                background: semanticColor.surface.primary,
-                foreground: semanticColor.text.primary,
-            },
-            hover: {
-                background: semanticColor.core.background.instructive.subtle,
-            },
             press: {
-                background: semanticColor.core.background.instructive.subtle,
                 border: semanticColor.core.border.instructive.default,
             },
             selected: {
-                background: semanticColor.core.background.instructive.subtle,
                 foreground: semanticColor.core.foreground.instructive.default,
                 border: semanticColor.core.border.instructive.default,
-            },
-            focus: {
-                border: semanticColor.focus.outer,
-            },
-            disabled: {
-                background: semanticColor.surface.primary,
-                foreground: semanticColor.text.disabled,
-                border: semanticColor.focus.outer,
             },
         },
         layout: {
@@ -53,22 +37,26 @@ export default {
         },
     },
     accessory: {
+        // NOTE: These colors will change in TB.
         color: {
             default: {
-                foreground: semanticColor.icon.primary,
+                foreground: semanticColor.core.foreground.neutral.default,
             },
             selected: {
-                foreground: semanticColor.icon.action,
+                foreground: semanticColor.core.foreground.instructive.subtle,
             },
             disabled: {
-                // Use secondary icon color for disabled state because opacity
-                // is also applied to the accessory. Opacity is used so it is
-                // applied to images also
-                foreground: semanticColor.icon.secondary,
+                // Using neutral.strong for disabled state because opacity is
+                // also applied to the accessory. Opacity is used so it is
+                // applied to images also.
+                foreground: semanticColor.core.foreground.neutral.strong,
             },
         },
     },
     rule: {
+        sizing: {
+            height: sizing.size_020,
+        },
         shadow: `inset 0px -1px 0px ${semanticColor.core.border.inverse.default}`,
     },
 };

--- a/packages/wonder-blocks-cell/src/theme/index.ts
+++ b/packages/wonder-blocks-cell/src/theme/index.ts
@@ -1,0 +1,4 @@
+import {mapValuesToCssVars} from "@khanacademy/wonder-blocks-tokens";
+import themeDefault from "./default";
+
+export default mapValuesToCssVars(themeDefault, "--wb-c-cell-");

--- a/packages/wonder-blocks-cell/src/util/types.ts
+++ b/packages/wonder-blocks-cell/src/util/types.ts
@@ -31,6 +31,10 @@ export type AccessoryStyle = {
      * To horizontally align the accessory.
      */
     alignItems?: "flex-start" | "flex-end" | "center";
+    /**
+     * To set spacing between child elements.
+     */
+    gap?: number | string;
 };
 
 /**

--- a/packages/wonder-blocks-cell/tsconfig-build.json
+++ b/packages/wonder-blocks-cell/tsconfig-build.json
@@ -9,7 +9,6 @@
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
-        {"path": "../wonder-blocks-layout/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
         {"path": "../wonder-blocks-typography/tsconfig-build.json"},
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,9 +660,6 @@ importers:
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
-      '@khanacademy/wonder-blocks-layout':
-        specifier: workspace:*
-        version: link:../wonder-blocks-layout
       '@khanacademy/wonder-blocks-tokens':
         specifier: workspace:*
         version: link:../wonder-blocks-tokens


### PR DESCRIPTION
## Summary:

- Refactors Cell structure by removing Strut in favor of CSS's gap property
- Moves the Cell tokens to a separate `theme` file and converts these component-level tokens to CSS variables (this is required here as the Cell styles differ in TB).
- Change old typography components with new ones (`Heading`, `BodyText`).

Issue: https://khanacademy.atlassian.net/browse/WB-1958

## Test plan:

Navigate to the Cell docs and verify that there are no noticeable visual
changes. The Cell should still render correctly with the same spacing and
alignment as before.

- `/?path=/story/packages-cell-testing-snapshots-compactcell--state-sheet-story`
- `/?path=/story/packages-cell-testing-snapshots-detailcell--state-sheet-story`