### PR TITLE
[WB-1867.2] Remove `light` prop from Modal package.

### DIFF
--- a/.changeset/large-avocados-thank.md
+++ b/.changeset/large-avocados-thank.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": major
+---
+
+Removes `light` prop from Modal package.

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -253,66 +253,6 @@ export const WithLauncher: StoryComponentType = {
     },
 };
 
-/**
- * This example shows how a modal dialog/panel can be created with a dark
- * background. The `light` prop of the `<ModalPanel>` element is set to `false`
- * to create a dark background.
- */
-export const WithDarkPanel: StoryComponentType = {
-    render: (args) => (
-        <View style={styles.previewSizer}>
-            <View style={styles.modalPositioner}>
-                <ModalDialog
-                    {...args}
-                    aria-labelledby="modal-title-0"
-                    aria-describedby="modal-desc-0"
-                >
-                    <ModalPanel
-                        content={
-                            <>
-                                <img
-                                    width="100%"
-                                    src="https://cdn.kastatic.org/images/lohp/laptop_collage@2x.png"
-                                    alt=""
-                                />
-                                <View
-                                    style={{
-                                        marginTop: spacing.medium_16,
-                                    }}
-                                >
-                                    <Title id="modal-title-0">
-                                        Modal Title
-                                    </Title>
-                                    <Strut size={spacing.large_24} />
-                                    <Body id="modal-desc-0">
-                                        Here is some text in the modal.
-                                    </Body>
-                                </View>
-                            </>
-                        }
-                        light={false}
-                        footer={
-                            <Button
-                                kind="secondary"
-                                style={[actionStyles.inverse]}
-                                onClick={() => {}}
-                            >
-                                Continue
-                            </Button>
-                        }
-                    />
-                </ModalDialog>
-            </View>
-        </View>
-    ),
-    args: {
-        style: {
-            maxWidth: 300,
-            maxHeight: 500,
-        },
-    },
-};
-
 const styles = StyleSheet.create({
     example: {
         alignItems: "center",

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -16,7 +16,6 @@ import {
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 import modalDialogArgtypes from "./modal-dialog.argtypes";
-import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -83,11 +82,8 @@ export default {
             defaultViewport: "desktop",
         },
         chromatic: {
-            modes: {
-                small: allModes.small,
-                large: allModes.large,
-                thunderblocks: allModes.themeThunderBlocks,
-            },
+            // We already have screenshots in one-pane-dialog.stories.tsx
+            disableSnapshot: true,
         },
     },
     // Make the following props null in the control panel

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -86,6 +86,7 @@ export default {
             modes: {
                 small: allModes.small,
                 large: allModes.large,
+                thunderblocks: allModes.themeThunderBlocks,
             },
         },
     },

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -17,7 +17,6 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 import modalDialogArgtypes from "./modal-dialog.argtypes";
 import {allModes} from "../../.storybook/modes";
-import {actionStyles} from "@khanacademy/wonder-blocks-styles";
 
 const customViewports = {
     phone: {

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -138,8 +138,8 @@ export default {
         },
         chromatic: {
             modes: {
-                small: allModes.small,
-                large: allModes.large,
+                default: allModes.themeDefault,
+                thunderblocks: allModes.themeThunderBlocks,
             },
         },
     },

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -16,7 +16,6 @@ import {
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
 import ComponentInfo from "../components/component-info";
-import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -137,10 +136,9 @@ export default {
             defaultViewport: "desktop",
         },
         chromatic: {
-            modes: {
-                default: allModes.themeDefault,
-                thunderblocks: allModes.themeThunderBlocks,
-            },
+            // We already have screenshots of other stories in
+            // one-pane-dialog.stories.tsx
+            disableSnapshot: true,
         },
     },
     argTypes: {

--- a/__docs__/wonder-blocks-modal/modal-header.argtypes.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.argtypes.tsx
@@ -28,18 +28,6 @@ export default {
         description: "The main title rendered in larger bold text.",
         table: {type: {summary: "string"}},
     },
-    light: {
-        control: {type: "boolean"},
-        defaultValue: "true",
-
-        description: `Whether to display the "light" version of this
-            component instead, for use when the item is used on a dark
-            background.`,
-        table: {
-            defaultValue: {summary: "true"},
-            type: {summary: "boolean"},
-        },
-    },
     titleId: {
         control: {type: "text"},
         description: `An id to provide a selector for the title element.

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -166,6 +166,7 @@ export default {
             modes: {
                 small: allModes.small,
                 large: allModes.large,
+                thunderblocks: allModes.themeThunderBlocks,
             },
         },
     },

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -19,7 +19,6 @@ import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
 import ComponentInfo from "../components/component-info";
 import ModalHeaderArgtypes from "./modal-header.argtypes";
-import {allModes} from "../../.storybook/modes";
 
 const customViewports = {
     phone: {
@@ -162,11 +161,11 @@ export default {
             viewports: customViewports,
             defaultViewport: "desktop",
         },
-        chromatic: {
-            modes: {
-                small: allModes.small,
-                large: allModes.large,
-                thunderblocks: allModes.themeThunderBlocks,
+        parameters: {
+            chromatic: {
+                // We already have screenshots of other stories in
+                // one-pane-dialog.stories.tsx
+                disableSnapshot: true,
             },
         },
     },

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -118,8 +118,6 @@ est.`}
  * - Add a title (required).
  * - Optionally add a subtitle or breadcrumbs.
  * - We encourage you to add `titleId` (see Accessibility notes).
- * - If the `ModalPanel` has a dark background, make sure to set `light` to
- *   `false`.
  * - If you need to create e2e tests, make sure to pass a `testId` prop and
  *   add a sufix to scope the testId to this component: e.g.
  *   `some-random-id-ModalHeader`. This scope will also be passed to the title
@@ -132,7 +130,6 @@ est.`}
  *      title="This is a modal title."
  *      subtitle="subtitle"
  *      titleId="uniqueTitleId"
- *      light={false}
  *  />
  * ```
  */
@@ -194,30 +191,6 @@ export const Default: StoryComponentType = {
 };
 
 /**
- * This is `<ModalHeader>` when `light` is set to false. This should only be
- * false if the `light` prop on the encompassing `<ModalPanel>` is also false .
- * Note that the close button is not visible on the header if the panel is
- * light.
- */
-export const Dark: StoryComponentType = {
-    render: () => (
-        <ModalDialog aria-labelledby="modal-title-2" style={styles.dialog}>
-            <ModalPanel
-                header={
-                    <ModalHeader
-                        title="Modal Title"
-                        titleId="modal-title-2"
-                        light={false}
-                    />
-                }
-                content={longBody}
-                light={false}
-            />
-        </ModalDialog>
-    ),
-};
-
-/**
  * This is `<ModalHeader>` with a subtitle, which can be done by passing a
  * string into the `subtitle` prop.
  */
@@ -239,32 +212,8 @@ export const WithSubtitle: StoryComponentType = {
 };
 
 /**
- * This is `<ModalHeader>` with a subtitle when it also has `light` set to
- * false.
- */
-export const WithSubtitleDark: StoryComponentType = {
-    render: () => (
-        <ModalDialog aria-labelledby="modal-title-4" style={styles.dialog}>
-            <ModalPanel
-                header={
-                    <ModalHeader
-                        title="Modal Title"
-                        titleId="modal-title-4"
-                        subtitle="This is what a subtitle looks like."
-                        light={false}
-                    />
-                }
-                content={longBody}
-                light={false}
-            />
-        </ModalDialog>
-    ),
-};
-
-/**
  * This is `<ModalHeader>` with breadcrumbs, which can be done by passing a
- * Wonder Blocks `<Breadcrumbs>` element into the `breadcrumbs` prop. Note that
- * `breadcrumbs` currently do not work when `light` is false.
+ * Wonder Blocks `<Breadcrumbs>` element into the `breadcrumbs` prop.
  */
 export const WithBreadcrumbs: StoryComponentType = {
     render: () => (

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -161,12 +161,10 @@ export default {
             viewports: customViewports,
             defaultViewport: "desktop",
         },
-        parameters: {
-            chromatic: {
-                // We already have screenshots of other stories in
-                // one-pane-dialog.stories.tsx
-                disableSnapshot: true,
-            },
+        chromatic: {
+            // We already have screenshots of other stories in
+            // one-pane-dialog.stories.tsx
+            disableSnapshot: true,
         },
     },
     argTypes: ModalHeaderArgtypes,

--- a/__docs__/wonder-blocks-modal/modal-panel.argtypes.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.argtypes.tsx
@@ -41,16 +41,6 @@ const argTypes: ArgTypes = {
             type: {summary: "boolean"},
         },
     },
-    light: {
-        control: {type: "boolean"},
-        description: `Whether to display the "light" version of this component
-            instead, for  use when the item is used on a dark background.`,
-        table: {
-            category: "Styling",
-            defaultValue: {summary: "true"},
-            type: {summary: "boolean"},
-        },
-    },
     scrollOverflow: {
         control: {type: "boolean"},
         description: `Should the contents of the panel become scrollable should

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -22,7 +22,6 @@ import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 import ComponentInfo from "../components/component-info";
 import modalPanelArgtypes from "./modal-panel.argtypes";
 import {allModes} from "../../.storybook/modes";
-import {actionStyles} from "@khanacademy/wonder-blocks-styles";
 
 const customViewports = {
     phone: {
@@ -183,26 +182,6 @@ export const Default: StoryComponentType = {
 };
 
 /**
- * This is what a modal panel looks like when its `light` prop is set to false.
- */
-export const Dark: StoryComponentType = {
-    render: () => (
-        <ModalDialog aria-labelledby="modal-title-a" style={styles.dialog}>
-            <ModalPanel
-                content={
-                    <>
-                        <Title id="modal-title-a">Modal Title</Title>
-                        <Strut size={spacing.large_24} />
-                        {longBody}
-                    </>
-                }
-                light={false}
-            />
-        </ModalDialog>
-    ),
-};
-
-/**
  * This is a `<ModalPanel>` with a `header` prop. Note that the header that
  * renders here as part of the `header` prop is sticky, so it remains even if
  * you scroll down in the modal.
@@ -240,32 +219,6 @@ export const WithFooter: StoryComponentType = {
                         <Button onClick={() => {}}>Continue</Button>
                     </ModalFooter>
                 }
-            />
-        </ModalDialog>
-    ),
-};
-
-/**
- * Here is a dark `<ModalPanel>` with a header and a footer. The `<Button>` in
- * the footer must have the `light` prop set to true in order to be visible on
- * the dark background.
- */
-export const DarkWithHeaderAndFooter: StoryComponentType = {
-    render: () => (
-        <ModalDialog aria-labelledby="modal-title-3" style={styles.dialog}>
-            <ModalPanel
-                header={
-                    <ModalHeader titleId="modal-title-2" title="Modal Title" />
-                }
-                content={longBody}
-                footer={
-                    <ModalFooter>
-                        <Button onClick={() => {}} style={actionStyles.inverse}>
-                            Continue
-                        </Button>
-                    </ModalFooter>
-                }
-                light={false}
             />
         </ModalDialog>
     ),
@@ -328,7 +281,6 @@ export const TwoPanels: StoryComponentType = {
                                 </Body>
                             </View>
                         }
-                        light={false}
                         closeButtonVisible={false}
                     />
                     <ModalPanel

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -180,6 +180,12 @@ export const Default: StoryComponentType = {
             />
         </ModalDialog>
     ),
+    parameters: {
+        chromatic: {
+            // We already have screenshots in one-pane-dialog.stories.tsx
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**
@@ -198,6 +204,12 @@ export const WithHeader: StoryComponentType = {
             />
         </ModalDialog>
     ),
+    parameters: {
+        chromatic: {
+            // We already have screenshots in one-pane-dialog.stories.tsx
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**
@@ -223,6 +235,12 @@ export const WithFooter: StoryComponentType = {
             />
         </ModalDialog>
     ),
+    parameters: {
+        chromatic: {
+            // We already have screenshots in one-pane-dialog.stories.tsx
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -152,6 +152,7 @@ export default {
             modes: {
                 small: allModes.small,
                 large: allModes.large,
+                thunderblocks: allModes.themeThunderBlocks,
             },
         },
     },

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -79,6 +79,7 @@ export default {
             modes: {
                 small: allModes.small,
                 large: allModes.large,
+                thunderblocks: allModes.themeThunderBlocks,
             },
         },
     },

--- a/packages/wonder-blocks-modal/src/components/modal-header.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-header.tsx
@@ -11,11 +11,6 @@ type Common = {
      */
     title: string;
     /**
-     * Whether to display the "light" version of this component instead, for
-     * use when the item is used on a dark background.
-     */
-    light: boolean;
-    /**
      * An id to provide a selector for the title element.
      */
     titleId: string;
@@ -75,8 +70,6 @@ type Props = Common | WithSubtitle | WithBreadcrumbs;
  * - Add a title (required).
  * - Optionally add a subtitle or breadcrumbs.
  * - We encourage you to add `titleId` (see Accessibility notes).
- * - If the `ModalPanel` has a dark background, make sure to set `light` to
- *   `false`.
  * - If you need to create e2e tests, make sure to pass a `testId` prop and
  *   add a sufix to scope the testId to this component: e.g.
  *   `some-random-id-ModalHeader`. This scope will also be passed to the title
@@ -89,7 +82,6 @@ type Props = Common | WithSubtitle | WithBreadcrumbs;
  *      title="Sidebar using ModalHeader"
  *      subtitle="subtitle"
  *      titleId="uniqueTitleId"
- *      light={false}
  *  />
  * ```
  */
@@ -97,7 +89,6 @@ export default function ModalHeader(props: Props) {
     const {
         // @ts-expect-error [FEI-5019] - TS2339 - Property 'breadcrumbs' does not exist on type 'Readonly<Props> & Readonly<{ children?: ReactNode; }>'.
         breadcrumbs = undefined,
-        light,
         // @ts-expect-error [FEI-5019] - TS2339 - Property 'subtitle' does not exist on type 'Readonly<Props> & Readonly<{ children?: ReactNode; }>'.
         subtitle = undefined,
         testId,
@@ -110,7 +101,7 @@ export default function ModalHeader(props: Props) {
     }
 
     return (
-        <View style={[styles.header, !light && styles.dark]} testId={testId}>
+        <View style={[styles.header]} testId={testId}>
             {breadcrumbs && (
                 <View style={styles.breadcrumbs}>{breadcrumbs}</View>
             )}
@@ -124,7 +115,7 @@ export default function ModalHeader(props: Props) {
             </HeadingMedium>
             {subtitle && (
                 <LabelSmall
-                    style={light && styles.subtitle}
+                    style={styles.subtitle}
                     testId={testId && `${testId}-subtitle`}
                 >
                     {subtitle}
@@ -158,11 +149,6 @@ const styles = StyleSheet.create({
         },
     },
 
-    dark: {
-        background: theme.root.color.inverse.background,
-        color: theme.root.color.inverse.foreground,
-    },
-
     breadcrumbs: {
         color: theme.header.color.secondary,
         marginBottom: theme.header.spacing.gap,
@@ -181,7 +167,3 @@ const styles = StyleSheet.create({
         marginTop: theme.header.spacing.gap,
     },
 });
-
-ModalHeader.defaultProps = {
-    light: true,
-};

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-import {actionStyles, focusStyles} from "@khanacademy/wonder-blocks-styles";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import {StyleSheet} from "aphrodite";
 import ModalContent from "./modal-content";
 import ModalHeader from "./modal-header";
@@ -35,11 +35,6 @@ type Props = {
      * become too tall?
      */
     scrollOverflow: boolean;
-    /**
-     * Whether to display the "light" version of this component instead, for
-     * use when the item is used on a dark background.
-     */
-    light: boolean;
     /**
      * Any optional styling to apply to the panel.
      */
@@ -84,7 +79,6 @@ type Props = {
 export default function ModalPanel({
     closeButtonVisible = true,
     scrollOverflow = true,
-    light = true,
     content,
     footer,
     header,
@@ -116,20 +110,15 @@ export default function ModalPanel({
 
     const mainContent = renderMainContent();
 
-    const isInverse = !light;
-
     return (
         <View
-            style={[styles.wrapper, isInverse && styles.dark, style]}
+            style={[styles.wrapper, style]}
             testId={testId && `${testId}-panel`}
         >
             {closeButtonVisible && (
                 <CloseButton
                     onClick={onClose}
-                    style={[
-                        styles.closeButton,
-                        isInverse && actionStyles.inverse,
-                    ]}
+                    style={[styles.closeButton]}
                     testId={testId && `${testId}-close`}
                 />
             )}
@@ -147,7 +136,6 @@ export default function ModalPanel({
 ModalPanel.defaultProps = {
     closeButtonVisible: true,
     scrollOverflow: true,
-    light: true,
 };
 
 const styles = StyleSheet.create({
@@ -175,11 +163,6 @@ const styles = StyleSheet.create({
         // programmatic focus. This is a workaround to make sure the focus
         // outline is visible when this control is focused.
         ":focus": focusStyles.focus[":focus-visible"],
-    },
-
-    dark: {
-        background: theme.root.color.inverse.background,
-        color: theme.root.color.inverse.foreground,
     },
 
     hasFooter: {

--- a/packages/wonder-blocks-modal/src/theme/default.ts
+++ b/packages/wonder-blocks-modal/src/theme/default.ts
@@ -5,13 +5,6 @@ const theme = {
      * Shared tokens
      */
     root: {
-        // TODO(WB-1852): Remove light variant.
-        color: {
-            inverse: {
-                background: semanticColor.surface.inverse,
-                foreground: semanticColor.text.inverse,
-            },
-        },
         border: {
             radius: border.radius.radius_040,
         },


### PR DESCRIPTION
## Summary:

Removes the `light` prop from modal as it is no longer needed.

### Implementation plan

1. #2676
2. #2677
3. #2678

Issue: https://khanacademy.atlassian.net/browse/WB-1867

## Test plan:

Navigate to the Modal stories in Storybook and ensure that the modals render
correctly.

Verify that the "Dark" stories are no longer present in the docs.