### PR TITLE
Set up banner tokens structure and update styles

### DIFF
--- a/.changeset/lazy-rice-cheat.md
+++ b/.changeset/lazy-rice-cheat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": patch
+---
+
+Update banner styles (use `sizing` instead of `spacing`, use semantic color tokens, set up banner token structure to support theming)

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -296,9 +296,7 @@ const Banner = (props: Props): React.ReactElement => {
                 />
                 <View style={styles.labelAndButtonsContainer}>
                     <View style={styles.labelContainer}>
-                        <BodyText size="small" tag="span">
-                            {text}
-                        </BodyText>
+                        <BodyText size="small">{text}</BodyText>
                     </View>
                     {actions && (
                         <View style={styles.actionsContainer}>

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -170,6 +170,19 @@ const getBannerKindStyle = (kind: BannerKind) => {
     }
 };
 
+const getBannerIconKindStyle = (kind: BannerKind) => {
+    switch (kind) {
+        case "success":
+            return styles.successIcon;
+        case "info":
+            return styles.infoIcon;
+        case "warning":
+            return styles.warningIcon;
+        case "critical":
+            return styles.criticalIcon;
+    }
+};
+
 /**
  * Banner. A banner displays a prominent message and related optional actions.
  * It can be used as a way of informing the user of important changes.
@@ -257,6 +270,7 @@ const Banner = (props: Props): React.ReactElement => {
     const valuesForKind = getValuesForKind(kind);
 
     const bannerKindStyle = getBannerKindStyle(kind);
+    const bannerIconKindStyle = getBannerIconKindStyle(kind);
 
     return (
         <View
@@ -275,7 +289,7 @@ const Banner = (props: Props): React.ReactElement => {
                 <PhosphorIcon
                     icon={icon || valuesForKind.icon}
                     size="medium"
-                    style={styles.icon}
+                    style={[styles.icon, bannerIconKindStyle]}
                     aria-label={kind}
                     testId="banner-kind-icon"
                     role="img"
@@ -328,6 +342,12 @@ const bannerTokens = {
         },
     },
     icon: {
+        color: {
+            info: semanticColor.icon.primary,
+            success: semanticColor.icon.primary,
+            warning: semanticColor.icon.primary,
+            critical: semanticColor.icon.primary,
+        },
         layout: {
             marginBlockStart: sizing.size_080,
             marginBlockEnd: sizing.size_080,
@@ -382,7 +402,6 @@ const styles = StyleSheet.create({
         marginInlineStart: bannerTokens.icon.layout.marginInlineStart,
         marginInlineEnd: bannerTokens.icon.layout.marginInlineEnd,
         alignSelf: "flex-start",
-        color: semanticColor.icon.primary,
     },
     labelAndButtonsContainer: {
         flex: 1,
@@ -447,6 +466,18 @@ const styles = StyleSheet.create({
     criticalBanner: {
         backgroundColor: semanticColor.feedback.critical.subtle.background,
         borderColor: semanticColor.core.border.critical.default,
+    },
+    successIcon: {
+        color: bannerTokens.icon.color.success,
+    },
+    infoIcon: {
+        color: bannerTokens.icon.color.info,
+    },
+    warningIcon: {
+        color: bannerTokens.icon.color.warning,
+    },
+    criticalIcon: {
+        color: bannerTokens.icon.color.critical,
     },
 });
 

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -367,6 +367,9 @@ const bannerTokens = {
         layout: {
             marginBlock: sizing.size_080,
         },
+        sizing: {
+            height: sizing.size_180,
+        },
     },
     action: {
         layout: {
@@ -422,7 +425,7 @@ const styles = StyleSheet.create({
         justifyContent: "flex-start",
         marginBlock: bannerTokens.actions.layout.marginBlock,
         // Set the height to remove the padding from buttons
-        height: 18,
+        height: bannerTokens.actions.sizing.height,
         alignItems: "center",
     },
     action: {

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -14,7 +14,7 @@ import {
     semanticColor,
     spacing,
 } from "@khanacademy/wonder-blocks-tokens";
-import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import infoIcon from "@phosphor-icons/core/regular/info.svg";
 import successIcon from "@phosphor-icons/core/regular/smiley.svg";
@@ -281,7 +281,9 @@ const Banner = (props: Props): React.ReactElement => {
                 />
                 <View style={styles.labelAndButtonsContainer}>
                     <View style={styles.labelContainer}>
-                        <LabelSmall>{text}</LabelSmall>
+                        <BodyText size="small" tag="span">
+                            {text}
+                        </BodyText>
                     </View>
                     {actions && (
                         <View style={styles.actionsContainer}>

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -12,6 +12,7 @@ import {
     border,
     font,
     semanticColor,
+    sizing,
     spacing,
 } from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
@@ -262,7 +263,8 @@ const Banner = (props: Props): React.ReactElement => {
         <View
             style={[
                 styles.containerOuter,
-                layout === "floating" && styles.floatingBorder,
+                layout === "floating" && styles.floatingLayout,
+                layout === "full-width" && styles.fullWidthLayout,
                 bannerKindStyle,
             ]}
             role={valuesForKind.role}
@@ -308,9 +310,30 @@ const Banner = (props: Props): React.ReactElement => {
     );
 };
 
+const bannerTokens = {
+    root: {
+        border: {
+            radius: {
+                default: border.radius.radius_0,
+                floating: border.radius.radius_040,
+            },
+            width: {
+                inlineStart: sizing.size_060, // uses rem so the border indicator scales to font size
+                inlineEnd: border.width.none,
+                blockStart: border.width.none,
+                blockEnd: border.width.none,
+            },
+        },
+    },
+    icon: {},
+};
+
 const styles = StyleSheet.create({
     containerOuter: {
-        borderInlineStartWidth: spacing.xxSmall_6,
+        borderInlineStartWidth: bannerTokens.root.border.width.inlineStart,
+        borderInlineEndWidth: bannerTokens.root.border.width.inlineEnd,
+        borderBlockStartWidth: bannerTokens.root.border.width.blockStart,
+        borderBlockEndWidth: bannerTokens.root.border.width.blockEnd,
         width: "100%",
     },
     containerInner: {
@@ -370,27 +393,30 @@ const styles = StyleSheet.create({
         marginLeft: spacing.xSmall_8,
         marginRight: spacing.xSmall_8,
     },
-    floatingBorder: {
-        borderRadius: border.radius.radius_040,
+    floatingLayout: {
+        borderRadius: bannerTokens.root.border.radius.floating,
         // Stop the square corners of the inner container from
         // flowing out of the rounded corners of the outer container.
         overflow: "hidden",
     },
+    fullWidthLayout: {
+        borderRadius: bannerTokens.root.border.radius.default,
+    },
     successBanner: {
         backgroundColor: semanticColor.feedback.success.subtle.background,
-        borderInlineStartColor: semanticColor.core.border.success.default,
+        borderColor: semanticColor.core.border.success.default,
     },
     infoBanner: {
         backgroundColor: semanticColor.feedback.info.subtle.background,
-        borderInlineStartColor: semanticColor.core.border.instructive.default,
+        borderColor: semanticColor.core.border.instructive.default,
     },
     warningBanner: {
         backgroundColor: semanticColor.feedback.warning.subtle.background,
-        borderInlineStartColor: semanticColor.core.border.warning.default,
+        borderColor: semanticColor.core.border.warning.default,
     },
     criticalBanner: {
         backgroundColor: semanticColor.feedback.critical.subtle.background,
-        borderInlineStartColor: semanticColor.core.border.critical.default,
+        borderColor: semanticColor.core.border.critical.default,
     },
 });
 

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -340,6 +340,20 @@ const bannerTokens = {
         layout: {
             padding: sizing.size_080,
         },
+        color: {
+            border: {
+                info: semanticColor.core.border.instructive.default,
+                success: semanticColor.core.border.success.default,
+                warning: semanticColor.core.border.warning.default,
+                critical: semanticColor.core.border.critical.default,
+            },
+            background: {
+                info: semanticColor.feedback.info.subtle.background,
+                success: semanticColor.feedback.success.subtle.background,
+                warning: semanticColor.feedback.warning.subtle.background,
+                critical: semanticColor.feedback.critical.subtle.background,
+            },
+        },
     },
     icon: {
         color: {
@@ -455,20 +469,20 @@ const styles = StyleSheet.create({
         borderRadius: bannerTokens.root.border.radius.default,
     },
     successBanner: {
-        backgroundColor: semanticColor.feedback.success.subtle.background,
-        borderColor: semanticColor.core.border.success.default,
+        backgroundColor: bannerTokens.root.color.background.success,
+        borderColor: bannerTokens.root.color.border.success,
     },
     infoBanner: {
-        backgroundColor: semanticColor.feedback.info.subtle.background,
-        borderColor: semanticColor.core.border.instructive.default,
+        backgroundColor: bannerTokens.root.color.background.info,
+        borderColor: bannerTokens.root.color.border.info,
     },
     warningBanner: {
-        backgroundColor: semanticColor.feedback.warning.subtle.background,
-        borderColor: semanticColor.core.border.warning.default,
+        backgroundColor: bannerTokens.root.color.background.warning,
+        borderColor: bannerTokens.root.color.border.warning,
     },
     criticalBanner: {
-        backgroundColor: semanticColor.feedback.critical.subtle.background,
-        borderColor: semanticColor.core.border.critical.default,
+        backgroundColor: bannerTokens.root.color.background.critical,
+        borderColor: bannerTokens.root.color.border.critical,
     },
     successIcon: {
         color: bannerTokens.icon.color.success,

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -77,7 +77,6 @@ type BannerLayout =
     | "full-width";
 
 type BannerValues = {
-    color: string;
     icon: PhosphorIconAsset;
     role: "status" | "alert";
     ariaLive?: "assertive" | "polite";
@@ -136,29 +135,38 @@ const getValuesForKind = (kind: BannerKind): BannerValues => {
     switch (kind) {
         case "success":
             return {
-                color: semanticColor.status.success.foreground,
                 icon: successIcon,
                 role: "status",
             };
         case "warning":
             return {
-                color: semanticColor.status.warning.foreground,
                 icon: warningIcon,
                 role: "alert",
                 ariaLive: "polite",
             };
         case "critical":
             return {
-                color: semanticColor.status.critical.foreground,
                 icon: criticalIcon,
                 role: "alert",
             };
         default:
             return {
-                color: semanticColor.status.notice.foreground,
                 icon: infoIcon,
                 role: "status",
             };
+    }
+};
+
+const getBannerKindStyle = (kind: BannerKind) => {
+    switch (kind) {
+        case "success":
+            return styles.successBanner;
+        case "info":
+            return styles.infoBanner;
+        case "warning":
+            return styles.warningBanner;
+        case "critical":
+            return styles.criticalBanner;
     }
 };
 
@@ -248,24 +256,20 @@ const Banner = (props: Props): React.ReactElement => {
 
     const valuesForKind = getValuesForKind(kind);
 
+    const bannerKindStyle = getBannerKindStyle(kind);
+
     return (
         <View
             style={[
                 styles.containerOuter,
                 layout === "floating" && styles.floatingBorder,
-                {borderInlineStartColor: valuesForKind.color},
+                bannerKindStyle,
             ]}
             role={valuesForKind.role}
             aria-label={ariaLabel}
             aria-live={valuesForKind.ariaLive}
             testId={testId}
         >
-            <View
-                style={[
-                    styles.backgroundColor,
-                    {backgroundColor: valuesForKind.color},
-                ]}
-            />
             <View style={styles.containerInner}>
                 <PhosphorIcon
                     icon={icon || valuesForKind.icon}
@@ -303,24 +307,9 @@ const Banner = (props: Props): React.ReactElement => {
 };
 
 const styles = StyleSheet.create({
-    backgroundColor: {
-        position: "absolute",
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 0,
-        opacity: 0.08,
-    },
     containerOuter: {
         borderInlineStartWidth: spacing.xxSmall_6,
         width: "100%",
-        // Because of the background color's opacity value,
-        // the base color needs to be hard-coded as white for the
-        // intended pastel background color to show up correctly
-        // on dark backgrounds.
-        // TODO(WB-1865): Verify if we can change this to use semanticColor
-        // status tokens.
-        backgroundColor: semanticColor.surface.primary,
     },
     containerInner: {
         flexDirection: "row",
@@ -384,6 +373,22 @@ const styles = StyleSheet.create({
         // Stop the square corners of the inner container from
         // flowing out of the rounded corners of the outer container.
         overflow: "hidden",
+    },
+    successBanner: {
+        backgroundColor: semanticColor.feedback.success.subtle.background,
+        borderInlineStartColor: semanticColor.core.border.success.default,
+    },
+    infoBanner: {
+        backgroundColor: semanticColor.feedback.info.subtle.background,
+        borderInlineStartColor: semanticColor.core.border.instructive.default,
+    },
+    warningBanner: {
+        backgroundColor: semanticColor.feedback.warning.subtle.background,
+        borderInlineStartColor: semanticColor.core.border.warning.default,
+    },
+    criticalBanner: {
+        backgroundColor: semanticColor.feedback.critical.subtle.background,
+        borderInlineStartColor: semanticColor.core.border.critical.default,
     },
 });
 

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -13,7 +13,6 @@ import {
     font,
     semanticColor,
     sizing,
-    spacing,
 } from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
@@ -324,8 +323,45 @@ const bannerTokens = {
                 blockEnd: border.width.none,
             },
         },
+        layout: {
+            padding: sizing.size_080,
+        },
     },
-    icon: {},
+    icon: {
+        layout: {
+            marginBlockStart: sizing.size_080,
+            marginBlockEnd: sizing.size_080,
+            // The total distance from the icon to the edge is 16px. The
+            // vertical identifier is already 6px, and the padding on inner
+            // conatiner is 8px. So that leaves 2px.
+            marginInlineStart: sizing.size_020,
+            marginInlineEnd: sizing.size_080,
+        },
+    },
+    label: {
+        layout: {
+            margin: sizing.size_080,
+        },
+    },
+    actions: {
+        layout: {
+            marginBlock: sizing.size_080,
+        },
+    },
+    action: {
+        layout: {
+            marginInline: sizing.size_080,
+        },
+    },
+    dismiss: {
+        sizing: {
+            height: sizing.size_400,
+            width: sizing.size_400,
+        },
+        layout: {
+            marginInline: sizing.size_080,
+        },
+    },
 };
 
 const styles = StyleSheet.create({
@@ -338,16 +374,13 @@ const styles = StyleSheet.create({
     },
     containerInner: {
         flexDirection: "row",
-        padding: spacing.xSmall_8,
+        padding: bannerTokens.root.layout.padding,
     },
     icon: {
-        marginTop: spacing.xSmall_8,
-        marginBottom: spacing.xSmall_8,
-        // The total distance from the icon to the edge is 16px. The
-        // vertical identifier is already 6px, and the padding on inner
-        // conatiner is 8px. So that leaves 2px.
-        marginInlineStart: spacing.xxxxSmall_2,
-        marginInlineEnd: spacing.xSmall_8,
+        marginBlockStart: bannerTokens.icon.layout.marginBlockStart,
+        marginBlockEnd: bannerTokens.icon.layout.marginBlockEnd,
+        marginInlineStart: bannerTokens.icon.layout.marginInlineStart,
+        marginInlineEnd: bannerTokens.icon.layout.marginInlineEnd,
         alignSelf: "flex-start",
         color: semanticColor.icon.primary,
     },
@@ -361,22 +394,20 @@ const styles = StyleSheet.create({
     },
     labelContainer: {
         flexShrink: 1,
-        margin: spacing.xSmall_8,
+        margin: bannerTokens.label.layout.margin,
         textAlign: "start",
         overflowWrap: "break-word",
     },
     actionsContainer: {
         flexDirection: "row",
         justifyContent: "flex-start",
-        marginTop: spacing.xSmall_8,
-        marginBottom: spacing.xSmall_8,
+        marginBlock: bannerTokens.actions.layout.marginBlock,
         // Set the height to remove the padding from buttons
         height: 18,
         alignItems: "center",
     },
     action: {
-        marginLeft: spacing.xSmall_8,
-        marginRight: spacing.xSmall_8,
+        marginInline: bannerTokens.action.layout.marginInline,
         justifyContent: "center",
     },
     link: {
@@ -386,12 +417,11 @@ const styles = StyleSheet.create({
         flexShrink: 1,
     },
     dismissContainer: {
-        height: 40,
-        width: 40,
+        height: bannerTokens.dismiss.sizing.height,
+        width: bannerTokens.dismiss.sizing.width,
         justifyContent: "center",
         alignItems: "center",
-        marginLeft: spacing.xSmall_8,
-        marginRight: spacing.xSmall_8,
+        marginInline: bannerTokens.dismiss.layout.marginInline,
     },
     floatingLayout: {
         borderRadius: bannerTokens.root.border.radius.floating,


### PR DESCRIPTION
## Summary:
- Set up banner tokens structure and define layout, sizing, color values (will set up the thunderblocks theming in the next PR)
- Updated styles
  - replace `LabelSmall` with `BodyText`
  - use `sizing` tokens instead of `spacing`
  - refactor styling for the background color so we can use semantic color tokens instead of also relying on opacity

Issue: WB-1865

## Test plan:
- Review Banner stories and snapshots
  - The component should look the same in Classic theme. 
  - Layout is now using rem values instead of px (since we use `sizing` tokens now) 