### PR TITLE
[WB-1868.2] Dropdown: Theming set up

### DIFF
--- a/.changeset/dull-ghosts-invite.md
+++ b/.changeset/dull-ghosts-invite.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Replaces deprecated typography components with BodyText and Heading. Switches from `spacing` tokens to `sizing`. Removes wb-layout dependency in favor of `gap`.

--- a/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {ActionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
@@ -28,7 +28,7 @@ const defaultArgs = {
 const styles = StyleSheet.create({
     example: {
         background: semanticColor.surface.secondary,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
         width: 300,
     },
     items: {

--- a/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
@@ -10,7 +10,7 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import actionItemArgtypes from "./action-item.argtypes";
-import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 const defaultArgs = {
     label: "Action Item",
@@ -146,8 +146,8 @@ export const CustomActionItemMultiLine = {
     args: {
         label: (
             <View>
-                <LabelLarge>Title</LabelLarge>
-                <LabelMedium>Subtitle</LabelMedium>
+                <BodyText weight="bold">Title</BodyText>
+                <BodyText>Subtitle</BodyText>
             </View>
         ),
         onClick: () => {},

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -10,12 +10,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Pill from "@khanacademy/wonder-blocks-pill";
-import {
-    border,
-    semanticColor,
-    sizing,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {
     ActionItem,
@@ -33,6 +28,7 @@ import type {Item} from "../../packages/wonder-blocks-dropdown/src/util/types";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
 import Button from "@khanacademy/wonder-blocks-button";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 
 const actionItems: Array<Item> = [
     <ActionItem
@@ -131,7 +127,7 @@ export default {
 const styles = StyleSheet.create({
     example: {
         background: semanticColor.surface.secondary,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
     },
     exampleExtended: {
         height: 300,
@@ -156,12 +152,9 @@ const styles = StyleSheet.create({
         borderRadius: border.radius.radius_040,
         background: semanticColor.status.warning.background,
         color: semanticColor.text.primary,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
     },
-    focused: {
-        outlineColor: semanticColor.focus.outer,
-        outlineOffset: spacing.xxxxSmall_2,
-    },
+    focused: focusStyles.focus[":focus-visible"],
     hovered: {
         textDecoration: "underline",
         cursor: "pointer",

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -11,7 +11,7 @@ import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {
     ActionItem,
     ActionMenu,
@@ -368,7 +368,8 @@ export const CustomOpener: StoryComponentType = {
     name: "With custom opener",
     args: {
         opener: ({focused, hovered, pressed, text}: any) => (
-            <LabelLarge
+            <BodyText
+                weight="bold"
                 onClick={() => {
                     console.log("custom click!!!!!");
                 }}
@@ -382,7 +383,7 @@ export const CustomOpener: StoryComponentType = {
                 role="button"
             >
                 {text}
-            </LabelLarge>
+            </BodyText>
         ),
     } as Partial<typeof ActionMenu>,
 };
@@ -470,7 +471,7 @@ export const CustomActionItems: StoryComponentType = {
             />,
             <ActionItem
                 key="4"
-                label={<LabelLarge>User profile</LabelLarge>}
+                label={<BodyText weight="bold">User profile</BodyText>}
                 horizontalRule="full-width"
                 leftAccessory={
                     <PhosphorIcon icon={IconMappings.info} size="medium" />

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import magnifyingGlassIcon from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 
 import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -50,7 +50,7 @@ const customItems = allProfilesWithPictures.map((user, index) => (
 const styles = StyleSheet.create({
     example: {
         background: semanticColor.surface.secondary,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
         width: 300,
     },
     wrapper: {
@@ -202,7 +202,7 @@ export const ControlledCombobox: Story = {
         }, [args.opened]);
 
         return (
-            <View style={{gap: spacing.medium_16}}>
+            <View style={{gap: sizing.size_160}}>
                 <Checkbox label="Open" onChange={setOpened} checked={opened} />
                 <Combobox
                     {...args}
@@ -449,7 +449,7 @@ export const StartIcon: Story = {
         const [_, updateArgs] = useArgs();
 
         return (
-            <View style={{gap: spacing.medium_16}}>
+            <View style={{gap: sizing.size_160}}>
                 <LabelMedium>With default size and color:</LabelMedium>
                 <Combobox
                     {...args}

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -6,7 +6,7 @@ import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import magnifyingGlassIcon from "@phosphor-icons/core/bold/magnifying-glass-bold.svg";
 
-import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
@@ -38,7 +38,7 @@ const customItems = allProfilesWithPictures.map((user, index) => (
         key={user.id}
         value={user.id}
         horizontalRule="full-width"
-        label={<LabelLarge>{user.name}</LabelLarge>}
+        label={<BodyText weight="bold">{user.name}</BodyText>}
         // TODO(WB-1752): Refactor API and types to enforce this prop when
         // `label` is not a string.
         labelAsText={user.name}
@@ -450,7 +450,7 @@ export const StartIcon: Story = {
 
         return (
             <View style={{gap: sizing.size_160}}>
-                <LabelMedium>With default size and color:</LabelMedium>
+                <BodyText>With default size and color:</BodyText>
                 <Combobox
                     {...args}
                     startIcon={<PhosphorIcon icon={magnifyingGlassIcon} />}
@@ -459,7 +459,7 @@ export const StartIcon: Story = {
                         action("onChange")(newValue);
                     }}
                 />
-                <LabelMedium>With custom size:</LabelMedium>
+                <BodyText>With custom size:</BodyText>
                 <Combobox
                     {...args}
                     startIcon={
@@ -473,7 +473,7 @@ export const StartIcon: Story = {
                         action("onChange")(newValue);
                     }}
                 />
-                <LabelMedium>With custom color:</LabelMedium>
+                <BodyText>With custom color:</BodyText>
                 <Combobox
                     {...args}
                     startIcon={
@@ -488,7 +488,7 @@ export const StartIcon: Story = {
                         action("onChange")(newValue);
                     }}
                 />
-                <LabelMedium>Disabled (overrides color prop):</LabelMedium>
+                <BodyText>Disabled (overrides color prop):</BodyText>
                 <Combobox
                     {...args}
                     startIcon={

--- a/__docs__/wonder-blocks-dropdown/listbox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/listbox.stories.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {Listbox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import Pill from "@khanacademy/wonder-blocks-pill";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import {allProfilesWithPictures} from "./option-item-examples";
 
@@ -28,7 +28,7 @@ const items = [
 const styles = StyleSheet.create({
     example: {
         background: semanticColor.surface.secondary,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
         width: 360,
     },
     customListbox: {

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -7,11 +7,7 @@ import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
-import {
-    border,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import Pill from "@khanacademy/wonder-blocks-pill";
@@ -29,6 +25,7 @@ import {
 } from "./option-item-examples";
 import {OpenerProps} from "../../packages/wonder-blocks-dropdown/src/util/types";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 
 type StoryComponentType = StoryObj<typeof MultiSelect>;
 
@@ -110,8 +107,8 @@ const styles = StyleSheet.create({
         overflow: "auto",
         border: "1px solid grey",
         borderRadius: border.radius.radius_040,
-        margin: spacing.xSmall_8,
-        padding: spacing.medium_16,
+        margin: sizing.size_080,
+        padding: sizing.size_160,
     },
     scrollableArea: {
         height: "200vh",
@@ -124,12 +121,9 @@ const styles = StyleSheet.create({
         borderRadius: border.radius.radius_040,
         background: semanticColor.status.warning.background,
         color: semanticColor.text.primary,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
     },
-    focused: {
-        outlineColor: semanticColor.focus.outer,
-        outlineOffset: spacing.xxxxSmall_2,
-    },
+    focused: focusStyles.focus[":focus-visible"],
     hovered: {
         textDecoration: "underline",
         cursor: "pointer",
@@ -432,7 +426,7 @@ export const Required: StoryComponentType = {
 export const ErrorFromValidation: StoryComponentType = {
     render: (args: PropsFor<typeof MultiSelect>) => {
         return (
-            <View style={{gap: spacing.large_24}}>
+            <View style={{gap: sizing.size_240}}>
                 <ControlledMultiSelect
                     {...args}
                     label="Validation example (try picking jupiter)"
@@ -548,7 +542,7 @@ export const DropdownInModal: StoryComponentType = {
  */
 export const Disabled: StoryComponentType = {
     render: () => (
-        <View style={{gap: spacing.xLarge_32}}>
+        <View style={{gap: sizing.size_320}}>
             <LabeledField
                 label="Disabled prop is set to true"
                 field={

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -8,7 +8,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
+import {Heading} from "@khanacademy/wonder-blocks-typography";
 import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import type {LabelsValues} from "@khanacademy/wonder-blocks-dropdown";
@@ -669,7 +669,8 @@ export const CustomOpener: StoryComponentType = {
             );
 
             return (
-                <HeadingLarge
+                <Heading
+                    size="xlarge"
                     onClick={() => {
                         // eslint-disable-next-line no-console
                         console.log("custom click!!!!!");
@@ -683,7 +684,7 @@ export const CustomOpener: StoryComponentType = {
                 >
                     {text}
                     {opened ? ": opened" : ""}
-                </HeadingLarge>
+                </Heading>
             );
         },
     } as MultiSelectArgs,

--- a/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-dropdown/package.json";
@@ -24,7 +24,7 @@ const defaultArgs = {
 const styles = StyleSheet.create({
     example: {
         background: semanticColor.surface.secondary,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
         width: 300,
     },
     items: {

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -13,7 +13,7 @@ import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import Pill from "@khanacademy/wonder-blocks-pill";
-import {Body, HeadingLarge} from "@khanacademy/wonder-blocks-typography";
+import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 import {
     SingleSelect,
     OptionItem,
@@ -720,13 +720,13 @@ export const DropdownInModal: StoryComponentType = {
         const modalContent = (
             <View style={styles.scrollableArea}>
                 <View style={{gap: sizing.size_240}}>
-                    <Body>
+                    <BodyText>
                         Sometimes we want to include Dropdowns inside a Modal,
                         and these controls can be accessed only by scrolling
                         down. This example help us to demonstrate that
                         SingleSelect components can correctly be displayed
                         within the visible scrolling area.
-                    </Body>
+                    </BodyText>
                     <SingleSelect
                         onChange={(selected) => setValue(selected)}
                         isFilterable={true}
@@ -790,7 +790,8 @@ export const CustomOpener: StoryComponentType = {
             );
 
             return (
-                <HeadingLarge
+                <Heading
+                    size="xlarge"
                     onClick={() => {
                         // eslint-disable-next-line no-console
                         console.log("custom click!!!!!");
@@ -805,7 +806,7 @@ export const CustomOpener: StoryComponentType = {
                 >
                     {text}
                     {opened ? ": opened" : ""}
-                </HeadingLarge>
+                </Heading>
             );
         },
     } as SingleSelectArgs,

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -7,15 +7,10 @@ import {action} from "@storybook/addon-actions";
 import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
-import {
-    border,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {OnePaneDialog, ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import {Body, HeadingLarge} from "@khanacademy/wonder-blocks-typography";
@@ -131,11 +126,11 @@ const styles = StyleSheet.create({
         borderRadius: border.radius.radius_040,
         background: semanticColor.status.warning.background,
         color: semanticColor.text.primary,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
     },
     focused: {
         outlineColor: semanticColor.focus.outer,
-        outlineOffset: spacing.xxxxSmall_2,
+        outlineOffset: sizing.size_020,
     },
     hovered: {
         textDecoration: "underline",
@@ -163,7 +158,7 @@ const styles = StyleSheet.create({
     // AutoFocus
     icon: {
         position: "absolute",
-        right: spacing.medium_16,
+        right: sizing.size_160,
     },
 });
 
@@ -392,7 +387,7 @@ export const LongOptionLabels: StoryComponentType = {
  */
 export const Disabled: StoryComponentType = {
     render: () => (
-        <View style={{gap: spacing.xLarge_32}}>
+        <View style={{gap: sizing.size_320}}>
             <LabeledField
                 label="Disabled prop is set to true"
                 field={
@@ -540,7 +535,7 @@ export const Required: StoryComponentType = {
 export const ErrorFromValidation: StoryComponentType = {
     render: (args: PropsFor<typeof SingleSelect>) => {
         return (
-            <View style={{gap: spacing.large_24}}>
+            <View style={{gap: sizing.size_240}}>
                 <ControlledSingleSelect
                     {...args}
                     label="Validation example (try picking lemon to trigger an error)"
@@ -724,7 +719,7 @@ export const DropdownInModal: StoryComponentType = {
 
         const modalContent = (
             <View style={styles.scrollableArea}>
-                <View>
+                <View style={{gap: sizing.size_240}}>
                     <Body>
                         Sometimes we want to include Dropdowns inside a Modal,
                         and these controls can be accessed only by scrolling
@@ -732,7 +727,6 @@ export const DropdownInModal: StoryComponentType = {
                         SingleSelect components can correctly be displayed
                         within the visible scrolling area.
                     </Body>
-                    <Strut size={spacing.large_24} />
                     <SingleSelect
                         onChange={(selected) => setValue(selected)}
                         isFilterable={true}

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -22,7 +22,6 @@
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",
     "@khanacademy/wonder-blocks-icon-button": "workspace:*",
-    "@khanacademy/wonder-blocks-layout": "workspace:*",
     "@khanacademy/wonder-blocks-modal": "workspace:*",
     "@khanacademy/wonder-blocks-pill": "workspace:*",
     "@khanacademy/wonder-blocks-search-field": "workspace:*",

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/action-item.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/action-item.test.tsx
@@ -3,7 +3,7 @@ import {render, screen} from "@testing-library/react";
 import * as ReactRouterDOM from "react-router-dom";
 import * as ReactRouterDOMV5Compat from "react-router-dom-v5-compat";
 
-import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import {Heading} from "@khanacademy/wonder-blocks-typography";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import plusIcon from "@phosphor-icons/core/regular/plus.svg";
@@ -88,11 +88,7 @@ describe("ActionItem", () => {
         // Arrange
 
         // Act
-        render(
-            <ActionItem
-                label={<HeadingSmall>A heading as an item</HeadingSmall>}
-            />,
-        );
+        render(<ActionItem label={<Heading>A heading as an item</Heading>} />);
 
         // Assert
         expect(screen.getByRole("heading")).toBeInTheDocument();

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/option-item.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/option-item.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {render, screen} from "@testing-library/react";
 
-import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import {Heading} from "@khanacademy/wonder-blocks-typography";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 
 import plusIcon from "@phosphor-icons/core/regular/plus.svg";
@@ -44,7 +44,7 @@ describe("OptionItem", () => {
         render(
             <OptionItem
                 value="1"
-                label={<HeadingSmall>A heading as an item</HeadingSmall>}
+                label={<Heading>A heading as an item</Heading>}
             />,
         );
 

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -2,12 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {CompactCell} from "@khanacademy/wonder-blocks-cell";
-import {
-    border,
-    semanticColor,
-    sizing,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import type {PropsFor, StyleType} from "@khanacademy/wonder-blocks-core";
@@ -218,6 +213,6 @@ const styles = StyleSheet.create({
 
     indent: {
         // Cell's internal padding + checkbox width + checkbox margin
-        paddingLeft: spacing.medium_16 * 2,
+        paddingInlineStart: sizing.size_320,
     },
 });

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {CompactCell} from "@khanacademy/wonder-blocks-cell";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import type {PropsFor, StyleType} from "@khanacademy/wonder-blocks-core";
 
@@ -150,9 +150,9 @@ export default class ActionItem extends React.Component<ActionProps> {
 
         const labelComponent =
             typeof label === "string" ? (
-                <LabelMedium lang={lang} style={styles.label}>
+                <BodyText lang={lang} style={styles.label}>
                     {label}
-                </LabelMedium>
+                </BodyText>
             ) : (
                 React.cloneElement(label, {
                     lang,

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
@@ -64,7 +64,9 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
         ];
 
         const label = (
-            <LabelLarge style={sharedStyles.text}>{children}</LabelLarge>
+            <BodyText weight="bold" style={sharedStyles.text}>
+                {children}
+            </BodyText>
         );
 
         return (
@@ -154,7 +156,6 @@ const sharedStyles = StyleSheet.create({
         textAlign: "left",
         display: "inline-block",
         alignItems: "center",
-        fontWeight: "bold",
         userSelect: "none",
         whiteSpace: "nowrap",
         overflow: "hidden",

--- a/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu-opener-core.tsx
@@ -4,12 +4,7 @@ import {StyleSheet} from "aphrodite";
 import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {
-    border,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import type {ClickableState} from "@khanacademy/wonder-blocks-clickable";
 import caretDownIcon from "@phosphor-icons/core/bold/caret-down-bold.svg";
@@ -90,7 +85,6 @@ export default class ActionMenuOpenerCore extends React.Component<Props> {
                 >
                     {label}
                 </View>
-                <Strut size={spacing.xxxSmall_4} />
                 <PhosphorIcon
                     size="small"
                     color="currentColor"
@@ -147,13 +141,14 @@ const sharedStyles = StyleSheet.create({
     default: {
         background: theme.actionMenuOpener.color.default.background,
         color: theme.actionMenuOpener.color.default.foreground,
+        gap: sizing.size_040,
     },
     disabled: {
         color: theme.actionMenuOpener.color.disabled.foreground,
         cursor: "not-allowed",
     },
     small: {
-        height: spacing.xLarge_32,
+        height: sizing.size_320,
     },
     text: {
         textAlign: "left",

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
@@ -6,6 +6,7 @@ import {
     type AriaProps,
     type StyleType,
 } from "@khanacademy/wonder-blocks-core";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import DropdownOpener from "./dropdown-opener";
 import ActionItem from "./action-item";
 import OptionItem from "./option-item";
@@ -329,7 +330,7 @@ export default class ActionMenu extends React.Component<Props, State> {
 
 const styles = StyleSheet.create({
     caret: {
-        marginLeft: 4,
+        marginInlineStart: sizing.size_040,
     },
     // The design calls for additional offset around the opener.
     opener: {
@@ -340,6 +341,6 @@ const styles = StyleSheet.create({
     },
     // This is to adjust the space between the menu and the opener.
     menuTopSpace: {
-        top: -4,
+        top: `calc(-1 * ${sizing.size_040})`,
     },
 });

--- a/packages/wonder-blocks-dropdown/src/components/check.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/check.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 
 /**
@@ -36,10 +36,10 @@ export default Check;
 const styles = StyleSheet.create({
     bounds: {
         alignSelf: "center",
-        height: spacing.medium_16,
+        height: sizing.size_160,
         // Semantically, this are the constants for a small-sized icon
-        minHeight: spacing.medium_16,
-        minWidth: spacing.medium_16,
+        minHeight: sizing.size_160,
+        minWidth: sizing.size_160,
     },
 
     hide: {

--- a/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
@@ -3,11 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {
-    border,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 
 /**
@@ -45,11 +41,11 @@ const Checkbox = function (props: CheckProps): React.ReactElement {
                         {
                             // The check icon is smaller than the checkbox, as
                             // per design.
-                            width: spacing.small_12,
-                            height: spacing.small_12,
+                            width: sizing.size_120,
+                            height: sizing.size_120,
                             // This margin is to center the check icon in the
                             // checkbox.
-                            margin: spacing.xxxxSmall_2,
+                            margin: sizing.size_020,
                         },
                         disabled && selected && styles.disabledCheckFormatting,
                     ]}
@@ -82,9 +78,9 @@ const styles = StyleSheet.create({
     checkbox: {
         alignSelf: "center",
         // Semantically, this are the constants for a small-sized icon
-        minHeight: spacing.medium_16,
-        minWidth: spacing.medium_16,
-        height: spacing.medium_16,
+        minHeight: sizing.size_160,
+        minWidth: sizing.size_160,
+        height: sizing.size_160,
         background: theme.checkbox.color.default.background,
         // TODO(WB-1864): Use the correct token once TB is updated.
         borderRadius: 3,

--- a/packages/wonder-blocks-dropdown/src/components/combobox-multiple-selection.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox-multiple-selection.tsx
@@ -3,9 +3,10 @@ import * as React from "react";
 
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import Pill from "@khanacademy/wonder-blocks-pill";
-import {font, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {font, sizing} from "@khanacademy/wonder-blocks-tokens";
 import xIcon from "@phosphor-icons/core/regular/x.svg";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 
 type Props = {
     /**
@@ -98,11 +99,9 @@ const styles = StyleSheet.create({
         fontSize: font.body.size.small,
         justifyContent: "space-between",
         alignItems: "center",
-        marginBlockStart: spacing.xxxSmall_4,
-        marginInlineEnd: spacing.xxxSmall_4,
-        paddingInlineEnd: spacing.xxxSmall_4,
+        marginBlockStart: sizing.size_040,
+        marginInlineEnd: sizing.size_040,
+        paddingInlineEnd: sizing.size_040,
     },
-    pillFocused: {
-        outline: `1px solid ${semanticColor.focus.outer}`,
-    },
+    pillFocused: focusStyles.focus[":focus-visible"],
 });

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -11,7 +11,7 @@ import {
     border,
     color,
     semanticColor,
-    spacing,
+    sizing,
 } from "@khanacademy/wonder-blocks-tokens";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
@@ -732,7 +732,7 @@ const styles = StyleSheet.create({
         background: theme.combobox.color.default.background,
         borderRadius: border.radius.radius_040,
         border: `solid 1px ${theme.combobox.color.default.border}`,
-        paddingInline: spacing.xSmall_8,
+        paddingInline: sizing.size_080,
     },
     focused: {
         background: theme.combobox.color.focus.background,
@@ -758,7 +758,7 @@ const styles = StyleSheet.create({
         border: "none",
         outline: "none",
         padding: 0,
-        minWidth: spacing.xxxSmall_4,
+        minWidth: sizing.size_040,
         width: "auto",
         display: "inline-grid",
         gridArea: "1 / 2",
@@ -775,7 +775,7 @@ const styles = StyleSheet.create({
         borderRadius: border.radius.radius_040,
         border: `solid ${border.width.thin} ${theme.listbox.color.default.border}`,
         // TODO(WB-1878): Move to elevation tokens.
-        boxShadow: `0px ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0px ${color.offBlack8}`,
+        boxShadow: `0px ${sizing.size_080} ${sizing.size_080} 0 ${color.offBlack8}`,
         // We use a custom property to set the max height of the dropdown.
         // This comes from the maxHeight custom modifier.
         // @see ../util/popper-max-height-modifier.ts
@@ -791,8 +791,8 @@ const styles = StyleSheet.create({
      */
     button: {
         position: "absolute",
-        right: spacing.xxxSmall_4,
-        top: spacing.xxxSmall_4,
+        right: sizing.size_040,
+        top: sizing.size_040,
         margin: 0,
     },
     buttonOpen: {
@@ -804,10 +804,10 @@ const styles = StyleSheet.create({
     clearButton: {
         // The clear button is positioned to the left of the arrow button.
         // This is calculated based on the padding + width of the arrow button.
-        right: spacing.xLarge_32 + spacing.xSmall_8,
+        right: sizing.size_400,
     },
     iconWrapper: {
-        padding: spacing.xxxSmall_4,
+        padding: sizing.size_040,
         // View has a default minWidth of 0, which causes the label text
         // to encroach on the icon when it needs to truncate. We can fix
         // this by setting the minWidth to auto.

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -16,7 +16,7 @@ import {
 
 import {PropsFor, View, keys} from "@khanacademy/wonder-blocks-core";
 import SearchField from "@khanacademy/wonder-blocks-search-field";
-import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
@@ -817,12 +817,12 @@ class DropdownCore extends React.Component<Props, State> {
 
         if (numResults === 0) {
             return (
-                <LabelMedium
+                <BodyText
                     style={styles.noResult}
                     testId="dropdown-core-no-results"
                 >
                     {noResults}
-                </LabelMedium>
+                </BodyText>
             );
         }
         return null;

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -9,9 +9,9 @@ import {VariableSizeList as List} from "react-window";
 
 import {
     color,
-    spacing,
     semanticColor,
     border,
+    sizing,
 } from "@khanacademy/wonder-blocks-tokens";
 
 import {PropsFor, View, keys} from "@khanacademy/wonder-blocks-core";
@@ -1096,11 +1096,10 @@ const styles = StyleSheet.create({
     dropdown: {
         backgroundColor: theme.dropdown.color.default.background,
         borderRadius: border.radius.radius_040,
-        paddingTop: spacing.xxxSmall_4,
-        paddingBottom: spacing.xxxSmall_4,
-        border: `solid 1px ${theme.dropdown.color.default.border}`,
+        paddingBlock: sizing.size_040,
+        border: `solid ${border.width.thin} ${theme.dropdown.color.default.border}`,
         // TODO(WB-1878): Move to elevation tokens.
-        boxShadow: `0px 8px 8px 0px ${color.offBlack8}`,
+        boxShadow: `0px ${sizing.size_080} ${sizing.size_080} 0 ${color.offBlack8}`,
         // We use a custom property to set the max height of the dropdown.
         // This comes from the maxHeight custom modifier.
         // @see ../util/popper-max-height-modifier.ts
@@ -1119,12 +1118,12 @@ const styles = StyleSheet.create({
     noResult: {
         color: theme.noResults.color.foreground,
         alignSelf: "center",
-        marginTop: spacing.xxSmall_6,
+        marginBlockStart: sizing.size_060,
     },
 
     searchInputStyle: {
-        margin: spacing.xSmall_8,
-        marginTop: spacing.xxxSmall_4,
+        margin: sizing.size_080,
+        marginBlockStart: sizing.size_040,
         // Set `minHeight` to "auto" to stop the search field from having
         // a height of 0 and being cut off.
         minHeight: "auto",

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
 import {semanticColor, border, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {AriaProps, StyleType, View} from "@khanacademy/wonder-blocks-core";
 
@@ -247,7 +247,7 @@ export default class OptionItem extends React.Component<OptionProps> {
                 }
                 rightAccessory={rightAccessory}
                 subtitle1={subtitle1}
-                title={<LabelMedium style={styles.label}>{label}</LabelMedium>}
+                title={<BodyText style={styles.label}>{label}</BodyText>}
                 subtitle2={subtitle2}
                 onClick={this.handleClick}
                 tabIndex={parentComponent === "listbox" ? -1 : undefined}

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -2,17 +2,11 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
-import {
-    spacing,
-    semanticColor,
-    border,
-    sizing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, border, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
 
 import {AriaProps, StyleType, View} from "@khanacademy/wonder-blocks-core";
 
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import Check from "./check";
 import Checkbox from "./checkbox";
@@ -231,12 +225,16 @@ export default class OptionItem extends React.Component<OptionProps> {
                 leftAccessory={
                     <>
                         {leftAccessory ? (
-                            <View style={{flexDirection: "row"}}>
+                            <View
+                                style={{
+                                    flexDirection: "row",
+                                    gap: sizing.size_080,
+                                }}
+                            >
                                 <CheckComponent
                                     disabled={disabled}
                                     selected={selected}
                                 />
-                                <Strut size={spacing.xSmall_8} />
                                 {leftAccessory}
                             </View>
                         ) : (

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -6,11 +6,7 @@ import {keys, type AriaProps} from "@khanacademy/wonder-blocks-core";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import {
-    border,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import caretDownIcon from "@phosphor-icons/core/bold/caret-down-bold.svg";
 import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
 import {OptionLabel} from "../util/types";
@@ -210,8 +206,8 @@ const styles = StyleSheet.create({
         // This asymmetry arises from the Icon on the right side, which has
         // extra padding built in. To have the component look more balanced,
         // we need to take off some paddingRight here.
-        paddingLeft: spacing.medium_16,
-        paddingRight: spacing.small_12,
+        paddingInlineStart: sizing.size_160,
+        paddingInlineEnd: sizing.size_120,
         borderWidth: 0,
         borderRadius: border.radius.radius_040,
         borderStyle: "solid",
@@ -225,7 +221,7 @@ const styles = StyleSheet.create({
     },
 
     text: {
-        marginRight: spacing.xSmall_8,
+        marginInlineEnd: sizing.size_080,
         whiteSpace: "nowrap",
         userSelect: "none",
         overflow: "hidden",
@@ -299,8 +295,8 @@ const _generateStyles = (placeholder: boolean, error: boolean) => {
                 ":hover:not([aria-disabled=true])": {
                     borderColor: currentState.border,
                     borderWidth: border.width.thin,
-                    paddingLeft: spacing.medium_16,
-                    paddingRight: spacing.small_12,
+                    paddingInlineStart: sizing.size_160,
+                    paddingInlineEnd: sizing.size_120,
                 },
             },
             ":focus-visible:not([aria-disabled=true])": focusStyling,

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -5,7 +5,7 @@ import {keys, type AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import caretDownIcon from "@phosphor-icons/core/bold/caret-down-bold.svg";
 import {DROPDOWN_ITEM_HEIGHT} from "../util/constants";
@@ -175,13 +175,13 @@ export default class SelectOpener extends React.Component<
                 onKeyUp={!disabled ? this.handleKeyUp : undefined}
                 onBlur={onBlur}
             >
-                <LabelMedium style={styles.text}>
+                <BodyText style={styles.text}>
                     {/* Note(tamarab): Prevents unwanted vertical
                                 shift for empty selection.
                         Note2(marcysutton): aria-hidden prevents "space"
                                 from being read in VoiceOver. */}
                     {children || <span aria-hidden="true">&nbsp;</span>}
-                </LabelMedium>
+                </BodyText>
                 <PhosphorIcon
                     icon={caretDownIcon}
                     color={iconColor}

--- a/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
@@ -4,7 +4,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {View} from "@khanacademy/wonder-blocks-core";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
@@ -49,10 +49,9 @@ const theme = {
 
 const styles = StyleSheet.create({
     separator: {
-        borderTop: `1px solid ${theme.separator.color.border}`,
+        borderTop: `${border.width.thin} solid ${theme.separator.color.border}`,
         height: 1,
         minHeight: 1,
-        marginTop: spacing.xxxSmall_4,
-        marginBottom: spacing.xxxSmall_4,
+        marginBlock: sizing.size_040,
     },
 });

--- a/packages/wonder-blocks-dropdown/src/util/constants.ts
+++ b/packages/wonder-blocks-dropdown/src/util/constants.ts
@@ -1,9 +1,8 @@
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {ComboboxLabels} from "./types";
 
 export const selectDropdownStyle = {
-    marginTop: spacing.xSmall_8,
-    marginBottom: spacing.xSmall_8,
+    marginBlock: sizing.size_080,
 } as const;
 
 // Filterable dropdown has minimum dimensions requested from Design.

--- a/packages/wonder-blocks-dropdown/tsconfig-build.json
+++ b/packages/wonder-blocks-dropdown/tsconfig-build.json
@@ -11,7 +11,6 @@
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
-        {"path": "../wonder-blocks-layout/tsconfig-build.json"},
         {"path": "../wonder-blocks-modal/tsconfig-build.json"},
         {"path": "../wonder-blocks-pill/tsconfig-build.json"},
         {"path": "../wonder-blocks-search-field/tsconfig-build.json"},


### PR DESCRIPTION
## Summary:

Prep work to set up ThunderBlocks theming for all the dropdown components.

- Replaces deprecated typography components with `BodyText` and `Heading`.
- Switches from `spacing` tokens to `sizing`.
- Removes wb-layout dependency (`Strut`) in favor of CSS's `gap`.

Issue: WB-1868

## Test plan:

- Navigate to the Dropdown docs and verify that the stories look correct.
- Ensure that all the dropdown snapshots look correct.