### PR TITLE
Add theming to Checkbox/Radio

### DIFF
--- a/.changeset/dull-experts-deny.md
+++ b/.changeset/dull-experts-deny.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+Add Thunderblocks theme to Checkbox and Radio components

--- a/.changeset/nice-toys-sparkle.md
+++ b/.changeset/nice-toys-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Adds CSS variable tokens for WB Form: Checkbox and Radio

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -11,6 +11,7 @@ import {
     border,
     semanticColor,
     spacing,
+    sizing,
 } from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
@@ -100,6 +101,9 @@ const styles = StyleSheet.create({
     wrapper: {
         height: "600px",
         width: "600px",
+    },
+    gap: {
+        gap: sizing.size_010,
     },
     centered: {
         alignItems: "center",
@@ -238,7 +242,7 @@ const ControlledWrapper = (args: any) => {
     }, [args.opened]);
 
     return (
-        <View style={styles.wrapper}>
+        <View style={[styles.wrapper, styles.gap]}>
             <Checkbox label="Open" onChange={setOpened} checked={opened} />
             <MultiSelect
                 {...args}

--- a/__docs__/wonder-blocks-form/checkbox-accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-accessibility.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
-import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 type CheckboxProps = PropsFor<typeof Checkbox>;
@@ -23,9 +23,9 @@ const ErrorTemplate = (args: CheckboxProps) => {
                 onChange={setChecked}
             />
             {errorState && (
-                <LabelSmall style={styles.error} id={errorId}>
+                <BodyText size="small" style={styles.error} id={errorId}>
                     You must agree to the terms to continue
-                </LabelSmall>
+                </BodyText>
             )}
         </View>
     );

--- a/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelLarge, LabelXSmall} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {Choice, CheckboxGroup} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
@@ -164,7 +164,9 @@ export const RowStyling: StoryComponentType = () => {
 
     return (
         <View style={styles.wrapper}>
-            <LabelLarge style={styles.title}>Science</LabelLarge>
+            <BodyText weight="bold" style={styles.title}>
+                Science
+            </BodyText>
             <CheckboxGroup
                 groupName="science-classes"
                 onChange={setSelectedValues}
@@ -220,11 +222,15 @@ export const MultipleChoiceStyling: StoryComponentType = () => {
 
     return (
         <CheckboxGroup
-            label={<LabelLarge>Select all prime numbers</LabelLarge>}
+            label={
+                <BodyText weight="bold" tag="span">
+                    Select all prime numbers
+                </BodyText>
+            }
             description={
-                <LabelXSmall style={styles.description}>
+                <BodyText size="xsmall" tag="span" style={styles.description}>
                     Hint: There is at least one prime number
-                </LabelXSmall>
+                </BodyText>
             }
             groupName="science-classes"
             onChange={setSelectedValues}

--- a/__docs__/wonder-blocks-form/checkbox.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox.stories.tsx
@@ -3,9 +3,9 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {Checkbox, CheckboxGroup, Choice} from "@khanacademy/wonder-blocks-form";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 import ComponentInfo from "../components/component-info";
@@ -70,7 +70,7 @@ Controlled.parameters = {
 
 export const Indeterminate: StoryComponentType = () => {
     return (
-        <View style={styles.row}>
+        <View style={[styles.row, styles.gap]}>
             <Checkbox
                 aria-label="Default example"
                 checked={null}
@@ -78,7 +78,6 @@ export const Indeterminate: StoryComponentType = () => {
                 error={false}
                 onChange={() => {}}
             />
-            <Strut size={8} />
             <Checkbox
                 aria-label="Disabled example"
                 checked={undefined}
@@ -86,7 +85,6 @@ export const Indeterminate: StoryComponentType = () => {
                 error={false}
                 onChange={() => {}}
             />
-            <Strut size={8} />
             <Checkbox
                 aria-label="Error example"
                 checked={null}
@@ -182,47 +180,41 @@ IndeterminateWithGroup.parameters = {
 };
 
 export const Variants: StoryComponentType = () => (
-    <View style={styles.row}>
+    <View style={[styles.row, styles.gap_240]}>
         <Checkbox
             aria-label="Default example"
             error={false}
             checked={false}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Checkbox
             aria-label="Checked example"
             error={false}
             checked={true}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Checkbox
             aria-label="Error example"
             error={true}
             checked={false}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Checkbox
             aria-label="Error checked example"
             error={true}
             checked={true}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Checkbox
             aria-label="Disabled example"
             disabled={true}
             checked={false}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Checkbox
             aria-label="Disabled checked example"
             disabled={true}
             checked={true}
-            style={styles.marginRight}
             onChange={() => {}}
         />
     </View>
@@ -242,7 +234,7 @@ export const VariantsControlled: StoryComponentType = () => {
     const [disabledChecked, disabledSetChecked] = React.useState(false);
 
     return (
-        <View style={styles.row}>
+        <View style={[styles.row, styles.gap_240]}>
             <Checkbox
                 aria-label="Checked example"
                 checked={defaultChecked}
@@ -310,9 +302,9 @@ export const AdditionalClickTarget: StoryComponentType = () => {
         <View style={styles.wrapper}>
             <View style={styles.topic}>
                 <label htmlFor="topic-123">
-                    <LabelMedium>{headingText}</LabelMedium>
+                    <BodyText tag="span">{headingText}</BodyText>
                 </label>
-                <LabelSmall>{descriptionText}</LabelSmall>
+                <BodyText size="small">{descriptionText}</BodyText>
             </View>
             <Checkbox checked={checked} id="topic-123" onChange={setChecked} />
         </View>
@@ -331,11 +323,11 @@ const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
     },
-    marginLeft: {
-        marginLeft: 16,
+    gap: {
+        gap: sizing.size_160,
     },
-    marginRight: {
-        marginRight: 16,
+    gap_240: {
+        gap: sizing.size_240,
     },
     wrapper: {
         flexDirection: "row",

--- a/__docs__/wonder-blocks-form/checkbox.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {Checkbox, CheckboxGroup, Choice} from "@khanacademy/wonder-blocks-form";
-import {sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing, spacing, font} from "@khanacademy/wonder-blocks-tokens";
 
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
 import ComponentInfo from "../components/component-info";
@@ -283,6 +283,39 @@ export const WithLabel: StoryComponentType = () => {
 };
 
 WithLabel.parameters = {
+    docs: {
+        description: {
+            story: "The checkbox can have an optional label and description. This allows it to be used as a settings-like item. The user of this component is responsible for keeping track of checked state and providing an onChange callback.",
+        },
+    },
+};
+
+export const WithStyledLabel: StoryComponentType = () => {
+    const [checked, setChecked] = React.useState(false);
+
+    const handleChange = () => {
+        setChecked(!checked);
+    };
+
+    return (
+        <Checkbox
+            label={
+                <BodyText
+                    weight="bold"
+                    tag="span"
+                    style={{lineHeight: font.body.lineHeight.small}}
+                >
+                    Receive assignment reminders for Algebra
+                </BodyText>
+            }
+            description="You will receive a reminder 24 hours before each deadline"
+            checked={checked}
+            onChange={() => handleChange()}
+        />
+    );
+};
+
+WithStyledLabel.parameters = {
     docs: {
         description: {
             story: "The checkbox can have an optional label and description. This allows it to be used as a settings-like item. The user of this component is responsible for keeping track of checked state and providing an onChange callback.",

--- a/__docs__/wonder-blocks-form/choice.stories.tsx
+++ b/__docs__/wonder-blocks-form/choice.stories.tsx
@@ -3,7 +3,6 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {
@@ -56,7 +55,6 @@ const ChoiceWrapper = (args: any) => {
                 <Choice label="Mushroom" value="mushroom-checkbox" />
                 <Choice aria-label="Pineapple" value="pineapple" {...args} />
             </CheckboxGroup>
-            <Strut size={spacing.xLarge_32} />
             <RadioGroup
                 label="Pizza order"
                 description="Choose only one topping."
@@ -111,5 +109,6 @@ export const Default: StoryComponentType = {
 const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
+        gap: spacing.xLarge_32,
     },
 });

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {Choice, RadioGroup} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
@@ -154,9 +154,9 @@ export const MultipleChoiceStyling: StoryComponentType = () => {
 
     return (
         <>
-            <LabelLarge style={styles.prompt}>
+            <BodyText weight="bold" tag="span" style={styles.prompt}>
                 Select your blood type
-            </LabelLarge>
+            </BodyText>
             <RadioGroup
                 groupName="science-classes"
                 onChange={setSelectedValue}
@@ -230,9 +230,8 @@ FiltersOutFalsyChildren.parameters = {
 
 /**
  * There are specific situations where you might want to use a custom label
- * component instead of using the default `LabelMedium` component. This example
- * demonstrates how to use a custom label component that can be passed in as a
- * prop to the `RadioGroup` component.
+ * component. This example demonstrates how to use a custom label component
+ * that can be passed in as a prop to the `RadioGroup` component.
  */
 export const CustomLabel: StoryComponentType = {
     ...Default,
@@ -251,8 +250,10 @@ export const CustomLabel: StoryComponentType = {
                     justifyContent: "space-between",
                 }}
             >
-                <LabelLarge>Pokemon</LabelLarge>
-                <LabelMedium>(optional)</LabelMedium>
+                <BodyText weight="bold" tag="span">
+                    Pokemon
+                </BodyText>
+                <BodyText tag="span">(optional)</BodyText>
             </View>
         ),
     },

--- a/__docs__/wonder-blocks-form/radio.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio.stories.tsx
@@ -3,7 +3,8 @@ import {StyleSheet} from "aphrodite";
 
 import type {Meta, StoryObj} from "@storybook/react";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
@@ -57,37 +58,28 @@ Controlled.parameters = {
 
 export const Variants: StoryComponentType = () => (
     <View style={styles.row}>
-        <Radio
-            aria-label="Example"
-            checked={false}
-            style={styles.marginRight}
-            onChange={() => {}}
-        />
+        <Radio aria-label="Example" checked={false} onChange={() => {}} />
         <Radio
             aria-label="Checked Example"
             checked={true}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Radio
             aria-label="Error Example"
             error={true}
             checked={false}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Radio
             aria-label="Checked Error Example"
             error={true}
             checked={true}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Radio
             aria-label="Disabled Example"
             disabled={true}
             checked={false}
-            style={styles.marginRight}
             onChange={() => {}}
         />
         <Radio
@@ -144,9 +136,9 @@ export const AdditionalClickTarget: StoryComponentType = () => {
         <View style={styles.wrapper}>
             <View style={styles.topic}>
                 <label htmlFor="topic-123">
-                    <LabelMedium>{headingText}</LabelMedium>
+                    <BodyText tag="span">{headingText}</BodyText>
                 </label>
-                <LabelSmall>{descriptionText}</LabelSmall>
+                <BodyText size="small">{descriptionText}</BodyText>
             </View>
             <Radio checked={checked} id="topic-123" onChange={setChecked} />
         </View>
@@ -170,9 +162,7 @@ AdditionalClickTarget.parameters = {
 const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
-    },
-    marginRight: {
-        marginRight: 16,
+        gap: sizing.size_240,
     },
     wrapper: {
         flexDirection: "row",

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -28,7 +28,8 @@
     "@khanacademy/wonder-blocks-search-field": "workspace:*",
     "@khanacademy/wonder-blocks-timing": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
-    "@khanacademy/wonder-blocks-typography": "workspace:*"
+    "@khanacademy/wonder-blocks-typography": "workspace:*",
+    "@khanacademy/wonder-blocks-form": "workspace:*"
   },
   "peerDependencies": {
     "@phosphor-icons/core": "catalog:",

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -30,8 +30,7 @@
     "@khanacademy/wonder-blocks-icon": "workspace:*",
     "@khanacademy/wonder-blocks-layout": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
-    "@khanacademy/wonder-blocks-typography": "workspace:*",
-    "@khanacademy/wonder-blocks-form": "workspace:*"
+    "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
     "@phosphor-icons/core": "catalog:",

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -30,7 +30,8 @@
     "@khanacademy/wonder-blocks-icon": "workspace:*",
     "@khanacademy/wonder-blocks-layout": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
-    "@khanacademy/wonder-blocks-typography": "workspace:*"
+    "@khanacademy/wonder-blocks-typography": "workspace:*",
+    "@khanacademy/wonder-blocks-form": "workspace:*"
   },
   "peerDependencies": {
     "@phosphor-icons/core": "catalog:",

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -6,7 +6,16 @@
   "main": "dist/index.js",
   "module": "dist/es/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/es/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./styles.css": "./dist/css/vars.css"
+  },
   "scripts": {
+    "build:css": "pnpm exec wonder-blocks-tokens .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },

--- a/packages/wonder-blocks-form/src/components/__tests__/checkbox.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/checkbox.test.tsx
@@ -81,6 +81,25 @@ describe("Checkbox", () => {
         expect(onChangeSpy).toHaveBeenCalled();
     });
 
+    test("clicking the inputWrapper triggers `onChange`", () => {
+        // Arrange
+        const onChangeSpy = jest.fn();
+        render(
+            <Checkbox
+                label="Receive assignment reminders for Algebra"
+                checked={false}
+                onChange={onChangeSpy}
+            />,
+        );
+
+        // Act
+        const checkboxWrapper = screen.getByTestId("wb-checkbox-wrapper");
+        checkboxWrapper.click();
+
+        // Assert
+        expect(onChangeSpy).toHaveBeenCalled();
+    });
+
     test.each`
         indeterminateValue | checkedValue
         ${true}            | ${null}

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -30,10 +30,12 @@ function mapCheckedToAriaChecked(value: Checked): AriaChecked {
     }
 }
 
-// The checkbox size
-const size = spacing.medium_16;
-// The check icon size
-const checkSize = spacing.small_12;
+const baseStyles = {
+    // The checkbox size
+    size: spacing.medium_16,
+    // The check icon size
+    checkSize: spacing.small_12,
+};
 
 const StyledInput = addStyle("input");
 
@@ -83,8 +85,8 @@ const CheckboxCore = React.forwardRef(function CheckboxCore(
                 sharedStyles.checkboxIcon,
                 // The check icon is smaller than the checkbox, as per design.
                 {
-                    width: checkSize,
-                    height: checkSize,
+                    width: baseStyles.checkSize,
+                    height: baseStyles.checkSize,
                 },
             ]}
         />
@@ -132,10 +134,10 @@ const sharedStyles = StyleSheet.create({
     },
 
     default: {
-        height: size,
-        width: size,
-        minHeight: size,
-        minWidth: size,
+        height: baseStyles.size,
+        width: baseStyles.size,
+        minHeight: baseStyles.size,
+        minWidth: baseStyles.size,
         margin: 0,
         outline: "none",
         boxSizing: "border-box",
@@ -155,7 +157,7 @@ const sharedStyles = StyleSheet.create({
         position: "absolute",
         pointerEvents: "none",
         // This margin is to center the check icon in the checkbox.
-        margin: (size - checkSize) / 2,
+        margin: (baseStyles.size - baseStyles.checkSize) / 2,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -73,8 +73,8 @@ const CheckboxCore = React.forwardRef(function CheckboxCore(
         <PhosphorIcon
             color={
                 disabled
-                    ? semanticColor.icon.disabled
-                    : semanticColor.icon.inverse
+                    ? theme.icon.disabled.foreground
+                    : theme.icon.default.foreground
             }
             icon={checked ? checkIcon : minusIcon}
             size="small"
@@ -195,19 +195,13 @@ const _generateStyles = (
         },
         // Form validation error state
         error: {
-            border: semanticColor.choice.error.border,
-            background: semanticColor.choice.error.background,
+            border: theme.choice.error.border,
+            background: theme.choice.error.background,
         },
         // Disabled state
-        disabled: {
-            border: semanticColor.choice.disabled.border,
-            background: semanticColor.choice.disabled.background,
-        },
+        disabled: theme.choice.disabled,
         // Disabled and checked state
-        disabledChecked: {
-            border: semanticColor.choice.disabledChecked.border,
-            background: semanticColor.choice.disabledChecked.background,
-        },
+        disabledChecked: theme.choice.disabledChecked,
     };
 
     let stateStyles: Record<string, any> = {};
@@ -271,7 +265,7 @@ const _generateStyles = (
             inputWrapper: {
                 ":hover input:not([disabled])": {
                     backgroundColor: error
-                        ? (semanticColor.choice as any).error.background
+                        ? theme.choice.error.background
                         : colorAction.hover.background,
                     outline: `${border.width.medium} solid ${colorAction.hover.border}`,
                     outlineOffset: -1,
@@ -286,7 +280,7 @@ const _generateStyles = (
                 // TODO(WB-1864): Use focusStyles.focus
                 ":focus-visible": {
                     backgroundColor: error
-                        ? (semanticColor.choice as any).error.background
+                        ? theme.choice.error.background
                         : colorAction.hover.background,
                     outline: `${border.width.medium} solid ${semanticColor.focus.outer}`,
                     outlineOffset: -1,

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -10,6 +10,7 @@ import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 import minusIcon from "@phosphor-icons/core/bold/minus-bold.svg";
+import theme from "../theme/index";
 
 import type {ChoiceCoreProps, Checked} from "../util/types";
 
@@ -139,16 +140,15 @@ const sharedStyles = StyleSheet.create({
         outline: "none",
         boxSizing: "border-box",
         borderStyle: "solid",
-        borderWidth: border.width.thin,
-        // TODO(WB-1864): Use the correct token once TB is updated.
-        borderRadius: 3,
+        borderWidth: theme.root.border.width.default,
+        borderRadius: theme.checkbox.border.radius.default,
     },
 
     disabled: {
         cursor: "auto",
         backgroundColor: semanticColor.input.disabled.background,
         borderColor: semanticColor.input.disabled.border,
-        borderWidth: border.width.thin,
+        borderWidth: theme.root.border.width.default,
     },
 
     checkboxIcon: {

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -63,7 +63,7 @@ const CheckboxCore = React.forwardRef(function CheckboxCore(
         stateStyles.default,
     ];
 
-    const wrapperStyle = [theme.inputWrapper, stateStyles.inputWrapper];
+    const wrapperStyle = [sharedStyles.inputWrapper, stateStyles.inputWrapper];
 
     const checkboxIcon = (
         <PhosphorIcon
@@ -133,6 +133,8 @@ const CheckboxCore = React.forwardRef(function CheckboxCore(
 
 const sharedStyles = StyleSheet.create({
     inputWrapper: {
+        margin: theme.choice.inputWrapper.layout.margin,
+        padding: theme.choice.inputWrapper.layout.padding,
         position: "relative",
     },
     // Reset the default styled input element
@@ -143,23 +145,23 @@ const sharedStyles = StyleSheet.create({
     },
 
     default: {
-        height: baseStyles.checkbox.sizing.size,
-        width: baseStyles.checkbox.sizing.size,
-        minHeight: baseStyles.checkbox.sizing.size,
-        minWidth: baseStyles.checkbox.sizing.size,
+        height: baseStyles.choice.sizing.size,
+        width: baseStyles.choice.sizing.size,
+        minHeight: baseStyles.choice.sizing.size,
+        minWidth: baseStyles.choice.sizing.size,
         margin: 0,
         outline: "none",
         boxSizing: "border-box",
         borderStyle: "solid",
-        borderWidth: theme.checkbox.border.width.default,
-        borderRadius: theme.checkbox.border.radius.default,
+        borderWidth: baseStyles.checkbox.border.width.default,
+        borderRadius: baseStyles.checkbox.border.radius.default,
     },
 
     checkboxIcon: {
         position: "absolute",
         pointerEvents: "none",
         // This margin is to center the check icon in the checkbox.
-        margin: `calc((${baseStyles.checkbox.sizing.size} - ${baseStyles.checkbox.sizing.checkSize}) / 2)`,
+        margin: `calc((${baseStyles.choice.sizing.size} - ${baseStyles.checkbox.sizing.checkSize}) / 2)`,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -59,13 +59,12 @@ const CheckboxCore = React.forwardRef(function CheckboxCore(
         return;
     };
 
-    const stateStyles = _generateStyles(checked, error);
+    const stateStyles = _generateStyles(checked, error, disabled);
 
     const defaultStyle = [
         sharedStyles.inputReset,
         sharedStyles.default,
-        !disabled && stateStyles.default,
-        disabled && sharedStyles.disabled,
+        stateStyles.default,
     ];
 
     const wrapperStyle = [theme.inputWrapper, stateStyles.inputWrapper];
@@ -160,13 +159,6 @@ const sharedStyles = StyleSheet.create({
         borderRadius: theme.checkbox.border.radius.default,
     },
 
-    disabled: {
-        cursor: "auto",
-        backgroundColor: semanticColor.input.disabled.background,
-        borderColor: semanticColor.input.disabled.border,
-        borderWidth: theme.checkbox.border.width.default,
-    },
-
     checkboxIcon: {
         position: "absolute",
         pointerEvents: "none",
@@ -177,9 +169,13 @@ const sharedStyles = StyleSheet.create({
 
 const styles: Record<string, any> = {};
 
-const _generateStyles = (checked: Checked, error: boolean) => {
+const _generateStyles = (
+    checked: Checked,
+    error: boolean,
+    disabled: boolean,
+) => {
     // "hash" the parameters
-    const styleKey = `${String(checked)}-${String(error)}`;
+    const styleKey = `${String(checked)}-${String(error)}-${String(disabled)}`;
     if (styles[styleKey]) {
         return styles[styleKey];
     }
@@ -199,14 +195,47 @@ const _generateStyles = (checked: Checked, error: boolean) => {
         },
         // Form validation error state
         error: {
-            border: semanticColor.input.error.border,
-            background: semanticColor.input.error.background,
+            border: semanticColor.choice.error.border,
+            background: semanticColor.choice.error.background,
+        },
+        // Disabled state
+        disabled: {
+            border: semanticColor.choice.disabled.border,
+            background: semanticColor.choice.disabled.background,
+        },
+        // Disabled and checked state
+        disabledChecked: {
+            border: semanticColor.choice.disabledChecked.border,
+            background: semanticColor.choice.disabledChecked.background,
         },
     };
 
     let stateStyles: Record<string, any> = {};
 
-    if (isCheckedOrIndeterminate) {
+    // Handle disabled states first
+    if (disabled) {
+        if (isCheckedOrIndeterminate) {
+            // Disabled and checked/indeterminate
+            stateStyles = {
+                default: {
+                    cursor: "auto",
+                    backgroundColor: states.disabledChecked.background,
+                    borderColor: states.disabledChecked.border,
+                    borderWidth: theme.checkbox.border.width.default,
+                },
+            };
+        } else {
+            // Disabled and unchecked
+            stateStyles = {
+                default: {
+                    cursor: "auto",
+                    backgroundColor: states.disabled.background,
+                    borderColor: states.disabled.border,
+                    borderWidth: theme.checkbox.border.width.default,
+                },
+            };
+        }
+    } else if (isCheckedOrIndeterminate) {
         stateStyles = {
             inputWrapper: {
                 // TODO(WB-1864): Revisit hover, press tokens
@@ -242,7 +271,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
             inputWrapper: {
                 ":hover input:not([disabled])": {
                     backgroundColor: error
-                        ? semanticColor.input.error.background
+                        ? (semanticColor.choice as any).error.background
                         : colorAction.hover.background,
                     outline: `${border.width.medium} solid ${colorAction.hover.border}`,
                     outlineOffset: -1,
@@ -257,7 +286,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
                 // TODO(WB-1864): Use focusStyles.focus
                 ":focus-visible": {
                     backgroundColor: error
-                        ? semanticColor.input.error.background
+                        ? (semanticColor.choice as any).error.background
                         : colorAction.hover.background,
                     outline: `${border.width.medium} solid ${semanticColor.focus.outer}`,
                     outlineOffset: -1,

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -202,9 +202,9 @@ const _generateStyles = (
                 backgroundColor: checkedStyles.rest.background,
                 borderColor: checkedStyles.rest.border,
 
-                ":focus-visible:not([disabled])": {
-                    ...focusStyles.focus,
-                },
+                // Use the global focus style
+                ":focus-visible:not([disabled])":
+                    focusStyles.focus[":focus-visible"],
 
                 ":active:not([disabled])": {
                     outline: `${border.width.medium} solid ${checkedStyles.press.border}`,

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -210,7 +210,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
         stateStyles = {
             inputWrapper: {
                 // TODO(WB-1864): Revisit hover, press tokens
-                ":hover input": {
+                ":hover input:not([disabled])": {
                     outline: `${border.width.medium} solid ${colorAction.hover.border}`,
                     outlineOffset: 1,
                 },
@@ -240,7 +240,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
 
         stateStyles = {
             inputWrapper: {
-                ":hover input": {
+                ":hover input:not([disabled])": {
                     backgroundColor: error
                         ? semanticColor.input.error.background
                         : colorAction.hover.background,

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -210,6 +210,8 @@ const _generateStyles = (
                     outline: `${border.width.medium} solid ${checkedStyles.press.border}`,
                     outlineOffset: 1,
                     background: checkedStyles.press.background,
+                    // Add border to ensure error press state matches background
+                    borderColor: checkedStyles.press.background,
                 },
             },
         };

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -1,11 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {
-    border,
-    spacing,
-    semanticColor,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, sizing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
@@ -32,9 +28,9 @@ function mapCheckedToAriaChecked(value: Checked): AriaChecked {
 
 const baseStyles = {
     // The checkbox size
-    size: spacing.medium_16,
+    size: sizing.size_160,
     // The check icon size
-    checkSize: spacing.small_12,
+    checkSize: sizing.size_120,
 };
 
 const StyledInput = addStyle("input");
@@ -108,7 +104,7 @@ const CheckboxCore = React.forwardRef(function CheckboxCore(
             <View
                 style={wrapperStyle}
                 onClick={handleWrapperClick}
-                data-testid="wb-checkbox-wrapper"
+                testId="wb-checkbox-wrapper"
             >
                 <StyledInput
                     {...sharedProps}
@@ -141,6 +137,9 @@ const CheckboxCore = React.forwardRef(function CheckboxCore(
 });
 
 const sharedStyles = StyleSheet.create({
+    inputWrapper: {
+        position: "relative",
+    },
     // Reset the default styled input element
     inputReset: {
         appearance: "none",
@@ -172,7 +171,7 @@ const sharedStyles = StyleSheet.create({
         position: "absolute",
         pointerEvents: "none",
         // This margin is to center the check icon in the checkbox.
-        margin: (baseStyles.size - baseStyles.checkSize) / 2,
+        margin: `calc((${baseStyles.size} - ${baseStyles.checkSize}) / 2)`,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/checkbox-group.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 
-import {addStyle} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import styles from "./group-styles";
@@ -135,22 +134,35 @@ const CheckboxGroup = React.forwardRef(function CheckboxGroup(
             style={[styles.fieldset, style]}
             ref={ref}
         >
-            {label && (
-                <StyledLegend style={styles.legend}>
-                    <LabelMedium>{label}</LabelMedium>
-                </StyledLegend>
-            )}
-            {description && (
-                <LabelSmall style={styles.description}>
-                    {description}
-                </LabelSmall>
-            )}
-            {errorMessage && (
-                <LabelSmall style={styles.error}>{errorMessage}</LabelSmall>
-            )}
-            {(label || description || errorMessage) && (
-                <Strut size={spacing.small_12} />
-            )}
+            <View
+                style={
+                    label || description || errorMessage
+                        ? {
+                              marginBlockEnd: spacing.small_12,
+                          }
+                        : undefined
+                }
+            >
+                {label && (
+                    <StyledLegend style={styles.legend}>
+                        <BodyText tag="span">{label}</BodyText>
+                    </StyledLegend>
+                )}
+                {description && (
+                    <BodyText
+                        size="small"
+                        tag="span"
+                        style={styles.description}
+                    >
+                        {description}
+                    </BodyText>
+                )}
+                {errorMessage && (
+                    <BodyText size="small" tag="span" style={styles.error}>
+                        {errorMessage}
+                    </BodyText>
+                )}
+            </View>
 
             {allChildren.map((child, index) => {
                 // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.

--- a/packages/wonder-blocks-form/src/components/checkbox-group.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 
-import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 import styles from "./group-styles";
 import Choice from "./choice";
@@ -150,32 +151,26 @@ const CheckboxGroup = React.forwardRef(function CheckboxGroup(
                 </BodyText>
             )}
 
-            <View
-                style={
-                    label || description || errorMessage
-                        ? {
-                              marginBlockStart: spacing.small_12,
-                          }
-                        : undefined
-                }
-            >
-                {allChildren.map((child, index) => {
-                    // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
-                    const {style, value} = child.props;
-                    const checked = selectedValues.includes(value);
-                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
-                    return React.cloneElement(child, {
-                        checked: checked,
-                        error: !!errorMessage,
-                        groupName: groupName,
-                        id: `${groupName}-${value}`,
-                        key: value,
-                        onChange: () => handleChange(value, checked),
-                        style: [index > 0 && styles.defaultLineGap, style],
-                        variant: "checkbox",
-                    });
-                })}
-            </View>
+            {(label || description || errorMessage) && (
+                <Strut size={spacing.small_12} />
+            )}
+
+            {allChildren.map((child, index) => {
+                // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
+                const {style, value} = child.props;
+                const checked = selectedValues.includes(value);
+                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
+                return React.cloneElement(child, {
+                    checked: checked,
+                    error: !!errorMessage,
+                    groupName: groupName,
+                    id: `${groupName}-${value}`,
+                    key: value,
+                    onChange: () => handleChange(value, checked),
+                    style: [index > 0 && styles.defaultLineGap, style],
+                    variant: "checkbox",
+                });
+            })}
         </StyledFieldset>
     );
 });

--- a/packages/wonder-blocks-form/src/components/checkbox-group.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.tsx
@@ -128,61 +128,54 @@ const CheckboxGroup = React.forwardRef(function CheckboxGroup(
 
     const allChildren = React.Children.toArray(children).filter(Boolean);
 
-    const legendId = React.useId();
-
     return (
         <StyledFieldset
-            aria-labelledby={legendId}
             data-testid={testId}
             style={[styles.fieldset, style]}
             ref={ref}
         >
+            {label && (
+                <StyledLegend style={styles.legend}>
+                    <BodyText tag="span">{label}</BodyText>
+                </StyledLegend>
+            )}
+            {description && (
+                <BodyText size="small" tag="span" style={styles.description}>
+                    {description}
+                </BodyText>
+            )}
+            {errorMessage && (
+                <BodyText size="small" tag="span" style={styles.error}>
+                    {errorMessage}
+                </BodyText>
+            )}
+
             <View
                 style={
                     label || description || errorMessage
                         ? {
-                              marginBlockEnd: spacing.small_12,
+                              marginBlockStart: spacing.small_12,
                           }
                         : undefined
                 }
             >
-                {label && (
-                    <StyledLegend style={styles.legend} id={legendId}>
-                        <BodyText tag="span">{label}</BodyText>
-                    </StyledLegend>
-                )}
-                {description && (
-                    <BodyText
-                        size="small"
-                        tag="span"
-                        style={styles.description}
-                    >
-                        {description}
-                    </BodyText>
-                )}
-                {errorMessage && (
-                    <BodyText size="small" tag="span" style={styles.error}>
-                        {errorMessage}
-                    </BodyText>
-                )}
+                {allChildren.map((child, index) => {
+                    // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
+                    const {style, value} = child.props;
+                    const checked = selectedValues.includes(value);
+                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
+                    return React.cloneElement(child, {
+                        checked: checked,
+                        error: !!errorMessage,
+                        groupName: groupName,
+                        id: `${groupName}-${value}`,
+                        key: value,
+                        onChange: () => handleChange(value, checked),
+                        style: [index > 0 && styles.defaultLineGap, style],
+                        variant: "checkbox",
+                    });
+                })}
             </View>
-
-            {allChildren.map((child, index) => {
-                // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
-                const {style, value} = child.props;
-                const checked = selectedValues.includes(value);
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
-                return React.cloneElement(child, {
-                    checked: checked,
-                    error: !!errorMessage,
-                    groupName: groupName,
-                    id: `${groupName}-${value}`,
-                    key: value,
-                    onChange: () => handleChange(value, checked),
-                    style: [index > 0 && styles.defaultLineGap, style],
-                    variant: "checkbox",
-                });
-            })}
         </StyledFieldset>
     );
 });

--- a/packages/wonder-blocks-form/src/components/checkbox-group.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-group.tsx
@@ -128,8 +128,11 @@ const CheckboxGroup = React.forwardRef(function CheckboxGroup(
 
     const allChildren = React.Children.toArray(children).filter(Boolean);
 
+    const legendId = React.useId();
+
     return (
         <StyledFieldset
+            aria-labelledby={legendId}
             data-testid={testId}
             style={[styles.fieldset, style]}
             ref={ref}
@@ -144,7 +147,7 @@ const CheckboxGroup = React.forwardRef(function CheckboxGroup(
                 }
             >
                 {label && (
-                    <StyledLegend style={styles.legend}>
+                    <StyledLegend style={styles.legend} id={legendId}>
                         <BodyText tag="span">{label}</BodyText>
                     </StyledLegend>
                 )}

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -99,6 +99,7 @@ type Props = AriaProps & {
         return (
             <BodyText
                 tag="div"
+                weight="semi"
                 style={[styles.label, disabled && styles.disabledLabel]}
             >
                 <label htmlFor={id}>{label}</label>
@@ -163,14 +164,15 @@ type Props = AriaProps & {
 
 const styles = StyleSheet.create({
     wrapper: {
-        lineHeight: font.weight.medium,
+        gap: spacing.xSmall_8,
+        lineHeight: font.body.lineHeight.small,
         flexDirection: "row",
         alignItems: "flex-start",
         outline: "none",
     },
     label: {
-        // Match the line-height of BodyText medium, minus former -2px margin
-        lineHeight: sizing.size_180,
+        color: semanticColor.core.foreground.neutral.strong,
+        lineHeight: font.body.lineHeight.small,
     },
     disabledLabel: {
         // Match disabled text input label color

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -4,6 +4,7 @@ import {StyleSheet} from "aphrodite";
 import {View, Id} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {
+    font,
     semanticColor,
     sizing,
     spacing,
@@ -162,13 +163,14 @@ type Props = AriaProps & {
 
 const styles = StyleSheet.create({
     wrapper: {
+        lineHeight: font.weight.medium,
         flexDirection: "row",
         alignItems: "center",
         outline: "none",
     },
     label: {
-        // Match the line-height of BodyText, with 20px lineHeight
-        lineHeight: sizing.size_200,
+        // Match the line-height of BodyText medium, minus former -2px margin
+        lineHeight: sizing.size_180,
     },
     disabledLabel: {
         // Match disabled text input label color

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {View, Id} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {
     font,
     semanticColor,
@@ -141,17 +140,18 @@ type Props = AriaProps & {
                             // focus on basis of it being an input element.
                             tabIndex={-1}
                         >
-                            <ChoiceCore
-                                {...coreProps}
-                                id={uniqueId}
-                                checked={checked}
-                                aria-describedby={descriptionId}
-                                onClick={handleClick}
-                                disabled={disabled}
-                                error={error}
-                                ref={ref}
-                            />
-                            <Strut size={spacing.xSmall_8} />
+                            <View style={styles.choiceWrapper}>
+                                <ChoiceCore
+                                    {...coreProps}
+                                    id={uniqueId}
+                                    checked={checked}
+                                    aria-describedby={descriptionId}
+                                    onClick={handleClick}
+                                    disabled={disabled}
+                                    error={error}
+                                    ref={ref}
+                                />
+                            </View>
                             {label && getLabel(uniqueId)}
                         </View>
                         {description && getDescription(descriptionId)}
@@ -169,6 +169,10 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: "flex-start",
         outline: "none",
+    },
+    choiceWrapper: {
+        display: "block",
+        marginBlockStart: sizing.size_010,
     },
     label: {
         color: semanticColor.core.foreground.neutral.strong,

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -175,7 +175,8 @@ const styles = StyleSheet.create({
         marginTop: -2,
     },
     disabledLabel: {
-        color: semanticColor.action.secondary.disabled.foreground,
+        // Match disabled text input label color
+        color: semanticColor.core.foreground.disabled.subtle,
     },
     description: {
         // 16 for icon + 8 for spacing strut

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -168,11 +168,6 @@ const styles = StyleSheet.create({
     },
     label: {
         lineHeight: sizing.size_140,
-        // NOTE: The checkbox/radio button (height 16px) should be center
-        // aligned with the first line of the label. However, LabelMedium has a
-        // declared line height of 20px, so we need to adjust the top to get the
-        // desired alignment.
-        marginTop: -2,
     },
     disabledLabel: {
         // Match disabled text input label color

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -163,11 +163,12 @@ type Props = AriaProps & {
 const styles = StyleSheet.create({
     wrapper: {
         flexDirection: "row",
-        alignItems: "flex-start",
+        alignItems: "center",
         outline: "none",
     },
     label: {
-        lineHeight: sizing.size_140,
+        // Match the line-height of BodyText, with 20px lineHeight
+        lineHeight: sizing.size_200,
     },
     disabledLabel: {
         // Match disabled text input label color

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -140,7 +140,7 @@ type Props = AriaProps & {
                             // focus on basis of it being an input element.
                             tabIndex={-1}
                         >
-                            <View style={styles.choiceWrapper}>
+                            <View style={[styles.choiceWrapper]}>
                                 <ChoiceCore
                                     {...coreProps}
                                     id={uniqueId}
@@ -172,6 +172,9 @@ const styles = StyleSheet.create({
     },
     choiceWrapper: {
         display: "block",
+        // Account for half of the default label lineHeight difference,
+        // which is 18px (label text) - 16px (choice size).
+        // This equals 1 pixel above, and 1 pixel below to be vertically centered
         marginBlockStart: sizing.size_010,
     },
     label: {

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -165,7 +165,7 @@ const styles = StyleSheet.create({
     wrapper: {
         lineHeight: font.weight.medium,
         flexDirection: "row",
-        alignItems: "center",
+        alignItems: "flex-start",
         outline: "none",
     },
     label: {

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -3,8 +3,12 @@ import {StyleSheet} from "aphrodite";
 
 import {View, Id} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {
+    semanticColor,
+    sizing,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import CheckboxCore from "./checkbox-core";
 import RadioCore from "./radio-core";
@@ -92,19 +96,20 @@ type Props = AriaProps & {
 
     const getLabel = (id: string): React.ReactNode => {
         return (
-            <LabelMedium
+            <BodyText
+                tag="div"
                 style={[styles.label, disabled && styles.disabledLabel]}
             >
                 <label htmlFor={id}>{label}</label>
-            </LabelMedium>
+            </BodyText>
         );
     };
 
     const getDescription = (id?: string): React.ReactNode => {
         return (
-            <LabelSmall style={styles.description} id={id}>
+            <BodyText size="small" style={styles.description} id={id}>
                 {description}
-            </LabelSmall>
+            </BodyText>
         );
     };
 
@@ -162,6 +167,7 @@ const styles = StyleSheet.create({
         outline: "none",
     },
     label: {
+        lineHeight: sizing.size_140,
         // NOTE: The checkbox/radio button (height 16px) should be center
         // aligned with the first line of the label. However, LabelMedium has a
         // declared line height of 20px, so we need to adjust the top to get the

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -139,10 +139,9 @@ const _generateStyles = (
                 // borders need to render in pixels for consistent size
                 borderWidth: `calc(${baseStyles.radio.sizing.size} / 4)`,
 
-                ":focus-visible:not([disabled])": {
-                    // Use the global focus style
-                    ...focusStyles.focus,
-                },
+                // Use the global focus style
+                ":focus-visible:not([disabled])":
+                    focusStyles.focus[":focus-visible"],
 
                 ":active:not([disabled])": {
                     outline: `${border.width.medium} solid ${checkedStyles.press.border}`,

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -1,10 +1,13 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import theme from "../theme/index";
 import type {ChoiceCoreProps, Checked} from "../util/types";
+
+import {colorStates, baseStyles} from "../util/styles";
 
 const StyledInput = addStyle("input");
 
@@ -74,10 +77,6 @@ const StyledInput = addStyle("input");
     );
 });
 
-const baseStyles = {
-    size: sizing.size_160,
-};
-
 const sharedStyles = StyleSheet.create({
     inputWrapper: {
         position: "relative",
@@ -89,16 +88,16 @@ const sharedStyles = StyleSheet.create({
         MozAppearance: "none",
     },
     default: {
-        height: baseStyles.size,
-        width: baseStyles.size,
-        minHeight: baseStyles.size,
-        minWidth: baseStyles.size,
+        height: baseStyles.radio.sizing.size,
+        width: baseStyles.radio.sizing.size,
+        minHeight: baseStyles.radio.sizing.size,
+        minWidth: baseStyles.radio.sizing.size,
         margin: 0,
         outline: "none",
         boxSizing: "border-box",
         borderStyle: "solid",
-        borderWidth: theme.radio.border.width.default,
-        borderRadius: theme.radio.border.radius.default,
+        borderWidth: baseStyles.radio.border.width.default,
+        borderRadius: baseStyles.radio.border.radius.default,
     },
 });
 
@@ -113,146 +112,79 @@ const _generateStyles = (
     if (styles[styleKey]) {
         return styles[styleKey];
     }
-    const actionType = error ? "destructive" : "progressive";
-    // NOTE: Radio buttons use the secondary style regardless of the checked
-    // state.
-    const colorAction = semanticColor.action.secondary[actionType];
-
-    const coreType = error ? "critical" : "instructive";
-    const colorCore = semanticColor.core.background[coreType];
-
-    // The different states that the component can be in.
-    const states = {
-        // Resting state (unchecked)
-        unchecked: {
-            border: theme.choice.default.border,
-            background: colorCore.subtle,
-        },
-        checked: {
-            // NOTE: This is a special case where the border is the same color
-            // as the foreground. This should change as soon as we simplify the
-            // existing `action` tokens.
-            border: colorAction.default.foreground,
-            background: colorCore.subtle,
-        },
-        // Form validation error state
-        error: {
-            border: theme.choice.error.border,
-            background: theme.choice.error.background,
-        },
-        // Disabled state
-        disabled: {
-            border: theme.choice.disabled.border,
-            background: theme.choice.disabled.background,
-        },
-    };
 
     let newStyles: Record<string, any> = {};
 
-    // Handle disabled states first
-    if (disabled) {
-        newStyles = {
-            inputWrapper: {},
-            default: {
-                cursor: "auto",
-                backgroundColor: states.disabled.background,
-                borderColor: states.disabled.border,
-                borderWidth: theme.radio.border.width.default,
-            },
-            disabledChecked: {
-                position: "absolute",
-                // position checkmark 1/4 of the overall size for 1/2 of its width/height
-                // accounting for increased padding/hit target area in TB
-                top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
-                left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
-                height: `calc(${baseStyles.size} / 2)`,
-                width: `calc(${baseStyles.size} / 2)`,
-                borderRadius: theme.radio.border.radius.default,
-                backgroundColor: theme.choice.disabled.background,
-            },
-        };
-    } else if (checked) {
+    type ChoiceState = "default" | "disabled" | "error";
+
+    const currentState: ChoiceState = error
+        ? "error"
+        : disabled
+          ? "disabled"
+          : "default";
+
+    if (checked) {
+        const checkedStyles = colorStates.radio.checked[currentState];
         newStyles = {
             inputWrapper: {
                 // TODO(WB-1864): Revisit hover, press tokens
                 ":hover input:not([disabled])": {
-                    outline: `${border.width.medium} solid ${colorAction.hover.border}`,
+                    outline: `${border.width.medium} solid ${checkedStyles.hover.border}`,
                     outlineOffset: 1,
                 },
             },
             default: {
-                backgroundColor: states.checked.background,
-                borderColor: states.checked.border,
+                backgroundColor: checkedStyles.rest.background,
+                borderColor: checkedStyles.rest.border,
                 // borders need to render in pixels for consistent size
-                borderWidth: `calc(${baseStyles.size} / 4)`,
+                borderWidth: `calc(${baseStyles.radio.sizing.size} / 4)`,
 
-                // Focus and hover have the same style. Focus style only shows
-                // up with keyboard navigation.
-                // TODO(WB-1864): Use focusStyles.focus
-                ":focus-visible": {
-                    outline: `${border.width.medium} solid ${semanticColor.focus.outer}`,
-                    outlineOffset: 1,
+                ":focus-visible:not([disabled])": {
+                    // Use the global focus style
+                    ...focusStyles.focus,
                 },
 
-                ":active": {
-                    outline: `${border.width.medium} solid ${colorAction.press.border}`,
+                ":active:not([disabled])": {
+                    outline: `${border.width.medium} solid ${checkedStyles.press.border}`,
                     outlineOffset: 1,
-                    borderColor: colorAction.press.border,
+                    borderColor: checkedStyles.press.border,
                 },
             },
             disabledChecked: {
                 position: "absolute",
-                top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
-                left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
-                height: `calc(${baseStyles.size} / 2)`,
-                width: `calc(${baseStyles.size} / 2)`,
-                borderRadius: theme.radio.border.radius.default,
-                backgroundColor: theme.choice.disabled.background,
+                top: `calc(${baseStyles.radio.sizing.size} * .25 + ${theme.inputWrapper.padding})`,
+                left: `calc(${baseStyles.radio.sizing.size} * .25 + ${theme.inputWrapper.padding})`,
+                height: `calc(${baseStyles.radio.sizing.size} / 2)`,
+                width: `calc(${baseStyles.radio.sizing.size} / 2)`,
+                borderRadius: baseStyles.radio.border.radius.default,
+                backgroundColor: checkedStyles.rest.background,
             },
         };
     } else {
-        const currentState = error ? states.error : states.unchecked;
-
+        const uncheckedStyles = colorStates.radio.unchecked[currentState];
         newStyles = {
             inputWrapper: {
                 // TODO(WB-1864): Revisit hover, press tokens
                 ":hover input:not([disabled])": {
-                    backgroundColor: error
-                        ? states.error.background
-                        : colorAction.hover.background,
-                    outline: `${border.width.medium} solid ${colorAction.hover.border}`,
+                    backgroundColor: uncheckedStyles.hover.background,
+                    outline: `${border.width.medium} solid ${uncheckedStyles.hover.border}`,
                     outlineOffset: -1,
                 },
             },
             default: {
-                backgroundColor: currentState.background,
-                borderColor: currentState.border,
+                backgroundColor: uncheckedStyles.rest.background,
+                borderColor: uncheckedStyles.rest.border,
 
-                // Focus and hover have the same style. Focus style only shows
-                // up with keyboard navigation.
-                // TODO(WB-1864): Use focusStyles.focus
-                ":focus-visible": {
-                    backgroundColor: error
-                        ? states.error.background
-                        : colorAction.hover.background,
-                    outline: `${border.width.medium} solid ${semanticColor.focus.outer}`,
-                    outlineOffset: -1,
+                ":focus-visible:not([disabled])": {
+                    // Use the global focus style
+                    ...focusStyles.focus,
                 },
 
-                ":active": {
-                    backgroundColor: colorAction.press.background,
-                    outline: `${border.width.medium} solid ${colorAction.press.border}`,
+                ":active:not([disabled])": {
+                    backgroundColor: uncheckedStyles.press.background,
+                    outline: `${border.width.medium} solid ${uncheckedStyles.press.border}`,
                     outlineOffset: -1,
                 },
-            },
-            disabledChecked: {
-                position: "absolute",
-                top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
-                left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
-                height: `calc(${baseStyles.size} / 2)`,
-                width: `calc(${baseStyles.size} / 2)`,
-                borderRadius: theme.radio.border.radius.default,
-                backgroundColor: theme.choice.disabled.background,
             },
         };
     }

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-
+import theme from "../theme/index";
 import type {ChoiceCoreProps, Checked} from "../util/types";
 
 const StyledInput = addStyle("input");
@@ -59,7 +59,7 @@ const disabledChecked = {
     left: size / 4,
     height: size / 2,
     width: size / 2,
-    borderRadius: border.radius.radius_full,
+    borderRadius: theme.radio.border.radius.default,
     backgroundColor: semanticColor.core.border.disabled.strong,
 } as const;
 
@@ -79,14 +79,14 @@ const sharedStyles = StyleSheet.create({
         outline: "none",
         boxSizing: "border-box",
         borderStyle: "solid",
-        borderWidth: border.width.thin,
-        borderRadius: border.radius.radius_full,
+        borderWidth: theme.root.border.width.default,
+        borderRadius: theme.radio.border.radius.default,
     },
     disabled: {
         cursor: "auto",
         backgroundColor: semanticColor.input.disabled.background,
         borderColor: semanticColor.input.disabled.border,
-        borderWidth: border.width.thin,
+        borderWidth: theme.root.border.width.default,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import theme from "../theme/index";
 import type {ChoiceCoreProps, Checked} from "../util/types";
@@ -74,20 +74,23 @@ const StyledInput = addStyle("input");
 });
 
 const baseStyles = {
-    size: 16, // circle with a different color. Here, we add that center circle. // If the checkbox is disabled and selected, it has a border but also an inner
+    size: sizing.size_160,
 };
 
 const disabledChecked = {
     position: "absolute",
-    top: baseStyles.size / 4,
-    left: baseStyles.size / 4,
-    height: baseStyles.size / 2,
-    width: baseStyles.size / 2,
+    top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
+    left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
+    height: `calc(${baseStyles.size} / 2)`,
+    width: `calc(${baseStyles.size} / 2)`,
     borderRadius: theme.radio.border.radius.default,
     backgroundColor: semanticColor.core.border.disabled.strong,
 } as const;
 
 const sharedStyles = StyleSheet.create({
+    inputWrapper: {
+        position: "relative",
+    },
     // Reset the default styled input element
     inputReset: {
         appearance: "none",
@@ -163,7 +166,8 @@ const _generateStyles = (checked: Checked, error: boolean) => {
             default: {
                 backgroundColor: states.checked.background,
                 borderColor: states.checked.border,
-                borderWidth: baseStyles.size / 4,
+                // borders need to render in pixels for consistent size
+                borderWidth: `calc(${baseStyles.size} / 4)`,
 
                 // Focus and hover have the same style. Focus style only shows
                 // up with keyboard navigation.

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -125,7 +125,7 @@ const _generateStyles = (
     const states = {
         // Resting state (unchecked)
         unchecked: {
-            border: semanticColor.choice.default.border,
+            border: theme.choice.default.border,
             background: colorCore.subtle,
         },
         checked: {
@@ -137,13 +137,13 @@ const _generateStyles = (
         },
         // Form validation error state
         error: {
-            border: semanticColor.choice.error.border,
-            background: semanticColor.choice.error.background,
+            border: theme.choice.error.border,
+            background: theme.choice.error.background,
         },
         // Disabled state
         disabled: {
-            border: semanticColor.choice.disabled.border,
-            background: semanticColor.choice.disabled.background,
+            border: theme.choice.disabled.border,
+            background: theme.choice.disabled.background,
         },
     };
 
@@ -161,12 +161,14 @@ const _generateStyles = (
             },
             disabledChecked: {
                 position: "absolute",
+                // position checkmark 1/4 of the overall size for 1/2 of its width/height
+                // accounting for increased padding/hit target area in TB
                 top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
                 left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
                 height: `calc(${baseStyles.size} / 2)`,
                 width: `calc(${baseStyles.size} / 2)`,
                 borderRadius: theme.radio.border.radius.default,
-                backgroundColor: semanticColor.choice.disabled.background,
+                backgroundColor: theme.choice.disabled.background,
             },
         };
     } else if (checked) {
@@ -205,7 +207,7 @@ const _generateStyles = (
                 height: `calc(${baseStyles.size} / 2)`,
                 width: `calc(${baseStyles.size} / 2)`,
                 borderRadius: theme.radio.border.radius.default,
-                backgroundColor: semanticColor.choice.disabled.background,
+                backgroundColor: theme.choice.disabled.background,
             },
         };
     } else {
@@ -250,7 +252,7 @@ const _generateStyles = (
                 height: `calc(${baseStyles.size} / 2)`,
                 width: `calc(${baseStyles.size} / 2)`,
                 borderRadius: theme.radio.border.radius.default,
-                backgroundColor: semanticColor.choice.disabled.background,
+                backgroundColor: theme.choice.disabled.background,
             },
         };
     }

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -174,10 +174,9 @@ const _generateStyles = (
                 backgroundColor: uncheckedStyles.rest.background,
                 borderColor: uncheckedStyles.rest.border,
 
-                ":focus-visible:not([disabled])": {
-                    // Use the global focus style
-                    ...focusStyles.focus,
-                },
+                // Use the global focus style
+                ":focus-visible:not([disabled])":
+                    focusStyles.focus[":focus-visible"],
 
                 ":active:not([disabled])": {
                     backgroundColor: uncheckedStyles.press.background,

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -24,12 +24,11 @@ const StyledInput = addStyle("input");
     const {checked, disabled, error, groupName, id, testId, ...sharedProps} =
         props;
 
-    const stateStyles = _generateStyles(checked, error);
+    const stateStyles = _generateStyles(checked, error, disabled);
     const defaultStyle = [
         sharedStyles.inputReset,
         sharedStyles.default,
-        !disabled && stateStyles.default,
-        disabled && sharedStyles.disabled,
+        stateStyles.default,
     ];
 
     const wrapperStyle = [theme.inputWrapper, stateStyles.inputWrapper];
@@ -67,7 +66,9 @@ const StyledInput = addStyle("input");
                         }
                     }}
                 />
-                {disabled && checked && <span style={disabledChecked} />}
+                {disabled && checked && (
+                    <span style={stateStyles.disabledChecked} />
+                )}
             </View>
         </React.Fragment>
     );
@@ -76,16 +77,6 @@ const StyledInput = addStyle("input");
 const baseStyles = {
     size: sizing.size_160,
 };
-
-const disabledChecked = {
-    position: "absolute",
-    top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
-    left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
-    height: `calc(${baseStyles.size} / 2)`,
-    width: `calc(${baseStyles.size} / 2)`,
-    borderRadius: theme.radio.border.radius.default,
-    backgroundColor: semanticColor.core.border.disabled.strong,
-} as const;
 
 const sharedStyles = StyleSheet.create({
     inputWrapper: {
@@ -109,18 +100,16 @@ const sharedStyles = StyleSheet.create({
         borderWidth: theme.radio.border.width.default,
         borderRadius: theme.radio.border.radius.default,
     },
-    disabled: {
-        cursor: "auto",
-        backgroundColor: semanticColor.input.disabled.background,
-        borderColor: semanticColor.input.disabled.border,
-        borderWidth: theme.radio.border.width.default,
-    },
 });
 
 const styles: Record<string, any> = {};
-const _generateStyles = (checked: Checked, error: boolean) => {
+const _generateStyles = (
+    checked: Checked,
+    error: boolean,
+    disabled: boolean,
+) => {
     // "hash" the parameters
-    const styleKey = `${String(checked)}-${String(error)}`;
+    const styleKey = `${String(checked)}-${String(error)}-${String(disabled)}`;
     if (styles[styleKey]) {
         return styles[styleKey];
     }
@@ -136,7 +125,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
     const states = {
         // Resting state (unchecked)
         unchecked: {
-            border: semanticColor.input.default.border,
+            border: semanticColor.choice.default.border,
             background: colorCore.subtle,
         },
         checked: {
@@ -148,13 +137,39 @@ const _generateStyles = (checked: Checked, error: boolean) => {
         },
         // Form validation error state
         error: {
-            border: semanticColor.input.error.border,
-            background: semanticColor.input.error.background,
+            border: semanticColor.choice.error.border,
+            background: semanticColor.choice.error.background,
+        },
+        // Disabled state
+        disabled: {
+            border: semanticColor.choice.disabled.border,
+            background: semanticColor.choice.disabled.background,
         },
     };
 
     let newStyles: Record<string, any> = {};
-    if (checked) {
+
+    // Handle disabled states first
+    if (disabled) {
+        newStyles = {
+            inputWrapper: {},
+            default: {
+                cursor: "auto",
+                backgroundColor: states.disabled.background,
+                borderColor: states.disabled.border,
+                borderWidth: theme.radio.border.width.default,
+            },
+            disabledChecked: {
+                position: "absolute",
+                top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
+                left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
+                height: `calc(${baseStyles.size} / 2)`,
+                width: `calc(${baseStyles.size} / 2)`,
+                borderRadius: theme.radio.border.radius.default,
+                backgroundColor: semanticColor.choice.disabled.background,
+            },
+        };
+    } else if (checked) {
         newStyles = {
             inputWrapper: {
                 // TODO(WB-1864): Revisit hover, press tokens
@@ -182,6 +197,15 @@ const _generateStyles = (checked: Checked, error: boolean) => {
                     outlineOffset: 1,
                     borderColor: colorAction.press.border,
                 },
+            },
+            disabledChecked: {
+                position: "absolute",
+                top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
+                left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
+                height: `calc(${baseStyles.size} / 2)`,
+                width: `calc(${baseStyles.size} / 2)`,
+                borderRadius: theme.radio.border.radius.default,
+                backgroundColor: semanticColor.choice.disabled.background,
             },
         };
     } else {
@@ -218,6 +242,15 @@ const _generateStyles = (checked: Checked, error: boolean) => {
                     outline: `${border.width.medium} solid ${colorAction.press.border}`,
                     outlineOffset: -1,
                 },
+            },
+            disabledChecked: {
+                position: "absolute",
+                top: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
+                left: `calc(${baseStyles.size} * .25 + ${theme.inputWrapper.padding})`,
+                height: `calc(${baseStyles.size} / 2)`,
+                width: `calc(${baseStyles.size} / 2)`,
+                borderRadius: theme.radio.border.radius.default,
+                backgroundColor: semanticColor.choice.disabled.background,
             },
         };
     }

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -34,7 +34,7 @@ const StyledInput = addStyle("input");
         stateStyles.default,
     ];
 
-    const wrapperStyle = [theme.inputWrapper, stateStyles.inputWrapper];
+    const wrapperStyle = [sharedStyles.inputWrapper, stateStyles.inputWrapper];
 
     const handleWrapperClick = (e: React.MouseEvent) => {
         // forward event from wrapper Div
@@ -79,6 +79,8 @@ const StyledInput = addStyle("input");
 
 const sharedStyles = StyleSheet.create({
     inputWrapper: {
+        padding: theme.choice.inputWrapper.layout.padding,
+        margin: theme.choice.inputWrapper.layout.margin,
         position: "relative",
     },
     // Reset the default styled input element
@@ -88,10 +90,10 @@ const sharedStyles = StyleSheet.create({
         MozAppearance: "none",
     },
     default: {
-        height: baseStyles.radio.sizing.size,
-        width: baseStyles.radio.sizing.size,
-        minHeight: baseStyles.radio.sizing.size,
-        minWidth: baseStyles.radio.sizing.size,
+        height: baseStyles.choice.sizing.size,
+        width: baseStyles.choice.sizing.size,
+        minHeight: baseStyles.choice.sizing.size,
+        minWidth: baseStyles.choice.sizing.size,
         margin: 0,
         outline: "none",
         boxSizing: "border-box",
@@ -137,7 +139,7 @@ const _generateStyles = (
                 backgroundColor: checkedStyles.rest.background,
                 borderColor: checkedStyles.rest.border,
                 // borders need to render in pixels for consistent size
-                borderWidth: `calc(${baseStyles.radio.sizing.size} / 4)`,
+                borderWidth: `calc(${baseStyles.choice.sizing.size} / 4)`,
 
                 // Use the global focus style
                 ":focus-visible:not([disabled])":
@@ -151,10 +153,10 @@ const _generateStyles = (
             },
             disabledChecked: {
                 position: "absolute",
-                top: `calc(${baseStyles.radio.sizing.size} * .25 + ${theme.inputWrapper.padding})`,
-                left: `calc(${baseStyles.radio.sizing.size} * .25 + ${theme.inputWrapper.padding})`,
-                height: `calc(${baseStyles.radio.sizing.size} / 2)`,
-                width: `calc(${baseStyles.radio.sizing.size} / 2)`,
+                top: `calc(${baseStyles.choice.sizing.size} * .25 + ${theme.choice.inputWrapper.layout.padding})`,
+                left: `calc(${baseStyles.choice.sizing.size} * .25 + ${theme.choice.inputWrapper.layout.padding})`,
+                height: `calc(${baseStyles.choice.sizing.size} / 2)`,
+                width: `calc(${baseStyles.choice.sizing.size} / 2)`,
                 borderRadius: baseStyles.radio.border.radius.default,
                 backgroundColor: checkedStyles.rest.background,
             },

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -158,7 +158,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
         newStyles = {
             inputWrapper: {
                 // TODO(WB-1864): Revisit hover, press tokens
-                ":hover input": {
+                ":hover input:not([disabled])": {
                     outline: `${border.width.medium} solid ${colorAction.hover.border}`,
                     outlineOffset: 1,
                 },
@@ -190,7 +190,7 @@ const _generateStyles = (checked: Checked, error: boolean) => {
         newStyles = {
             inputWrapper: {
                 // TODO(WB-1864): Revisit hover, press tokens
-                ":hover input": {
+                ":hover input:not([disabled])": {
                     backgroundColor: error
                         ? states.error.background
                         : colorAction.hover.background,

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -52,13 +52,16 @@ const StyledInput = addStyle("input");
     );
 });
 
-const size = 16; // circle with a different color. Here, we add that center circle. // If the checkbox is disabled and selected, it has a border but also an inner
+const baseStyles = {
+    size: 16, // circle with a different color. Here, we add that center circle. // If the checkbox is disabled and selected, it has a border but also an inner
+};
+
 const disabledChecked = {
     position: "absolute",
-    top: size / 4,
-    left: size / 4,
-    height: size / 2,
-    width: size / 2,
+    top: baseStyles.size / 4,
+    left: baseStyles.size / 4,
+    height: baseStyles.size / 2,
+    width: baseStyles.size / 2,
     borderRadius: theme.radio.border.radius.default,
     backgroundColor: semanticColor.core.border.disabled.strong,
 } as const;
@@ -71,10 +74,10 @@ const sharedStyles = StyleSheet.create({
         MozAppearance: "none",
     },
     default: {
-        height: size,
-        width: size,
-        minHeight: size,
-        minWidth: size,
+        height: baseStyles.size,
+        width: baseStyles.size,
+        minHeight: baseStyles.size,
+        minWidth: baseStyles.size,
         margin: 0,
         outline: "none",
         boxSizing: "border-box",

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -125,10 +125,9 @@ const RadioGroup = React.forwardRef(function RadioGroup(
                 style={
                     label || description || errorMessage
                         ? {
-                              display: "contents",
                               marginBlockEnd: spacing.small_12,
                           }
-                        : {display: "contents"}
+                        : undefined
                 }
             >
                 {label && (

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -112,57 +112,55 @@ const RadioGroup = React.forwardRef(function RadioGroup(
     } = props;
 
     const allChildren = React.Children.toArray(children).filter(Boolean);
-    const legendId = React.useId();
 
     return (
         <StyledFieldset
-            aria-labelledby={legendId}
             data-testid={testId}
             style={[styles.fieldset, style]}
             ref={ref}
         >
+            {label && (
+                <StyledLegend style={styles.legend}>
+                    <BodyText tag="span">{label}</BodyText>
+                </StyledLegend>
+            )}
+            {description && (
+                <BodyText size="small" style={styles.description}>
+                    {description}
+                </BodyText>
+            )}
+            {errorMessage && (
+                <BodyText size="small" style={styles.error}>
+                    {errorMessage}
+                </BodyText>
+            )}
+
             <View
                 style={
                     label || description || errorMessage
                         ? {
-                              marginBlockEnd: spacing.small_12,
+                              marginBlockStart: spacing.small_12,
                           }
                         : undefined
                 }
             >
-                {label && (
-                    <StyledLegend style={styles.legend} id={legendId}>
-                        <BodyText tag="span">{label}</BodyText>
-                    </StyledLegend>
-                )}
-                {description && (
-                    <BodyText size="small" style={styles.description}>
-                        {description}
-                    </BodyText>
-                )}
-                {errorMessage && (
-                    <BodyText size="small" style={styles.error}>
-                        {errorMessage}
-                    </BodyText>
-                )}
+                {allChildren.map((child, index) => {
+                    // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
+                    const {style, value} = child.props;
+                    const checked = selectedValue === value;
+                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
+                    return React.cloneElement(child, {
+                        checked: checked,
+                        error: !!errorMessage,
+                        groupName: groupName,
+                        id: `${groupName}-${value}`,
+                        key: value,
+                        onChange: () => onChange(value),
+                        style: [index > 0 && styles.defaultLineGap, style],
+                        variant: "radio",
+                    });
+                })}
             </View>
-
-            {allChildren.map((child, index) => {
-                // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
-                const {style, value} = child.props;
-                const checked = selectedValue === value;
-                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
-                return React.cloneElement(child, {
-                    checked: checked,
-                    error: !!errorMessage,
-                    groupName: groupName,
-                    id: `${groupName}-${value}`,
-                    key: value,
-                    onChange: () => onChange(value),
-                    style: [index > 0 && styles.defaultLineGap, style],
-                    variant: "radio",
-                });
-            })}
         </StyledFieldset>
     );
 });

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 
-import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 import styles from "./group-styles";
 import Choice from "./choice";
@@ -135,32 +136,26 @@ const RadioGroup = React.forwardRef(function RadioGroup(
                 </BodyText>
             )}
 
-            <View
-                style={
-                    label || description || errorMessage
-                        ? {
-                              marginBlockStart: spacing.small_12,
-                          }
-                        : undefined
-                }
-            >
-                {allChildren.map((child, index) => {
-                    // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
-                    const {style, value} = child.props;
-                    const checked = selectedValue === value;
-                    // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
-                    return React.cloneElement(child, {
-                        checked: checked,
-                        error: !!errorMessage,
-                        groupName: groupName,
-                        id: `${groupName}-${value}`,
-                        key: value,
-                        onChange: () => onChange(value),
-                        style: [index > 0 && styles.defaultLineGap, style],
-                        variant: "radio",
-                    });
-                })}
-            </View>
+            {(label || description || errorMessage) && (
+                <Strut size={spacing.small_12} />
+            )}
+
+            {allChildren.map((child, index) => {
+                // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.
+                const {style, value} = child.props;
+                const checked = selectedValue === value;
+                // @ts-expect-error [FEI-5019] - TS2769 - No overload matches this call.
+                return React.cloneElement(child, {
+                    checked: checked,
+                    error: !!errorMessage,
+                    groupName: groupName,
+                    id: `${groupName}-${value}`,
+                    key: value,
+                    onChange: () => onChange(value),
+                    style: [index > 0 && styles.defaultLineGap, style],
+                    variant: "radio",
+                });
+            })}
         </StyledFieldset>
     );
 });

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 
-import {addStyle} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import styles from "./group-styles";
@@ -120,22 +119,29 @@ const RadioGroup = React.forwardRef(function RadioGroup(
             style={[styles.fieldset, style]}
             ref={ref}
         >
-            {label && (
-                <StyledLegend style={styles.legend}>
-                    <LabelMedium>{label}</LabelMedium>
-                </StyledLegend>
-            )}
-            {description && (
-                <LabelSmall style={styles.description}>
-                    {description}
-                </LabelSmall>
-            )}
-            {errorMessage && (
-                <LabelSmall style={styles.error}>{errorMessage}</LabelSmall>
-            )}
-            {(label || description || errorMessage) && (
-                <Strut size={spacing.small_12} />
-            )}
+            <View
+                style={
+                    label || description || errorMessage
+                        ? {marginBlockEnd: spacing.small_12}
+                        : undefined
+                }
+            >
+                {label && (
+                    <StyledLegend style={styles.legend}>
+                        <BodyText tag="span">{label}</BodyText>
+                    </StyledLegend>
+                )}
+                {description && (
+                    <BodyText size="small" style={styles.description}>
+                        {description}
+                    </BodyText>
+                )}
+                {errorMessage && (
+                    <BodyText size="small" style={styles.error}>
+                        {errorMessage}
+                    </BodyText>
+                )}
+            </View>
 
             {allChildren.map((child, index) => {
                 // @ts-expect-error [FEI-5019] - TS2339 - Property 'props' does not exist on type 'ReactChild | ReactFragment | ReactPortal'.

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -112,9 +112,11 @@ const RadioGroup = React.forwardRef(function RadioGroup(
     } = props;
 
     const allChildren = React.Children.toArray(children).filter(Boolean);
+    const legendId = React.useId();
 
     return (
         <StyledFieldset
+            aria-labelledby={legendId}
             data-testid={testId}
             style={[styles.fieldset, style]}
             ref={ref}
@@ -122,12 +124,15 @@ const RadioGroup = React.forwardRef(function RadioGroup(
             <View
                 style={
                     label || description || errorMessage
-                        ? {marginBlockEnd: spacing.small_12}
-                        : undefined
+                        ? {
+                              display: "contents",
+                              marginBlockEnd: spacing.small_12,
+                          }
+                        : {display: "contents"}
                 }
             >
                 {label && (
-                    <StyledLegend style={styles.legend}>
+                    <StyledLegend style={styles.legend} id={legendId}>
                         <BodyText tag="span">{label}</BodyText>
                     </StyledLegend>
                 )}

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -1,53 +1,9 @@
-import {
-    border,
-    color,
-    semanticColor,
-    sizing,
-} from "@khanacademy/wonder-blocks-tokens";
-
-const {core, surface} = semanticColor;
+import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
     inputWrapper: {
         padding: sizing.size_0,
         margin: sizing.size_0,
-    },
-    choice: {
-        default: {
-            border: core.border.neutral.default,
-            background: surface.primary,
-            foreground: core.foreground.neutral.strong,
-        },
-        error: {
-            border: core.border.critical.default,
-            background: core.background.critical.subtle,
-            foreground: core.foreground.neutral.strong,
-        },
-        checked: {
-            border: core.border.instructive.default,
-            background: core.background.instructive.default,
-            foreground: core.foreground.inverse.strong,
-        },
-        disabled: {
-            border: core.border.disabled.default,
-            background: color.offWhite,
-            foreground: core.foreground.neutral.default,
-        },
-        disabledChecked: {
-            border: core.border.disabled.default,
-            background: color.offWhite,
-            foreground: core.border.neutral.subtle,
-        },
-        // hover: {
-        //     border: core.border.instructive.default,
-        //     background: surface.primary,
-        //     foreground: core.foreground.inverse.strong,
-        // },
-        // press: {
-        //     border: core.border.instructive.strong,
-        //     background: core.background.instructive.strong,
-        //     foreground: core.foreground.inverse.strong,
-        // },
     },
     checkbox: {
         border: {
@@ -57,24 +13,6 @@ export default {
             width: {
                 default: border.width.thin,
             },
-        },
-    },
-    radio: {
-        border: {
-            radius: {
-                default: border.radius.radius_full,
-            },
-            width: {
-                default: border.width.thin,
-            },
-        },
-    },
-    icon: {
-        default: {
-            foreground: color.offWhite,
-        },
-        disabled: {
-            foreground: core.foreground.disabled.default,
         },
     },
 };

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -1,17 +1,17 @@
 import {border} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
-    root: {
-        border: {
-            width: {
-                default: border.width.thin,
-            },
-        },
+    inputWrapper: {
+        padding: "0px",
+        margin: "0px",
     },
     checkbox: {
         border: {
             radius: {
-                default: 3,
+                default: "3px",
+            },
+            width: {
+                default: border.width.thin,
             },
         },
     },
@@ -19,6 +19,9 @@ export default {
         border: {
             radius: {
                 default: border.radius.radius_full,
+            },
+            width: {
+                default: border.width.thin,
             },
         },
     },

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -1,0 +1,25 @@
+import {border} from "@khanacademy/wonder-blocks-tokens";
+
+export default {
+    root: {
+        border: {
+            width: {
+                default: border.width.thin,
+            },
+        },
+    },
+    checkbox: {
+        border: {
+            radius: {
+                default: 3,
+            },
+        },
+    },
+    radio: {
+        border: {
+            radius: {
+                default: border.radius.radius_full,
+            },
+        },
+    },
+};

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -1,9 +1,53 @@
-import {border} from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    color,
+    semanticColor,
+    sizing,
+} from "@khanacademy/wonder-blocks-tokens";
+
+const {core, surface} = semanticColor;
 
 export default {
     inputWrapper: {
-        padding: "0px",
-        margin: "0px",
+        padding: sizing.size_0,
+        margin: sizing.size_0,
+    },
+    choice: {
+        default: {
+            border: core.border.neutral.default,
+            background: surface.primary,
+            foreground: core.foreground.neutral.strong,
+        },
+        error: {
+            border: core.border.critical.default,
+            background: core.background.critical.subtle,
+            foreground: core.foreground.neutral.strong,
+        },
+        checked: {
+            border: core.border.instructive.default,
+            background: core.background.instructive.default,
+            foreground: core.foreground.inverse.strong,
+        },
+        disabled: {
+            border: core.border.disabled.default,
+            background: color.offWhite,
+            foreground: core.foreground.neutral.default,
+        },
+        disabledChecked: {
+            border: core.border.disabled.default,
+            background: color.offWhite,
+            foreground: core.border.neutral.subtle,
+        },
+        // hover: {
+        //     border: core.border.instructive.default,
+        //     background: surface.primary,
+        //     foreground: core.foreground.inverse.strong,
+        // },
+        // press: {
+        //     border: core.border.instructive.strong,
+        //     background: core.background.instructive.strong,
+        //     foreground: core.foreground.inverse.strong,
+        // },
     },
     checkbox: {
         border: {
@@ -23,6 +67,14 @@ export default {
             width: {
                 default: border.width.thin,
             },
+        },
+    },
+    icon: {
+        default: {
+            foreground: color.offWhite,
+        },
+        disabled: {
+            foreground: core.foreground.disabled.default,
         },
     },
 };

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -1,17 +1,11 @@
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
-    inputWrapper: {
-        padding: sizing.size_0,
-        margin: sizing.size_0,
-    },
-    checkbox: {
-        border: {
-            radius: {
-                default: "3px",
-            },
-            width: {
-                default: border.width.thin,
+    choice: {
+        inputWrapper: {
+            layout: {
+                padding: sizing.size_0,
+                margin: sizing.size_0,
             },
         },
     },

--- a/packages/wonder-blocks-form/src/theme/index.ts
+++ b/packages/wonder-blocks-form/src/theme/index.ts
@@ -1,0 +1,4 @@
+import {mapValuesToCssVars} from "@khanacademy/wonder-blocks-tokens";
+import themeDefault from "./default";
+
+export default mapValuesToCssVars(themeDefault, "--wb-c-form-");

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,15 +1,51 @@
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+
+const {core, surface} = semanticColor;
 
 export default {
     inputWrapper: {
         padding: sizing.size_040,
         margin: `calc(${sizing.size_040} * -1)`,
     },
+    choice: {
+        default: {
+            border: core.border.neutral.default,
+            background: surface.primary,
+            foreground: core.foreground.neutral.strong,
+        },
+        error: {
+            border: core.border.critical.default,
+            background: core.background.critical.subtle,
+            foreground: core.foreground.neutral.strong,
+        },
+        checked: {
+            border: core.border.instructive.default,
+            background: core.background.instructive.default,
+            foreground: core.foreground.inverse.strong,
+        },
+        disabled: {
+            border: core.border.disabled.default,
+            foreground: core.foreground.neutral.default,
+        },
+        disabledChecked: {
+            border: core.border.disabled.default,
+            background: core.border.disabled.default,
+            foreground: core.border.neutral.subtle,
+        },
+    },
     checkbox: {
         border: {
             radius: {
                 default: border.radius.radius_040,
             },
+        },
+    },
+    icon: {
+        default: {
+            foreground: core.foreground.inverse.strong,
+        },
+        disabled: {
+            foreground: core.border.neutral.subtle,
         },
     },
 };

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,0 +1,22 @@
+import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+
+export default {
+    root: {
+        border: {
+            width: {
+                default: border.width.thin,
+            },
+        },
+        sizing: {
+            height: sizing.size_240,
+            width: sizing.size_240,
+        },
+    },
+    checkbox: {
+        border: {
+            radius: {
+                default: border.radius.radius_040,
+            },
+        },
+    },
+};

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,14 +1,11 @@
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
-    inputWrapper: {
-        padding: sizing.size_040,
-        margin: `calc(${sizing.size_040} * -1)`,
-    },
-    checkbox: {
-        border: {
-            radius: {
-                default: border.radius.radius_040,
+    choice: {
+        inputWrapper: {
+            layout: {
+                padding: sizing.size_040,
+                margin: `calc(${sizing.size_040} * -1)`,
             },
         },
     },

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,51 +1,15 @@
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-
-const {core, surface} = semanticColor;
+import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
     inputWrapper: {
         padding: sizing.size_040,
         margin: `calc(${sizing.size_040} * -1)`,
     },
-    choice: {
-        default: {
-            border: core.border.neutral.default,
-            background: surface.primary,
-            foreground: core.foreground.neutral.strong,
-        },
-        error: {
-            border: core.border.critical.default,
-            background: core.background.critical.subtle,
-            foreground: core.foreground.neutral.strong,
-        },
-        checked: {
-            border: core.border.instructive.default,
-            background: core.background.instructive.default,
-            foreground: core.foreground.inverse.strong,
-        },
-        disabled: {
-            border: core.border.disabled.default,
-            foreground: core.foreground.neutral.default,
-        },
-        disabledChecked: {
-            border: core.border.disabled.default,
-            background: core.border.disabled.default,
-            foreground: core.border.neutral.subtle,
-        },
-    },
     checkbox: {
         border: {
             radius: {
                 default: border.radius.radius_040,
             },
-        },
-    },
-    icon: {
-        default: {
-            foreground: core.foreground.inverse.strong,
-        },
-        disabled: {
-            foreground: core.border.neutral.subtle,
         },
     },
 };

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,33 +1,15 @@
-import {border, sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
     inputWrapper: {
-        padding: `${spacing.medium_16}px`,
-        margin: `calc(-${spacing.medium_16}px)`,
+        padding: sizing.size_040,
+        margin: `calc(${sizing.size_040} * -1)`,
     },
     checkbox: {
         border: {
             radius: {
                 default: border.radius.radius_040,
             },
-            width: {
-                default: border.width.thin,
-            },
-        },
-        sizing: {
-            height: sizing.size_240,
-            width: sizing.size_240,
-        },
-    },
-    radio: {
-        border: {
-            width: {
-                default: border.width.thin,
-            },
-        },
-        sizing: {
-            height: sizing.size_240,
-            width: sizing.size_240,
         },
     },
 };

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,8 +1,15 @@
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
-    root: {
+    inputWrapper: {
+        padding: `${spacing.medium_16}px`,
+        margin: `calc(-${spacing.medium_16}px)`,
+    },
+    checkbox: {
         border: {
+            radius: {
+                default: border.radius.radius_040,
+            },
             width: {
                 default: border.width.thin,
             },
@@ -12,11 +19,15 @@ export default {
             width: sizing.size_240,
         },
     },
-    checkbox: {
+    radio: {
         border: {
-            radius: {
-                default: border.radius.radius_040,
+            width: {
+                default: border.width.thin,
             },
+        },
+        sizing: {
+            height: sizing.size_240,
+            width: sizing.size_240,
         },
     },
 };

--- a/packages/wonder-blocks-form/src/util/styles.ts
+++ b/packages/wonder-blocks-form/src/util/styles.ts
@@ -85,11 +85,7 @@ export const baseStyles = {
             foreground: semanticColor.core.foreground.inverse.strong,
         },
         disabled: {
-            // the semanticColor isn't working for this icon.
-            // our approach changed to use the TB theme in Classic,
-            // but the icon foreground color is themed and no longer works.
-            // semanticColor for TB: core.border.neutral.subtle (too dark in classic)
-            foreground: "#CBCBCD",
+            foreground: semanticColor.core.foreground.neutral.subtle,
         },
     },
 };

--- a/packages/wonder-blocks-form/src/util/styles.ts
+++ b/packages/wonder-blocks-form/src/util/styles.ts
@@ -118,7 +118,7 @@ export const colorStates: StyleMap = {
         checked: {
             default: {
                 rest: {
-                    border: semanticColor.input.checked.border,
+                    border: semanticColor.core.transparent,
                     background: semanticColor.input.checked.background,
                 },
                 hover: {
@@ -172,7 +172,7 @@ export const colorStates: StyleMap = {
         checked: {
             default: {
                 rest: {
-                    border: semanticColor.input.checked.border,
+                    border: semanticColor.input.checked.background,
                     background: semanticColor.core.border.inverse.strong,
                 },
                 hover: baseStyles.choice.checked,

--- a/packages/wonder-blocks-form/src/util/styles.ts
+++ b/packages/wonder-blocks-form/src/util/styles.ts
@@ -27,6 +27,10 @@ export interface StyleMap {
 export const baseStyles = {
     // Reusable base styles for Checkbox and Radio
     choice: {
+        sizing: {
+            // The checkbox/radio size
+            size: sizing.size_160,
+        },
         checked: {
             border: semanticColor.input.checked.border,
         },
@@ -56,9 +60,6 @@ export const baseStyles = {
         },
     },
     radio: {
-        sizing: {
-            size: sizing.size_160,
-        },
         border: {
             radius: {
                 default: border.radius.radius_full,
@@ -69,15 +70,21 @@ export const baseStyles = {
         },
     },
     checkbox: {
+        border: {
+            radius: {
+                default: border.radius.radius_040,
+            },
+            width: {
+                default: border.width.thin,
+            },
+        },
+        sizing: {
+            // The check icon size
+            checkSize: sizing.size_120,
+        },
         disabledChecked: {
             border: semanticColor.core.transparent,
             background: semanticColor.core.background.disabled.strong,
-        },
-        sizing: {
-            // The checkbox size
-            size: sizing.size_160,
-            // The check icon size
-            checkSize: sizing.size_120,
         },
     },
     icon: {

--- a/packages/wonder-blocks-form/src/util/styles.ts
+++ b/packages/wonder-blocks-form/src/util/styles.ts
@@ -1,21 +1,26 @@
 import {border, sizing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
-type StyleState = {
-    rest: any;
-    hover: any;
-    press: any;
+type InteractionState = {
+    background?: string;
+    border?: string;
 };
 
-type StyleCategory = {
-    default: StyleState;
-    disabled: StyleState;
-    error: StyleState;
+type ComponentState = {
+    rest: InteractionState;
+    hover: InteractionState;
+    press: InteractionState;
+};
+
+type ComponentStates = {
+    default: ComponentState;
+    disabled: ComponentState;
+    error: ComponentState;
 };
 
 export interface StyleMap {
     [key: string]: {
-        unchecked: StyleCategory;
-        checked: StyleCategory;
+        unchecked: ComponentStates;
+        checked: ComponentStates;
     };
 }
 

--- a/packages/wonder-blocks-form/src/util/styles.ts
+++ b/packages/wonder-blocks-form/src/util/styles.ts
@@ -177,11 +177,9 @@ export const colorStates: StyleMap = {
                 },
                 hover: baseStyles.choice.checked,
                 press: {
-                    border: semanticColor.action.secondary.progressive.press
-                        .border,
+                    border: semanticColor.core.background.instructive.strong,
                     background:
-                        semanticColor.action.secondary.progressive.press
-                            .background,
+                        semanticColor.core.background.instructive.strong,
                 },
             },
             error: {

--- a/packages/wonder-blocks-form/src/util/styles.ts
+++ b/packages/wonder-blocks-form/src/util/styles.ts
@@ -189,7 +189,7 @@ export const colorStates: StyleMap = {
             },
             disabled: {
                 rest: {
-                    border: semanticColor.core.border.disabled.strong,
+                    border: semanticColor.core.border.disabled.default,
                     background: semanticColor.core.border.inverse.strong,
                 },
                 hover: {

--- a/packages/wonder-blocks-form/src/util/styles.ts
+++ b/packages/wonder-blocks-form/src/util/styles.ts
@@ -1,0 +1,207 @@
+import {border, sizing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+
+type StyleState = {
+    rest: any;
+    hover: any;
+    press: any;
+};
+
+type StyleCategory = {
+    default: StyleState;
+    disabled: StyleState;
+    error: StyleState;
+};
+
+export interface StyleMap {
+    [key: string]: {
+        unchecked: StyleCategory;
+        checked: StyleCategory;
+    };
+}
+
+export const baseStyles = {
+    // Reusable base styles for Checkbox and Radio
+    choice: {
+        checked: {
+            border: semanticColor.input.checked.border,
+        },
+        disabled: {
+            border: semanticColor.input.disabled.border,
+            background: semanticColor.input.disabled.background,
+        },
+        error: {
+            border: semanticColor.input.error.border,
+            background: semanticColor.input.error.background,
+        },
+        unchecked: {
+            rest: {
+                border: semanticColor.input.default.border,
+                background: semanticColor.input.default.background,
+            },
+            hover: {
+                border: semanticColor.action.secondary.progressive.hover.border,
+                background:
+                    semanticColor.action.secondary.progressive.hover.background,
+            },
+            press: {
+                border: semanticColor.action.secondary.progressive.press.border,
+                background:
+                    semanticColor.action.secondary.progressive.press.background,
+            },
+        },
+    },
+    radio: {
+        sizing: {
+            size: sizing.size_160,
+        },
+        border: {
+            radius: {
+                default: border.radius.radius_full,
+            },
+            width: {
+                default: border.width.thin,
+            },
+        },
+    },
+    checkbox: {
+        disabledChecked: {
+            border: semanticColor.core.transparent,
+            background: semanticColor.core.background.disabled.strong,
+        },
+        sizing: {
+            // The checkbox size
+            size: sizing.size_160,
+            // The check icon size
+            checkSize: sizing.size_120,
+        },
+    },
+    icon: {
+        default: {
+            foreground: semanticColor.core.foreground.inverse.strong,
+        },
+        disabled: {
+            // the semanticColor isn't working for this icon.
+            // our approach changed to use the TB theme in Classic,
+            // but the icon foreground color is themed and no longer works.
+            // semanticColor for TB: core.border.neutral.subtle (too dark in classic)
+            foreground: "#CBCBCD",
+        },
+    },
+};
+
+// The different states that components can be in.
+// These states reference baseStyles defaults with overrides where necessary.
+export const colorStates: StyleMap = {
+    checkbox: {
+        unchecked: {
+            default: baseStyles.choice.unchecked,
+            disabled: {
+                rest: baseStyles.choice.disabled,
+                hover: baseStyles.choice.disabled,
+                press: baseStyles.choice.disabled,
+            },
+            error: {
+                rest: baseStyles.choice.error,
+                hover: baseStyles.choice.error,
+                press: {
+                    ...baseStyles.choice.error,
+                    border: semanticColor.core.border.critical.strong,
+                },
+            },
+        },
+        // specific styles for Checkbox states
+        checked: {
+            default: {
+                rest: {
+                    border: semanticColor.input.checked.border,
+                    background: semanticColor.input.checked.background,
+                },
+                hover: {
+                    border: semanticColor.core.border.instructive.default,
+                },
+                press: {
+                    border: semanticColor.input.checked.border,
+                    background:
+                        semanticColor.core.background.instructive.strong,
+                },
+            },
+            disabled: {
+                rest: baseStyles.checkbox.disabledChecked,
+                hover: baseStyles.checkbox.disabledChecked,
+                press: baseStyles.checkbox.disabledChecked,
+            },
+            error: {
+                rest: {
+                    background: semanticColor.core.border.critical.default,
+                    border: semanticColor.core.border.critical.default,
+                },
+                hover: {
+                    background: semanticColor.core.background.critical.default,
+                    border: semanticColor.core.border.critical.default,
+                },
+                press: {
+                    background: semanticColor.core.background.critical.strong,
+                    border: semanticColor.core.border.critical.strong,
+                },
+            },
+        },
+    },
+    radio: {
+        unchecked: {
+            default: baseStyles.choice.unchecked,
+            disabled: {
+                rest: baseStyles.choice.disabled,
+                hover: baseStyles.choice.disabled,
+                press: baseStyles.choice.disabled,
+            },
+            error: {
+                rest: baseStyles.choice.error,
+                hover: baseStyles.choice.error,
+                press: {
+                    ...baseStyles.choice.error,
+                    border: semanticColor.core.border.critical.strong,
+                },
+            },
+        },
+        // specific styles for Radio states
+        checked: {
+            default: {
+                rest: {
+                    border: semanticColor.input.checked.border,
+                    background: semanticColor.core.border.inverse.strong,
+                },
+                hover: baseStyles.choice.checked,
+                press: {
+                    border: semanticColor.action.secondary.progressive.press
+                        .border,
+                    background:
+                        semanticColor.action.secondary.progressive.press
+                            .background,
+                },
+            },
+            error: {
+                rest: baseStyles.choice.error,
+                hover: baseStyles.choice.error,
+                press: {
+                    ...baseStyles.choice.error,
+                    background: semanticColor.core.background.critical.strong,
+                    border: semanticColor.core.border.critical.strong,
+                },
+            },
+            disabled: {
+                rest: {
+                    border: semanticColor.core.border.disabled.strong,
+                    background: semanticColor.core.border.inverse.strong,
+                },
+                hover: {
+                    border: semanticColor.core.border.disabled.strong,
+                    background: semanticColor.core.border.inverse.strong,
+                },
+                press: {
+                    border: semanticColor.core.border.disabled.strong,
+                    background: semanticColor.core.border.inverse.strong,
+                },
+            },
+        },
+    },
+};

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -539,22 +539,6 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             },
         },
     },
-
-    choice: {
-        default: {
-            border: core.border.neutral.default,
-            background: surface.primary,
-            foreground: core.foreground.neutral.strong,
-        },
-        disabled: {
-            background: core.background.neutral.subtle,
-        },
-        disabledChecked: {
-            border: core.border.disabled.subtle,
-            background: core.background.disabled.strong,
-        },
-    },
-
     status: {
         critical: {
             background: color.red_90,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -540,6 +540,21 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
         },
     },
 
+    choice: {
+        default: {
+            border: core.border.neutral.default,
+            background: surface.primary,
+            foreground: core.foreground.neutral.strong,
+        },
+        disabled: {
+            background: core.background.neutral.subtle,
+        },
+        disabledChecked: {
+            border: core.border.disabled.subtle,
+            background: core.background.disabled.strong,
+        },
+    },
+
     status: {
         critical: {
             background: color.red_90,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -699,6 +699,33 @@ export const semanticColor = {
             foreground: core.foreground.neutral.strong,
         },
     },
+    choice: {
+        default: {
+            border: core.border.neutral.default,
+            background: surface.primary,
+            foreground: core.foreground.neutral.strong,
+        },
+        checked: {
+            border: core.border.instructive.default,
+            background: core.background.instructive.default,
+            foreground: core.foreground.inverse.strong,
+        },
+        disabled: {
+            border: core.border.disabled.default,
+            background: color.offWhite,
+            foreground: core.foreground.neutral.default,
+        },
+        disabledChecked: {
+            border: core.border.disabled.default,
+            background: color.offWhite,
+            foreground: core.foreground.disabled.strong,
+        },
+        error: {
+            border: core.border.critical.default,
+            background: core.background.critical.subtle,
+            foreground: core.foreground.neutral.strong,
+        },
+    },
     /**
      * For labels, icons, filters, alerts, and other elements where color can
      * add meaning to the state of the system or an item in the system.

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -699,33 +699,6 @@ export const semanticColor = {
             foreground: core.foreground.neutral.strong,
         },
     },
-    choice: {
-        default: {
-            border: core.border.neutral.default,
-            background: surface.primary,
-            foreground: core.foreground.neutral.strong,
-        },
-        checked: {
-            border: core.border.instructive.default,
-            background: core.background.instructive.default,
-            foreground: core.foreground.inverse.strong,
-        },
-        disabled: {
-            border: core.border.disabled.default,
-            background: color.offWhite,
-            foreground: core.foreground.neutral.default,
-        },
-        disabledChecked: {
-            border: core.border.disabled.default,
-            background: color.offWhite,
-            foreground: core.foreground.disabled.strong,
-        },
-        error: {
-            border: core.border.critical.default,
-            background: core.background.critical.subtle,
-            foreground: core.foreground.neutral.strong,
-        },
-    },
     /**
      * For labels, icons, filters, alerts, and other elements where color can
      * add meaning to the state of the system or an item in the system.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,6 +845,9 @@ importers:
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
+      '@khanacademy/wonder-blocks-form':
+        specifier: workspace:*
+        version: 'link:'
       '@khanacademy/wonder-blocks-icon':
         specifier: workspace:*
         version: link:../wonder-blocks-icon

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,9 @@ importers:
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
+      '@khanacademy/wonder-blocks-form':
+        specifier: workspace:*
+        version: link:../wonder-blocks-form
       '@khanacademy/wonder-blocks-icon':
         specifier: workspace:*
         version: link:../wonder-blocks-icon
@@ -845,9 +848,6 @@ importers:
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
-      '@khanacademy/wonder-blocks-form':
-        specifier: workspace:*
-        version: 'link:'
       '@khanacademy/wonder-blocks-icon':
         specifier: workspace:*
         version: link:../wonder-blocks-icon


### PR DESCRIPTION
## Summary:
Adds theming support to Checkbox and Radio, including the Thunderblocks theme.

Notable differences in TB include:
- Increased hover and target click areas (4px)
- 4px border-radius instead of 3px
- Semantic colors: Component/Input/Selected blue

Issue: WB-1972, WB-1974

## Test plan:
1. Review Test sheets for Checkbox and Radio
2. Test clicking of padded wrapper around both component types
3. Compare to Figma designs
   - TB: https://www.figma.com/design/EuFu0U7gqc1koXm8ZhlOLp/%E2%9A%A1%EF%B8%8F-Components?node-id=2048-52&t=B2xxLXv7GkDySMja-0
   - OG: https://www.figma.com/design/VbVu3h2BpBhH80niq101MHHE/%F0%9F%92%A0-Main-Components?node-id=15197-6798&t=zmIZ176DtJ5rmwyU-0