### PR TITLE
[🔥AUDIT🔥] fix image path in docs

### DIFF
--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -214,7 +214,7 @@ export const Scenarios: StoryComponentType = {
                     label: "Badge",
                     icon: (
                         <Icon>
-                            <img src={"/logo.svg"} alt="Wonder Blocks" />
+                            <img src={"logo.svg"} alt="Wonder Blocks" />
                         </Icon>
                     ),
                 },
@@ -224,7 +224,7 @@ export const Scenarios: StoryComponentType = {
                 props: {
                     icon: (
                         <Icon>
-                            <img src={"/logo.svg"} alt="Wonder Blocks" />
+                            <img src={"logo.svg"} alt="Wonder Blocks" />
                         </Icon>
                     ),
                 },

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -151,7 +151,7 @@ export const CustomIcons: StoryComponentType = {
                 <Badge
                     icon={
                         <Icon>
-                            <img src={"/logo.svg"} alt="Wonder Blocks" />
+                            <img src={"logo.svg"} alt="Wonder Blocks" />
                         </Icon>
                     }
                     label="Custom Icon"

--- a/__docs__/wonder-blocks-badge/due-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/due-badge.stories.tsx
@@ -145,7 +145,7 @@ export const CustomIcons: StoryComponentType = {
                 <DueBadge
                     icon={
                         <Icon>
-                            <img src={"/logo.svg"} alt="Wonder Blocks" />
+                            <img src={"logo.svg"} alt="Wonder Blocks" />
                         </Icon>
                     }
                     label="Custom Icon"

--- a/__docs__/wonder-blocks-badge/status-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/status-badge.stories.tsx
@@ -225,7 +225,7 @@ export const CustomIcons: StoryComponentType = {
                                 icon={
                                     <Icon>
                                         <img
-                                            src={"/logo.svg"}
+                                            src={"logo.svg"}
                                             alt="Wonder Blocks"
                                         />
                                     </Icon>

--- a/__docs__/wonder-blocks-icon/icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/icon.stories.tsx
@@ -36,7 +36,7 @@ type StoryComponentType = StoryObj<typeof Icon>;
 
 export const Default: StoryComponentType = {
     args: {
-        children: <img src="/logo.svg" alt="Wonder Blocks" />,
+        children: <img src="logo.svg" alt="Wonder Blocks" />,
     },
     parameters: {
         chromatic: {
@@ -57,7 +57,7 @@ export const Sizes: StoryComponentType = {
                         <View style={styles.iconContainer} key={size}>
                             <LabelSmall>{size}</LabelSmall>
                             <Icon size={size}>
-                                <img src="/logo.svg" alt="Wonder Blocks" />
+                                <img src="logo.svg" alt="Wonder Blocks" />
                             </Icon>
                         </View>
                     ),
@@ -72,7 +72,7 @@ export const Sizes: StoryComponentType = {
  */
 export const CustomStyles: StoryComponentType = {
     args: {
-        children: <img src="/logo.svg" alt="Wonder Blocks" />,
+        children: <img src="logo.svg" alt="Wonder Blocks" />,
         size: "xlarge",
         style: {
             borderRadius: border.radius.radius_full,


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Some images in the Icon stories in the deployed instance of Storybook are not rendering as expected. 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/a94d02f5-b512-4ea4-a459-d354f10151f7" />

It renders as expected when the image path doesn't start with `/`

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9ea8b7f0-972f-4d2f-87b2-86c48a9e3fbb" />



Issue: WB-XXXX

## Test plan:
The icons should all render an image (`?path=/docs/packages-icon-icon--docs`)