### PR TITLE
Update styling of BodyText and Heading components to allow overrides

### DIFF
--- a/.changeset/chatty-bees-explain.md
+++ b/.changeset/chatty-bees-explain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-typography": patch
+---
+
+Update styling of BodyText and Heading components to allow overrides

--- a/__docs__/wonder-blocks-typography/body-text.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body-text.stories.tsx
@@ -15,7 +15,7 @@ import {
     LabelLarge,
     Body,
 } from "@khanacademy/wonder-blocks-typography";
-import {spacing, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {font, spacing, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {allModes} from "../../.storybook/modes";
 
 /**
@@ -233,6 +233,7 @@ const styles = StyleSheet.create({
     },
     customStyle: {
         fontSize: sizing.size_280,
+        fontWeight: font.weight.bold,
         lineHeight: sizing.size_320,
         marginTop: sizing.size_200,
     },

--- a/__docs__/wonder-blocks-typography/body-text.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body-text.stories.tsx
@@ -15,7 +15,7 @@ import {
     LabelLarge,
     Body,
 } from "@khanacademy/wonder-blocks-typography";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {allModes} from "../../.storybook/modes";
 
 /**
@@ -198,14 +198,6 @@ export const ClassicConversionGuide = {
  * An example of overriding `BodyText` component's styling.
  */
 export const CustomStyling = {
-    parameters: {
-        chromatic: {
-            modes: {
-                default: allModes.themeDefault,
-                thunderblocks: allModes.themeThunderBlocks,
-            },
-        },
-    },
     render: () => (
         <View>
             <BodyText>
@@ -240,7 +232,8 @@ const styles = StyleSheet.create({
         margin: 0,
     },
     customStyle: {
-        lineHeight: "3rem",
-        marginTop: "2rem",
+        fontSize: sizing.size_280,
+        lineHeight: sizing.size_320,
+        marginTop: sizing.size_200,
     },
 });

--- a/__docs__/wonder-blocks-typography/body-text.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body-text.stories.tsx
@@ -115,11 +115,11 @@ export const SizesAndWeights = {
     render: () => (
         <View style={styles.grid}>
             <View style={styles.row}>
-                <BodyText size="xsmall" weight="bold">
-                    xSmall bold
-                </BodyText>
                 <BodyText size="xsmall" weight="medium">
                     xSmall medium
+                </BodyText>
+                <BodyText size="xsmall" weight="bold">
+                    xSmall bold
                 </BodyText>
                 <div />
             </View>
@@ -161,25 +161,62 @@ export const ClassicConversionGuide = {
     render: () => (
         <View style={[styles.grid, styles.conversionGuide]}>
             <View style={styles.row}>
-                <LabelXSmall tag="p">LabelXSmall</LabelXSmall>
+                <LabelXSmall tag="p" style={styles.classic}>
+                    LabelXSmall
+                </LabelXSmall>
                 <BodyText size="xsmall">BodyText size=xsmall</BodyText>
             </View>
             <View style={styles.row}>
-                <LabelSmall tag="p">LabelSmall</LabelSmall>
+                <LabelSmall tag="p" style={styles.classic}>
+                    LabelSmall
+                </LabelSmall>
                 <BodyText size="small">BodyText size=small</BodyText>
             </View>
             <View style={styles.row}>
-                <LabelMedium tag="p">LabelMedium</LabelMedium>
+                <LabelMedium tag="p" style={styles.classic}>
+                    LabelMedium
+                </LabelMedium>
                 <BodyText>BodyText</BodyText>
             </View>
             <View style={styles.row}>
-                <LabelLarge tag="p">LabelLarge</LabelLarge>
+                <LabelLarge tag="p" style={styles.classic}>
+                    LabelLarge
+                </LabelLarge>
                 <BodyText weight="bold">BodyText weight=bold</BodyText>
             </View>
             <View style={styles.row}>
-                <Body tag="p">Body</Body>
+                <Body tag="p" style={styles.classic}>
+                    Body
+                </Body>
                 <BodyText>BodyText</BodyText>
             </View>
+        </View>
+    ),
+};
+
+/**
+ * An example of overriding `BodyText` component's styling.
+ */
+export const CustomStyling = {
+    parameters: {
+        chromatic: {
+            modes: {
+                default: allModes.themeDefault,
+                thunderblocks: allModes.themeThunderBlocks,
+            },
+        },
+    },
+    render: () => (
+        <View>
+            <BodyText>
+                Text to show the default styling based on props. If we add more
+                text here, it will run on multiple lines.
+            </BodyText>
+            <BodyText style={styles.customStyle}>
+                A lot of text that runs on multiple lines, with custom styling.
+                We really like ice cream. What flavor is your favorite? That’s
+                not ice cream, it’s sorbet!
+            </BodyText>
         </View>
     ),
 };
@@ -198,5 +235,12 @@ const styles = StyleSheet.create({
     },
     row: {
         display: "contents",
+    },
+    classic: {
+        margin: 0,
+    },
+    customStyle: {
+        lineHeight: "3rem",
+        marginTop: "2rem",
     },
 });

--- a/__docs__/wonder-blocks-typography/body-text.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body-text.stories.tsx
@@ -116,29 +116,29 @@ export const SizesAndWeights = {
         <View style={styles.grid}>
             <View style={styles.row}>
                 <BodyText size="xsmall" weight="medium">
-                    xSmall medium
+                    xSmall size, medium weight
                 </BodyText>
                 <BodyText size="xsmall" weight="bold">
-                    xSmall bold
+                    xSmall size, bold weight
                 </BodyText>
                 <div />
             </View>
             <View style={styles.row}>
                 <BodyText size="small" weight="semi">
-                    Small semibold
+                    Small size, semibold weight
                 </BodyText>
                 <div />
                 <div />
             </View>
             <View style={styles.row}>
                 <BodyText size="medium" weight="medium">
-                    Medium medium
+                    Medium size, medium weight
                 </BodyText>
                 <BodyText size="medium" weight="semi">
-                    Medium semibold
+                    Medium size, semibold weight
                 </BodyText>
                 <BodyText size="medium" weight="bold">
-                    Medium bold
+                    Medium size, bold weight
                 </BodyText>
             </View>
         </View>

--- a/__docs__/wonder-blocks-typography/heading.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading.stories.tsx
@@ -16,7 +16,7 @@ import {
     Tagline,
     Title,
 } from "@khanacademy/wonder-blocks-typography";
-import {spacing, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {font, spacing, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {allModes} from "../../.storybook/modes";
 
 /**
@@ -264,6 +264,7 @@ const styles = StyleSheet.create({
     },
     customStyle: {
         fontSize: sizing.size_320,
+        fontWeight: font.weight.semi,
         lineHeight: sizing.size_400,
         marginTop: sizing.size_200,
     },

--- a/__docs__/wonder-blocks-typography/heading.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading.stories.tsx
@@ -16,7 +16,7 @@ import {
     Tagline,
     Title,
 } from "@khanacademy/wonder-blocks-typography";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {spacing, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {allModes} from "../../.storybook/modes";
 
 /**
@@ -233,14 +233,6 @@ export const ClassicConversionGuide = {
  * An example of overriding `Heading` component's styling.
  */
 export const CustomStyling = {
-    parameters: {
-        chromatic: {
-            modes: {
-                default: allModes.themeDefault,
-                thunderblocks: allModes.themeThunderBlocks,
-            },
-        },
-    },
     render: () => (
         <View>
             <Heading>
@@ -271,7 +263,8 @@ const styles = StyleSheet.create({
         display: "contents",
     },
     customStyle: {
-        lineHeight: "4rem",
-        marginTop: "2rem",
+        fontSize: sizing.size_320,
+        lineHeight: sizing.size_400,
+        marginTop: sizing.size_200,
     },
 });

--- a/__docs__/wonder-blocks-typography/heading.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading.stories.tsx
@@ -129,54 +129,54 @@ export const SizesAndWeights = {
         <View style={styles.grid}>
             <View style={styles.row}>
                 <Heading size="small" weight="bold">
-                    Small bold
+                    Small size, bold weight
                 </Heading>
                 <Heading size="small" weight="semi">
-                    Small semibold
+                    Small size, semibold weight
                 </Heading>
                 <Heading size="small" weight="medium">
-                    Small medium
+                    Small size, medium weight
                 </Heading>
             </View>
             <View style={styles.row}>
                 <Heading size="medium" weight="bold">
-                    Medium bold
+                    Medium size, bold weight
                 </Heading>
                 <Heading size="medium" weight="semi">
-                    Medium semibold
+                    Medium size, semibold weight
                 </Heading>
                 <Heading size="medium" weight="medium">
-                    Medium medium
+                    Medium size, medium weight
                 </Heading>
             </View>
             <View style={styles.row}>
                 <Heading size="large" weight="bold">
-                    Large bold
+                    Large size, bold weight
                 </Heading>
                 <Heading size="large" weight="semi">
-                    Large semibold
+                    Large size, semibold weight
                 </Heading>
                 <Heading size="large" weight="medium">
-                    Large medium
+                    Large size, medium weight
                 </Heading>
             </View>
             <View style={styles.row}>
                 <Heading size="xlarge" weight="bold">
-                    xLarge bold
+                    xLarge size, bold weight
                 </Heading>
                 <Heading size="xlarge" weight="semi">
-                    xLarge semibold
+                    xLarge size, semibold weight
                 </Heading>
                 <Heading size="xlarge" weight="medium">
-                    xLarge medium
+                    xLarge size, medium weight
                 </Heading>
             </View>
             <View style={styles.row}>
                 <Heading size="xxlarge" weight="bold">
-                    xxLarge bold
+                    xxLarge size, bold weight
                 </Heading>
                 <Heading size="xxlarge" weight="semi">
-                    xxLarge semibold
+                    xxLarge size, semibold weight
                 </Heading>
                 <div />
             </View>

--- a/__docs__/wonder-blocks-typography/heading.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading.stories.tsx
@@ -134,6 +134,9 @@ export const SizesAndWeights = {
                 <Heading size="small" weight="semi">
                     Small semibold
                 </Heading>
+                <Heading size="small" weight="medium">
+                    Small medium
+                </Heading>
             </View>
             <View style={styles.row}>
                 <Heading size="medium" weight="bold">
@@ -141,6 +144,9 @@ export const SizesAndWeights = {
                 </Heading>
                 <Heading size="medium" weight="semi">
                     Medium semibold
+                </Heading>
+                <Heading size="medium" weight="medium">
+                    Medium medium
                 </Heading>
             </View>
             <View style={styles.row}>
@@ -150,6 +156,9 @@ export const SizesAndWeights = {
                 <Heading size="large" weight="semi">
                     Large semibold
                 </Heading>
+                <Heading size="large" weight="medium">
+                    Large medium
+                </Heading>
             </View>
             <View style={styles.row}>
                 <Heading size="xlarge" weight="bold">
@@ -158,11 +167,18 @@ export const SizesAndWeights = {
                 <Heading size="xlarge" weight="semi">
                     xLarge semibold
                 </Heading>
+                <Heading size="xlarge" weight="medium">
+                    xLarge medium
+                </Heading>
             </View>
             <View style={styles.row}>
                 <Heading size="xxlarge" weight="bold">
                     xxLarge bold
                 </Heading>
+                <Heading size="xxlarge" weight="semi">
+                    xxLarge semibold
+                </Heading>
+                <div />
             </View>
         </View>
     ),
@@ -213,10 +229,37 @@ export const ClassicConversionGuide = {
     ),
 };
 
+/**
+ * An example of overriding `Heading` component's styling.
+ */
+export const CustomStyling = {
+    parameters: {
+        chromatic: {
+            modes: {
+                default: allModes.themeDefault,
+                thunderblocks: allModes.themeThunderBlocks,
+            },
+        },
+    },
+    render: () => (
+        <View>
+            <Heading>
+                Text to show the default styling based on props. If we add more
+                text here, it will run on multiple lines.
+            </Heading>
+            <Heading style={styles.customStyle}>
+                A lot of text that runs on multiple lines, with custom styling.
+                We really like ice cream. What flavor is your favorite? That’s
+                not ice cream, it’s sorbet!
+            </Heading>
+        </View>
+    ),
+};
+
 const styles = StyleSheet.create({
     grid: {
         display: "grid",
-        gridTemplateColumns: "max-content max-content",
+        gridTemplateColumns: "max-content max-content max-content",
         rowGap: spacing.medium_16,
         columnGap: spacing.large_24,
     },
@@ -226,5 +269,9 @@ const styles = StyleSheet.create({
     },
     row: {
         display: "contents",
+    },
+    customStyle: {
+        lineHeight: "4rem",
+        marginTop: "2rem",
     },
 });

--- a/packages/wonder-blocks-typography/src/components/body-text.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-text.tsx
@@ -1,12 +1,24 @@
 import * as React from "react";
 import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
-import {font} from "@khanacademy/wonder-blocks-tokens";
 import styles from "../util/styles";
 
 type Props = PropsFor<typeof Text> & {
     size?: "xsmall" | "small" | "medium";
     weight?: "medium" | "semi" | "bold";
 };
+
+// List style combinations for matching with props
+const styleMapping = {
+    "xsmall-medium": styles.BodyTextXSmallMedium,
+    "xsmall-semi": styles.BodyTextXSmallSemi,
+    "xsmall-bold": styles.BodyTextXSmallBold,
+    "small-medium": styles.BodyTextSmallMedium,
+    "small-semi": styles.BodyTextSmallSemi,
+    "small-bold": styles.BodyTextSmallBold,
+    "medium-medium": styles.BodyTextMediumMedium,
+    "medium-semi": styles.BodyTextMediumSemi,
+    "medium-bold": styles.BodyTextMediumBold,
+} as const;
 
 const BodyText = React.forwardRef(function BodyText(
     {
@@ -20,11 +32,7 @@ const BodyText = React.forwardRef(function BodyText(
     ref,
 ) {
     // map props to theme and global token defaults for CSS styles
-    const themeBodyText = {
-        fontSize: font.body.size[size],
-        fontWeight: font.weight[weight],
-        lineHeight: font.body.lineHeight[size],
-    };
+    const themeBodyText = styleMapping[`${size}-${weight}`];
     return (
         <Text
             {...otherProps}

--- a/packages/wonder-blocks-typography/src/components/body-text.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-text.tsx
@@ -9,15 +9,15 @@ type Props = PropsFor<typeof Text> & {
 
 // List style combinations for matching with props
 const styleMapping = {
-    "xsmall-medium": styles.BodyTextXSmallMedium,
-    "xsmall-semi": styles.BodyTextXSmallSemi,
-    "xsmall-bold": styles.BodyTextXSmallBold,
-    "small-medium": styles.BodyTextSmallMedium,
-    "small-semi": styles.BodyTextSmallSemi,
-    "small-bold": styles.BodyTextSmallBold,
-    "medium-medium": styles.BodyTextMediumMedium,
-    "medium-semi": styles.BodyTextMediumSemi,
-    "medium-bold": styles.BodyTextMediumBold,
+    "xsmall-medium": styles.BodyTextXSmallMediumWeight,
+    "xsmall-semi": styles.BodyTextXSmallSemiWeight,
+    "xsmall-bold": styles.BodyTextXSmallBoldWeight,
+    "small-medium": styles.BodyTextSmallMediumWeight,
+    "small-semi": styles.BodyTextSmallSemiWeight,
+    "small-bold": styles.BodyTextSmallBoldWeight,
+    "medium-medium": styles.BodyTextMediumMediumWeight,
+    "medium-semi": styles.BodyTextMediumSemiWeight,
+    "medium-bold": styles.BodyTextMediumBoldWeight,
 } as const;
 
 const BodyText = React.forwardRef(function BodyText(

--- a/packages/wonder-blocks-typography/src/components/heading.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading.tsx
@@ -20,21 +20,21 @@ type Props = PropsFor<typeof Text> & {
 
 // List style combinations for matching with props
 const styleMapping = {
-    "small-medium": styles.HeadingSmallMedium,
-    "small-semi": styles.HeadingSmallSemi,
-    "small-bold": styles.HeadingSmallBold,
-    "medium-medium": styles.HeadingMediumMedium,
-    "medium-semi": styles.HeadingMediumSemi,
-    "medium-bold": styles.HeadingMediumBold,
-    "large-medium": styles.HeadingLargeMedium,
-    "large-semi": styles.HeadingLargeSemi,
-    "large-bold": styles.HeadingLargeBold,
-    "xlarge-medium": styles.HeadingXLargeMedium,
-    "xlarge-semi": styles.HeadingXLargeSemi,
-    "xlarge-bold": styles.HeadingXLargeBold,
-    "xxlarge-medium": styles.HeadingXxLargeMedium,
-    "xxlarge-semi": styles.HeadingXxLargeSemi,
-    "xxlarge-bold": styles.HeadingXxLargeBold,
+    "small-medium": styles.HeadingSmallMediumWeight,
+    "small-semi": styles.HeadingSmallSemiWeight,
+    "small-bold": styles.HeadingSmallBoldWeight,
+    "medium-medium": styles.HeadingMediumMediumWeight,
+    "medium-semi": styles.HeadingMediumSemiWeight,
+    "medium-bold": styles.HeadingMediumBoldWeight,
+    "large-medium": styles.HeadingLargeMediumWeight,
+    "large-semi": styles.HeadingLargeSemiWeight,
+    "large-bold": styles.HeadingLargeBoldWeight,
+    "xlarge-medium": styles.HeadingXLargeMediumWeight,
+    "xlarge-semi": styles.HeadingXLargeSemiWeight,
+    "xlarge-bold": styles.HeadingXLargeBoldWeight,
+    "xxlarge-medium": styles.HeadingXxLargeMediumWeight,
+    "xxlarge-semi": styles.HeadingXxLargeSemiWeight,
+    "xxlarge-bold": styles.HeadingXxLargeBoldWeight,
 } as const;
 
 const Heading = React.forwardRef(function Heading(props: Props, ref) {

--- a/packages/wonder-blocks-typography/src/components/heading.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
-import {font} from "@khanacademy/wonder-blocks-tokens";
 import styles from "../util/styles";
 
 const tagMap = {
@@ -19,6 +18,25 @@ type Props = PropsFor<typeof Text> & {
     weight?: "medium" | "semi" | "bold";
 };
 
+// List style combinations for matching with props
+const styleMapping = {
+    "small-medium": styles.HeadingSmallMedium,
+    "small-semi": styles.HeadingSmallSemi,
+    "small-bold": styles.HeadingSmallBold,
+    "medium-medium": styles.HeadingMediumMedium,
+    "medium-semi": styles.HeadingMediumSemi,
+    "medium-bold": styles.HeadingMediumBold,
+    "large-medium": styles.HeadingLargeMedium,
+    "large-semi": styles.HeadingLargeSemi,
+    "large-bold": styles.HeadingLargeBold,
+    "xlarge-medium": styles.HeadingXLargeMedium,
+    "xlarge-semi": styles.HeadingXLargeSemi,
+    "xlarge-bold": styles.HeadingXLargeBold,
+    "xxlarge-medium": styles.HeadingXxLargeMedium,
+    "xxlarge-semi": styles.HeadingXxLargeSemi,
+    "xxlarge-bold": styles.HeadingXxLargeBold,
+} as const;
+
 const Heading = React.forwardRef(function Heading(props: Props, ref) {
     const {size, weight = "bold", style, children, tag, ...otherProps} = props;
 
@@ -29,11 +47,7 @@ const Heading = React.forwardRef(function Heading(props: Props, ref) {
     const resolvedTag = tag ?? (size ? tagMap[size] : "h2");
 
     // map props to theme and global token defaults for CSS styles
-    const themeHeading = {
-        fontSize: font.heading.size[finalSize],
-        fontWeight: font.weight[weight],
-        lineHeight: font.heading.lineHeight[finalSize],
-    };
+    const themeHeading = styleMapping[`${finalSize}-${weight}`];
 
     return (
         <Text

--- a/packages/wonder-blocks-typography/src/util/styles.ts
+++ b/packages/wonder-blocks-typography/src/util/styles.ts
@@ -30,15 +30,130 @@ const styles: StyleDeclaration = StyleSheet.create({
     Heading: {
         ...common,
         fontFamily: font.family.sans,
-        // weight and size are determined by props
+        // weight and size are matched by props, using the combinations below
         // lineHeight is determined by fontSize on REM scale
+    },
+    HeadingSmallBold: {
+        fontSize: font.heading.size.small,
+        fontWeight: font.weight.bold,
+        lineHeight: font.heading.lineHeight.small,
+    },
+    HeadingSmallSemi: {
+        fontSize: font.heading.size.small,
+        fontWeight: font.weight.semi,
+        lineHeight: font.heading.lineHeight.small,
+    },
+    HeadingSmallMedium: {
+        fontSize: font.heading.size.small,
+        fontWeight: font.weight.medium,
+        lineHeight: font.heading.lineHeight.small,
+    },
+    HeadingMediumBold: {
+        fontSize: font.heading.size.medium,
+        fontWeight: font.weight.bold,
+        lineHeight: font.heading.lineHeight.medium,
+    },
+    HeadingMediumSemi: {
+        fontSize: font.heading.size.medium,
+        fontWeight: font.weight.semi,
+        lineHeight: font.heading.lineHeight.medium,
+    },
+    HeadingMediumMedium: {
+        fontSize: font.heading.size.medium,
+        fontWeight: font.weight.medium,
+        lineHeight: font.heading.lineHeight.medium,
+    },
+    HeadingLargeBold: {
+        fontSize: font.heading.size.large,
+        fontWeight: font.weight.bold,
+        lineHeight: font.heading.lineHeight.large,
+    },
+    HeadingLargeSemi: {
+        fontSize: font.heading.size.large,
+        fontWeight: font.weight.semi,
+        lineHeight: font.heading.lineHeight.small,
+    },
+    HeadingLargeMedium: {
+        fontSize: font.heading.size.large,
+        fontWeight: font.weight.medium,
+        lineHeight: font.heading.lineHeight.small,
+    },
+    HeadingXLargeBold: {
+        fontSize: font.heading.size.xlarge,
+        fontWeight: font.weight.bold,
+        lineHeight: font.heading.lineHeight.xlarge,
+    },
+    HeadingXLargeMedium: {
+        fontSize: font.heading.size.xlarge,
+        fontWeight: font.weight.medium,
+        lineHeight: font.heading.lineHeight.xlarge,
+    },
+    HeadingXLargeSemi: {
+        fontSize: font.heading.size.xlarge,
+        fontWeight: font.weight.semi,
+        lineHeight: font.heading.lineHeight.xlarge,
+    },
+    HeadingXxLargeSemi: {
+        fontSize: font.heading.size.xxlarge,
+        fontWeight: font.weight.semi,
+        lineHeight: font.heading.lineHeight.xxlarge,
+    },
+    HeadingXxLargeBold: {
+        fontSize: font.heading.size.xxlarge,
+        fontWeight: font.weight.bold,
+        lineHeight: font.heading.lineHeight.xxlarge,
     },
     BodyText: {
         ...common,
         fontFamily: font.family.sans,
         margin: 0,
-        // weight and size are determined by props
+        // weight and size are matched by props, using the combinations below
         // lineHeight is determined by fontSize on REM scale
+    },
+    BodyTextXSmallMedium: {
+        fontSize: font.body.size.xsmall,
+        fontWeight: font.weight.medium,
+        lineHeight: font.body.lineHeight.xsmall,
+    },
+    BodyTextXSmallSemi: {
+        fontSize: font.body.size.xsmall,
+        fontWeight: font.weight.semi,
+        lineHeight: font.body.lineHeight.xsmall,
+    },
+    BodyTextXSmallBold: {
+        fontSize: font.body.size.xsmall,
+        fontWeight: font.weight.bold,
+        lineHeight: font.body.lineHeight.xsmall,
+    },
+    BodyTextSmallMedium: {
+        fontSize: font.body.size.small,
+        fontWeight: font.weight.medium,
+        lineHeight: font.body.lineHeight.small,
+    },
+    BodyTextSmallSemi: {
+        fontSize: font.body.size.small,
+        fontWeight: font.weight.semi,
+        lineHeight: font.body.lineHeight.small,
+    },
+    BodyTextSmallBold: {
+        fontSize: font.body.size.small,
+        fontWeight: font.weight.bold,
+        lineHeight: font.body.lineHeight.small,
+    },
+    BodyTextMediumMedium: {
+        fontSize: font.body.size.medium,
+        fontWeight: font.weight.medium,
+        lineHeight: font.body.lineHeight.medium,
+    },
+    BodyTextMediumSemi: {
+        fontSize: font.body.size.medium,
+        fontWeight: font.weight.semi,
+        lineHeight: font.body.lineHeight.medium,
+    },
+    BodyTextMediumBold: {
+        fontSize: font.body.size.medium,
+        fontWeight: font.weight.bold,
+        lineHeight: font.body.lineHeight.medium,
     },
     HeadingLarge: {
         ...common,

--- a/packages/wonder-blocks-typography/src/util/styles.ts
+++ b/packages/wonder-blocks-typography/src/util/styles.ts
@@ -71,12 +71,12 @@ const styles: StyleDeclaration = StyleSheet.create({
     HeadingLargeSemiWeight: {
         fontSize: font.heading.size.large,
         fontWeight: font.weight.semi,
-        lineHeight: font.heading.lineHeight.small,
+        lineHeight: font.heading.lineHeight.large,
     },
     HeadingLargeMediumWeight: {
         fontSize: font.heading.size.large,
         fontWeight: font.weight.medium,
-        lineHeight: font.heading.lineHeight.small,
+        lineHeight: font.heading.lineHeight.large,
     },
     HeadingXLargeBoldWeight: {
         fontSize: font.heading.size.xlarge,

--- a/packages/wonder-blocks-typography/src/util/styles.ts
+++ b/packages/wonder-blocks-typography/src/util/styles.ts
@@ -33,72 +33,72 @@ const styles: StyleDeclaration = StyleSheet.create({
         // weight and size are matched by props, using the combinations below
         // lineHeight is determined by fontSize on REM scale
     },
-    HeadingSmallBold: {
+    HeadingSmallBoldWeight: {
         fontSize: font.heading.size.small,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.small,
     },
-    HeadingSmallSemi: {
+    HeadingSmallSemiWeight: {
         fontSize: font.heading.size.small,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.small,
     },
-    HeadingSmallMedium: {
+    HeadingSmallMediumWeight: {
         fontSize: font.heading.size.small,
         fontWeight: font.weight.medium,
         lineHeight: font.heading.lineHeight.small,
     },
-    HeadingMediumBold: {
+    HeadingMediumBoldWeight: {
         fontSize: font.heading.size.medium,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.medium,
     },
-    HeadingMediumSemi: {
+    HeadingMediumSemiWeight: {
         fontSize: font.heading.size.medium,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.medium,
     },
-    HeadingMediumMedium: {
+    HeadingMediumMediumWeight: {
         fontSize: font.heading.size.medium,
         fontWeight: font.weight.medium,
         lineHeight: font.heading.lineHeight.medium,
     },
-    HeadingLargeBold: {
+    HeadingLargeBoldWeight: {
         fontSize: font.heading.size.large,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.large,
     },
-    HeadingLargeSemi: {
+    HeadingLargeSemiWeight: {
         fontSize: font.heading.size.large,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.small,
     },
-    HeadingLargeMedium: {
+    HeadingLargeMediumWeight: {
         fontSize: font.heading.size.large,
         fontWeight: font.weight.medium,
         lineHeight: font.heading.lineHeight.small,
     },
-    HeadingXLargeBold: {
+    HeadingXLargeBoldWeight: {
         fontSize: font.heading.size.xlarge,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.xlarge,
     },
-    HeadingXLargeMedium: {
+    HeadingXLargeMediumWeight: {
         fontSize: font.heading.size.xlarge,
         fontWeight: font.weight.medium,
         lineHeight: font.heading.lineHeight.xlarge,
     },
-    HeadingXLargeSemi: {
+    HeadingXLargeSemiWeight: {
         fontSize: font.heading.size.xlarge,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.xlarge,
     },
-    HeadingXxLargeSemi: {
+    HeadingXxLargeSemiWeight: {
         fontSize: font.heading.size.xxlarge,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.xxlarge,
     },
-    HeadingXxLargeBold: {
+    HeadingXxLargeBoldWeight: {
         fontSize: font.heading.size.xxlarge,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.xxlarge,
@@ -110,47 +110,47 @@ const styles: StyleDeclaration = StyleSheet.create({
         // weight and size are matched by props, using the combinations below
         // lineHeight is determined by fontSize on REM scale
     },
-    BodyTextXSmallMedium: {
+    BodyTextXSmallMediumWeight: {
         fontSize: font.body.size.xsmall,
         fontWeight: font.weight.medium,
         lineHeight: font.body.lineHeight.xsmall,
     },
-    BodyTextXSmallSemi: {
+    BodyTextXSmallSemiWeight: {
         fontSize: font.body.size.xsmall,
         fontWeight: font.weight.semi,
         lineHeight: font.body.lineHeight.xsmall,
     },
-    BodyTextXSmallBold: {
+    BodyTextXSmallBoldWeight: {
         fontSize: font.body.size.xsmall,
         fontWeight: font.weight.bold,
         lineHeight: font.body.lineHeight.xsmall,
     },
-    BodyTextSmallMedium: {
+    BodyTextSmallMediumWeight: {
         fontSize: font.body.size.small,
         fontWeight: font.weight.medium,
         lineHeight: font.body.lineHeight.small,
     },
-    BodyTextSmallSemi: {
+    BodyTextSmallSemiWeight: {
         fontSize: font.body.size.small,
         fontWeight: font.weight.semi,
         lineHeight: font.body.lineHeight.small,
     },
-    BodyTextSmallBold: {
+    BodyTextSmallBoldWeight: {
         fontSize: font.body.size.small,
         fontWeight: font.weight.bold,
         lineHeight: font.body.lineHeight.small,
     },
-    BodyTextMediumMedium: {
+    BodyTextMediumMediumWeight: {
         fontSize: font.body.size.medium,
         fontWeight: font.weight.medium,
         lineHeight: font.body.lineHeight.medium,
     },
-    BodyTextMediumSemi: {
+    BodyTextMediumSemiWeight: {
         fontSize: font.body.size.medium,
         fontWeight: font.weight.semi,
         lineHeight: font.body.lineHeight.medium,
     },
-    BodyTextMediumBold: {
+    BodyTextMediumBoldWeight: {
         fontSize: font.body.size.medium,
         fontWeight: font.weight.bold,
         lineHeight: font.body.lineHeight.medium,


### PR DESCRIPTION
## Summary:
The BodyText and Heading components used dynamic styles to match the fontSize, fontWeight, and lineHeight via component props. But the way the styles were inlined meant they couldn't be overridden.

This PR puts all of the style combinations into a styles.ts file but still matches them via props. There are also stories showing the styles being overridden (specifically the lineHeight).

Issue: WB-1978

## Test plan:
1. Review stories for style combinations and custom styles
   - BodyText: /?path=/docs/packages-typography-bodytext-new--docs&globals=theme:thunderblocks
   - Heading: /?path=/docs/packages-typography-heading-new--docs&globals=theme:thunderblocks