### PR TITLE
Add `styles` prop to `Banner` so that the `root` element can be styled

### DIFF
--- a/.changeset/green-grapes-call.md
+++ b/.changeset/green-grapes-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": minor
+---
+
+Add `styles` prop to `Banner` so that the `root` element can be styled

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -5,14 +5,8 @@ import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
-import {
-    color,
-    spacing,
-    semanticColor,
-    sizing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Banner from "@khanacademy/wonder-blocks-banner";
 
@@ -105,19 +99,16 @@ export const Kinds: StoryComponentType = {
                 kind="info"
                 layout="floating"
             />
-            <Strut size={spacing.medium_16} />
             <Banner
                 text="kind: success - This is a message about something positive or successful!"
                 kind="success"
                 layout="floating"
             />
-            <Strut size={spacing.medium_16} />
             <Banner
                 text="kind: warning - This is a message warning the user about a potential issue."
                 kind="warning"
                 layout="floating"
             />
-            <Strut size={spacing.medium_16} />
             <Banner
                 text="kind: critical - This is a message about something critical or an error."
                 kind="critical"
@@ -141,8 +132,10 @@ export const Kinds: StoryComponentType = {
  * added around the floating banner so that it will not touch its outline.
  */
 export const Layouts: StoryComponentType = () => {
-    const borderStyle = {border: `2px solid ${color.fadedPurple24}`} as const;
-    const floatingContainerStyle = {padding: spacing.xSmall_8} as const;
+    const borderStyle = {
+        border: `2px solid ${semanticColor.core.border.inverse.strong}`,
+    } as const;
+    const floatingContainerStyle = {padding: sizing.size_080} as const;
 
     return (
         <View style={styles.container}>
@@ -151,13 +144,11 @@ export const Layouts: StoryComponentType = () => {
                 layout="full-width"
                 kind="success"
             />
-            <Strut size={spacing.medium_16} />
             <Banner
                 text="This banner has floating layout."
                 layout="floating"
                 kind="success"
             />
-            <Strut size={spacing.medium_16} />
             <View style={borderStyle}>
                 <Banner
                     text="This banner has full-width layout. There is no space around it."
@@ -165,7 +156,6 @@ export const Layouts: StoryComponentType = () => {
                     kind="success"
                 />
             </View>
-            <Strut size={spacing.medium_16} />
             <View style={[borderStyle, floatingContainerStyle]}>
                 <Banner
                     text={`This banner has floating layout. Padding has been
@@ -212,11 +202,8 @@ export const LongText: StoryComponentType = {
 export const DarkBackground: StoryComponentType = () => (
     <View style={styles.container}>
         <Banner text="kind: info" kind="info" layout="full-width" />
-        <Strut size={spacing.medium_16} />
         <Banner text="kind: success" kind="success" layout="full-width" />
-        <Strut size={spacing.medium_16} />
         <Banner text="kind: warning" kind="warning" layout="full-width" />
-        <Strut size={spacing.medium_16} />
         <Banner text="kind: critical" kind="critical" layout="full-width" />
     </View>
 );
@@ -275,7 +262,7 @@ export const WithLinks: StoryComponentType = {
  */
 export const WithInlineLinks: StoryComponentType = {
     render: () => (
-        <>
+        <View style={styles.container}>
             <Banner
                 text="Oh no! The button and link on the right look different! Don't mix button and link actions."
                 kind="critical"
@@ -285,7 +272,6 @@ export const WithInlineLinks: StoryComponentType = {
                     {type: "button", title: "Button", onClick: () => {}},
                 ]}
             />
-            <Strut size={spacing.medium_16} />
             <Banner
                 text={
                     <LabelSmall>
@@ -302,7 +288,7 @@ export const WithInlineLinks: StoryComponentType = {
                 layout="floating"
                 actions={[{type: "button", title: "Button", onClick: () => {}}]}
             />
-        </>
+        </View>
     ),
 };
 
@@ -589,7 +575,7 @@ export const WithCustomIcon: StoryComponentType = {
  */
 export const RightToLeft: StoryComponentType = {
     render: () => (
-        <View style={styles.rightToLeft}>
+        <View style={[styles.rightToLeft, styles.container]}>
             <Banner
                 text="یہ اردو میں لکھا ہے۔"
                 actions={[
@@ -598,7 +584,6 @@ export const RightToLeft: StoryComponentType = {
                 ]}
                 layout="full-width"
             />
-            <Strut size={spacing.medium_16} />
             <Banner
                 text="یہ اردو میں لکھا ہے۔"
                 actions={[
@@ -690,6 +675,7 @@ const styles = StyleSheet.create({
     },
     container: {
         width: "100%",
+        gap: sizing.size_160,
     },
     narrowBanner: {
         maxWidth: 400,

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -649,7 +649,7 @@ export const WithCustomStyles: StoryComponentType = {
             <Banner
                 text={reallyLongText}
                 layout="floating"
-                // styles={{root: {flexShrink: 0}}}
+                styles={{root: {flexShrink: 0}}}
             />
             <View
                 style={{

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -649,7 +649,7 @@ export const WithCustomStyles: StoryComponentType = {
             <Banner
                 text={reallyLongText}
                 layout="floating"
-                styles={{root: {flexShrink: 0}}}
+                // styles={{root: {flexShrink: 0}}}
             />
             <View
                 style={{

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -666,6 +666,12 @@ export const WithCustomStyles: StoryComponentType = {
             </View>
         </View>
     ),
+    parameters: {
+        chromatic: {
+            // Keep snapshots to confirm custom styles are working
+            disableSnapshot: false,
+        },
+    },
 };
 
 const styles = StyleSheet.create({

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -133,7 +133,7 @@ export const Kinds: StoryComponentType = {
  */
 export const Layouts: StoryComponentType = () => {
     const borderStyle = {
-        border: `2px solid ${semanticColor.core.border.inverse.strong}`,
+        border: `${border.width.medium} solid ${semanticColor.core.border.inverse.strong}`,
     } as const;
     const floatingContainerStyle = {padding: sizing.size_080} as const;
 

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -7,7 +7,12 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    color,
+    spacing,
+    semanticColor,
+    sizing,
+} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Banner from "@khanacademy/wonder-blocks-banner";
 
@@ -15,6 +20,7 @@ import BannerArgTypes from "./banner.argtypes";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-banner/package.json";
 import crownIcon from "../wonder-blocks-icon/icons/crown.svg";
+import {reallyLongText} from "../components/text-for-testing";
 
 type StoryComponentType = StoryObj<typeof Banner>;
 
@@ -641,6 +647,40 @@ export const RightToLeftMultiline: StoryComponentType = {
             disableSnapshot: false,
         },
     },
+};
+
+/**
+ * There are times where custom styles need to be applied to the Banner
+ * component, especially for layout purposes. Custom styles can be applied by
+ * using the `styles` prop. The following parts can be styled:
+ * - `root`: Styles the root element
+ *
+ * If there are other parts you need to customize, please reach out to the
+ * Wonder Blocks team!
+ */
+export const WithCustomStyles: StoryComponentType = {
+    render: () => (
+        <View style={{height: "500px", width: "300px", gap: sizing.size_160}}>
+            <Banner
+                text={reallyLongText}
+                layout="floating"
+                // styles={{root: {flexShrink: 0}}}
+            />
+            <View
+                style={{
+                    backgroundColor:
+                        semanticColor.core.background.neutral.subtle,
+                    flexGrow: 1,
+                    overflowY: "auto",
+                }}
+            >
+                <View style={{padding: sizing.size_160}}>
+                    {reallyLongText}
+                    {reallyLongText}
+                </View>
+            </View>
+        </View>
+    ),
 };
 
 const styles = StyleSheet.create({

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -6,7 +6,7 @@ import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import Banner from "@khanacademy/wonder-blocks-banner";
 

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import xIcon from "@phosphor-icons/core/bold/x-bold.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import {addStyle, View} from "@khanacademy/wonder-blocks-core";
+import {addStyle, StyleType, View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon, PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import Link from "@khanacademy/wonder-blocks-link";
@@ -129,6 +129,13 @@ type Props = {
      * - `string`: an import referencing an arbitrary SVG file.
      */
     icon?: PhosphorIconAsset | string;
+    /**
+     * Custom styles for the elements in the Banner component.
+     * - `root`: Styles the root element
+     */
+    styles?: {
+        root?: StyleType;
+    };
 };
 
 const getValuesForKind = (kind: BannerKind): BannerValues => {
@@ -224,6 +231,7 @@ const Banner = (props: Props): React.ReactElement => {
         text,
         testId,
         icon,
+        styles: stylesProp,
     } = props;
 
     const renderActions = () => {
@@ -276,7 +284,7 @@ const Banner = (props: Props): React.ReactElement => {
 
     return (
         <View
-            style={[styles.containerOuter, bannerKindStyle]}
+            style={[styles.containerOuter, bannerKindStyle, stylesProp?.root]}
             role={valuesForKind.role}
             aria-label={ariaLabel}
             aria-live={valuesForKind.ariaLive}

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import xIcon from "@phosphor-icons/core/bold/x-bold.svg";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import {addStyle, StyleType, View} from "@khanacademy/wonder-blocks-core";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon, PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import Link from "@khanacademy/wonder-blocks-link";
@@ -129,13 +129,6 @@ type Props = {
      * - `string`: an import referencing an arbitrary SVG file.
      */
     icon?: PhosphorIconAsset | string;
-    /**
-     * Custom styles for the elements in the Banner component.
-     * - `root`: Styles the root element
-     */
-    styles?: {
-        root?: StyleType;
-    };
 };
 
 const getValuesForKind = (kind: BannerKind): BannerValues => {
@@ -231,7 +224,6 @@ const Banner = (props: Props): React.ReactElement => {
         text,
         testId,
         icon,
-        styles: stylesProp,
     } = props;
 
     const renderActions = () => {
@@ -284,7 +276,7 @@ const Banner = (props: Props): React.ReactElement => {
 
     return (
         <View
-            style={[styles.containerOuter, bannerKindStyle, stylesProp?.root]}
+            style={[styles.containerOuter, bannerKindStyle]}
             role={valuesForKind.role}
             aria-label={ariaLabel}
             aria-live={valuesForKind.ariaLive}


### PR DESCRIPTION
## Summary:
- Allows the `root` element of the `Banner` component to be styled using a `styles` prop
- This supports the use case where consumers may need to apply layout properties to the banner so it works with existing layouts (for example, setting `flex-shrink: 0` on the banner so it doesn't shrink)
- Currently, we only support custom styling for the `root` element. This may change later on if we decide to support the customization of other elements in the component

- Stories:
  - stories clean up: remove use of color tokens, spacing tokens, and strut usage
  - set up story that needs to have custom styles supported

Issue: WB-1980

## Test plan:
- Confirm that the custom styles story renders as expected (banner does not shrink) (`/?path=/docs/packages-banner--docs#with-custom-styles`)
- Review prop docs and Custom Styles docs for Banner (`/?path=/docs/packages-banner--docs#with-custom-styles`)
- Note: I've pre-accepted the new story in Chromatic so that we can see what the visual difference is once we support the `styles` prop