### PR TITLE
[WB-1867.3] Add ThunderBlocks theme to modal

### DIFF
--- a/.changeset/forty-zebras-yell.md
+++ b/.changeset/forty-zebras-yell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": minor
+---
+
+Adds ThunderBlocks theme to modal package. Updates typography to use BodyText and Heading. Removes Strut uses.

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -3,9 +3,8 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import {
     ModalLauncher,
@@ -125,15 +124,14 @@ export const Default: StoryComponentType = {
                 >
                     <ModalPanel
                         content={
-                            <>
+                            <View style={{gap: sizing.size_240}}>
                                 <Heading size="xxlarge" id="modal-title-0">
                                     Modal Title
                                 </Heading>
-                                <Strut size={spacing.large_24} />
                                 <BodyText id="modal-desc-0">
                                     Here is some text in the modal.
                                 </BodyText>
-                            </>
+                            </View>
                         }
                     />
                 </ModalDialog>
@@ -190,15 +188,14 @@ export const WithAboveAndBelow: StoryComponentType = {
                     >
                         <ModalPanel
                             content={
-                                <>
+                                <View style={{gap: sizing.size_240}}>
                                     <Heading size="xxlarge" id="modal-title-2">
                                         Modal Title
                                     </Heading>
-                                    <Strut size={spacing.large_24} />
                                     <BodyText>
                                         Here is some text in the modal.
                                     </BodyText>
-                                </>
+                                </View>
                             }
                         />
                     </ModalDialog>
@@ -228,13 +225,12 @@ export const WithLauncher: StoryComponentType = {
             >
                 <ModalPanel
                     content={
-                        <>
+                        <View style={{gap: sizing.size_240}}>
                             <Heading size="xxlarge" id="modal-title-3">
                                 Modal Title
                             </Heading>
-                            <Strut size={spacing.large_24} />
                             <BodyText>Here is some text in the modal.</BodyText>
-                        </>
+                        </View>
                     }
                 />
             </ModalDialog>

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {Body, Title} from "@khanacademy/wonder-blocks-typography";
+import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import {
@@ -126,11 +126,13 @@ export const Default: StoryComponentType = {
                     <ModalPanel
                         content={
                             <>
-                                <Title id="modal-title-0">Modal Title</Title>
+                                <Heading size="xxlarge" id="modal-title-0">
+                                    Modal Title
+                                </Heading>
                                 <Strut size={spacing.large_24} />
-                                <Body id="modal-desc-0">
+                                <BodyText id="modal-desc-0">
                                     Here is some text in the modal.
-                                </Body>
+                                </BodyText>
                             </>
                         }
                     />
@@ -189,11 +191,13 @@ export const WithAboveAndBelow: StoryComponentType = {
                         <ModalPanel
                             content={
                                 <>
-                                    <Title id="modal-title-2">
+                                    <Heading size="xxlarge" id="modal-title-2">
                                         Modal Title
-                                    </Title>
+                                    </Heading>
                                     <Strut size={spacing.large_24} />
-                                    <Body>Here is some text in the modal.</Body>
+                                    <BodyText>
+                                        Here is some text in the modal.
+                                    </BodyText>
                                 </>
                             }
                         />
@@ -225,9 +229,11 @@ export const WithLauncher: StoryComponentType = {
                 <ModalPanel
                     content={
                         <>
-                            <Title id="modal-title-3">Modal Title</Title>
+                            <Heading size="xxlarge" id="modal-title-3">
+                                Modal Title
+                            </Heading>
                             <Strut size={spacing.large_24} />
-                            <Body>Here is some text in the modal.</Body>
+                            <BodyText>Here is some text in the modal.</BodyText>
                         </>
                     }
                 />

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -4,8 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -164,13 +163,12 @@ export const Default: StoryComponentType = {
         <ModalDialog aria-labelledby={"modal-id-0"} style={styles.dialog}>
             <ModalPanel
                 content={
-                    <>
+                    <View style={{gap: sizing.size_240}}>
                         <Heading size="xxlarge" id="modal-id-0">
                             Modal Heading
                         </Heading>
-                        <Strut size={spacing.large_24} />
                         {longBody}
-                    </>
+                    </View>
                 }
                 footer={<ModalFooter {...args} />}
             />
@@ -187,13 +185,12 @@ export const WithButton: StoryComponentType = {
         <ModalDialog aria-labelledby={"modal-id-2"} style={styles.dialog}>
             <ModalPanel
                 content={
-                    <>
+                    <View style={{gap: sizing.size_240}}>
                         <Heading size="xxlarge" id="modal-id-2">
                             Modal Heading
                         </Heading>
-                        <Strut size={spacing.large_24} />
                         {longBody}
-                    </>
+                    </View>
                 }
                 footer={
                     <ModalFooter>
@@ -216,10 +213,10 @@ export const WithThreeActions: StoryComponentType = {
 
         const buttonStyle = {
             [desktop]: {
-                marginRight: spacing.medium_16,
+                marginInlineEnd: sizing.size_160,
             },
             [mobile]: {
-                marginBottom: spacing.medium_16,
+                marginBlockEnd: sizing.size_160,
             },
         } as const;
 
@@ -238,13 +235,12 @@ export const WithThreeActions: StoryComponentType = {
             <ModalDialog aria-labelledby={"modal-id-3"} style={styles.dialog}>
                 <ModalPanel
                     content={
-                        <>
+                        <View style={{gap: sizing.size_240}}>
                             <Heading size="xxlarge" id="modal-id-3">
                                 Modal Heading
                             </Heading>
-                            <Strut size={spacing.large_24} />
                             {longBody}
-                        </>
+                        </View>
                     }
                     footer={
                         <ModalFooter>
@@ -282,19 +278,19 @@ export const WithMultipleActions: StoryComponentType = {
         const rowStyle = {
             flexDirection: "row",
             justifyContent: "flex-end",
+            gap: sizing.size_160,
         } as const;
 
         return (
             <ModalDialog aria-labelledby={"modal-id-4"} style={styles.dialog}>
                 <ModalPanel
                     content={
-                        <>
+                        <View style={{gap: sizing.size_240}}>
                             <Heading size="xxlarge" id="modal-id-4">
                                 Modal Heading
                             </Heading>
-                            <Strut size={spacing.large_24} />
-                            {longBody}
-                        </>
+                            <BodyText>Here is some text in the modal.</BodyText>
+                        </View>
                     }
                     footer={
                         <ModalFooter>
@@ -302,7 +298,6 @@ export const WithMultipleActions: StoryComponentType = {
                                 <BodyText weight="bold">Step 1 of 4</BodyText>
                                 <View style={rowStyle}>
                                     <Button kind="tertiary">Previous</Button>
-                                    <Strut size={16} />
                                     <Button kind="primary">Next</Button>
                                 </View>
                             </View>

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -6,7 +6,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import {Body, LabelLarge, Title} from "@khanacademy/wonder-blocks-typography";
+import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import {
     ModalDialog,
@@ -44,12 +44,12 @@ const customViewports = {
 
 const longBody = (
     <>
-        <Body>
+        <BodyText>
             {`Let's make this body content long in order
 to test scroll overflow.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -60,9 +60,9 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -73,9 +73,9 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -86,7 +86,7 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
     </>
 );
 
@@ -165,7 +165,9 @@ export const Default: StoryComponentType = {
             <ModalPanel
                 content={
                     <>
-                        <Title id="modal-id-0">Modal Title</Title>
+                        <Heading size="xxlarge" id="modal-id-0">
+                            Modal Heading
+                        </Heading>
                         <Strut size={spacing.large_24} />
                         {longBody}
                     </>
@@ -186,7 +188,9 @@ export const WithButton: StoryComponentType = {
             <ModalPanel
                 content={
                     <>
-                        <Title id="modal-id-2">Modal Title</Title>
+                        <Heading size="xxlarge" id="modal-id-2">
+                            Modal Heading
+                        </Heading>
                         <Strut size={spacing.large_24} />
                         {longBody}
                     </>
@@ -235,7 +239,9 @@ export const WithThreeActions: StoryComponentType = {
                 <ModalPanel
                     content={
                         <>
-                            <Title id="modal-id-3">Modal Title</Title>
+                            <Heading size="xxlarge" id="modal-id-3">
+                                Modal Heading
+                            </Heading>
                             <Strut size={spacing.large_24} />
                             {longBody}
                         </>
@@ -283,7 +289,9 @@ export const WithMultipleActions: StoryComponentType = {
                 <ModalPanel
                     content={
                         <>
-                            <Title id="modal-id-4">Modal Title</Title>
+                            <Heading size="xxlarge" id="modal-id-4">
+                                Modal Heading
+                            </Heading>
                             <Strut size={spacing.large_24} />
                             {longBody}
                         </>
@@ -291,7 +299,7 @@ export const WithMultipleActions: StoryComponentType = {
                     footer={
                         <ModalFooter>
                             <View style={footerStyle}>
-                                <LabelLarge>Step 1 of 4</LabelLarge>
+                                <BodyText weight="bold">Step 1 of 4</BodyText>
                                 <View style={rowStyle}>
                                     <Button kind="tertiary">Previous</Button>
                                     <Strut size={16} />

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "@khanacademy/wonder-blocks-breadcrumbs";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
-import {Body} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {
     ModalDialog,
@@ -47,12 +47,12 @@ const customViewports = {
 
 const longBody = (
     <>
-        <Body>
+        <BodyText>
             {`Let's make this body content long in order
 to test scroll overflow.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -63,9 +63,9 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -76,9 +76,9 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -89,7 +89,7 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
     </>
 );
 

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -10,8 +10,7 @@ import {
     RadioGroup,
     Choice,
 } from "@khanacademy/wonder-blocks-form";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -370,29 +369,27 @@ export const WithInitialFocusId: StoryComponentType = () => {
         <OnePaneDialog
             title="Single-line title"
             content={
-                <>
+                <View style={{gap: sizing.size_240}}>
                     <LabeledTextField
                         label="Label"
                         value={value}
                         onChange={setValue}
                     />
-                    <Strut size={spacing.large_24} />
                     <LabeledTextField
                         label="Label 2"
                         value={value2}
                         onChange={setValue2}
                         id="text-field-to-be-focused"
                     />
-                </>
+                </View>
             }
             footer={
-                <>
+                <View style={styles.row}>
                     <Button kind="tertiary" onClick={closeModal}>
                         Cancel
                     </Button>
-                    <Strut size={spacing.medium_16} />
                     <Button onClick={closeModal}>Submit</Button>
-                </>
+                </View>
             }
         />
     );
@@ -437,7 +434,7 @@ const SubModal = () => (
     <OnePaneDialog
         title="Submodal"
         content={
-            <View style={{gap: spacing.medium_16}}>
+            <View style={{gap: sizing.size_160}}>
                 <BodyText>
                     This modal demonstrates how the focus trap works when a
                     modal is opened from another modal.
@@ -463,14 +460,13 @@ export const FocusTrap: StoryComponentType = () => {
             title="Testing the focus trap on multiple modals"
             closeButtonVisible={false}
             content={
-                <>
+                <View style={{gap: sizing.size_240}}>
                     <BodyText id="focus-trap-story-body-text">
                         This modal demonstrates how the focus trap works with
                         form elements (or focusable elements). Also demonstrates
                         how the focus trap is moved to the next modal when it is
                         opened (focus/tap on the `Open another modal` button).
                     </BodyText>
-                    <Strut size={spacing.large_24} />
                     <RadioGroup
                         label="A RadioGroup component inside a modal"
                         description="Some description"
@@ -481,10 +477,10 @@ export const FocusTrap: StoryComponentType = () => {
                         <Choice label="Choice 1" value="some-choice-value" />
                         <Choice label="Choice 2" value="some-choice-value-2" />
                     </RadioGroup>
-                </>
+                </View>
             }
             footer={
-                <>
+                <View style={styles.row}>
                     <ModalLauncher modal={SubModal}>
                         {({openModal}) => (
                             <Button kind="secondary" onClick={openModal}>
@@ -492,11 +488,11 @@ export const FocusTrap: StoryComponentType = () => {
                             </Button>
                         )}
                     </ModalLauncher>
-                    <Strut size={spacing.medium_16} />
+
                     <Button onClick={closeModal} disabled={!selectedValue}>
                         Next
                     </Button>
-                </>
+                </View>
             }
             aria-describedby="focus-trap-story-body-text"
         />
@@ -542,6 +538,7 @@ const styles = StyleSheet.create({
     },
     row: {
         flexDirection: "row",
+        gap: sizing.size_160,
     },
 });
 
@@ -583,7 +580,7 @@ export const CreatingACustomModal: StoryComponentType = {
                     style={{maxWidth: 423}}
                     closeButtonVisible={true}
                     content={
-                        <>
+                        <View style={{gap: sizing.size_240}}>
                             <StyledImg
                                 src="./km-ready.svg"
                                 alt="An illustration a bubble with Khanmigo inside."
@@ -593,22 +590,19 @@ export const CreatingACustomModal: StoryComponentType = {
                                     // This is to ensure that the image is
                                     // aligned to the top left corner of the
                                     // dialog.
-                                    marginLeft: -spacing.xLarge_32,
-                                    marginTop: -spacing.xLarge_32,
+                                    marginInlineStart: `calc(${sizing.size_320} * -1)`,
+                                    marginBlockStart: `calc(${sizing.size_320} * -1)`,
                                 }}
                             />
-                            <Strut size={spacing.large_24} />
                             <Heading size="medium" id="ready-dialog-title">
                                 Hi, I’m Khanmigo!
                             </Heading>
-                            <Strut size={spacing.xSmall_8} />
                             <BodyText>
                                 I’m your new AI-powered assistant, tutor, and
                                 all around cheerleader to help you power up your
                                 learning journey. Let’s take a look around
                                 together!
                             </BodyText>
-                            <Strut size={spacing.large_24} />
                             {/* Footer */}
                             <View
                                 style={{
@@ -623,7 +617,7 @@ export const CreatingACustomModal: StoryComponentType = {
                                     Next
                                 </Button>
                             </View>
-                        </>
+                        </View>
                     }
                 />
             </ModalDialog>

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -12,12 +12,7 @@ import {
 } from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import {
-    Body,
-    HeadingSmall,
-    LabelLarge,
-    Title,
-} from "@khanacademy/wonder-blocks-typography";
+import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import {
     ModalDialog,
@@ -62,7 +57,7 @@ const DefaultModal = (): ModalElement => (
         title="Single-line title"
         content={
             <View>
-                <Body>
+                <BodyText>
                     {`Lorem ipsum dolor sit amet, consectetur
                     adipiscing elit, sed do eiusmod tempor incididunt
                     ut labore et dolore magna aliqua. Ut enim ad minim
@@ -73,7 +68,7 @@ const DefaultModal = (): ModalElement => (
                     Excepteur sint occaecat cupidatat non proident,
                     sunt in culpa qui officia deserunt mollit anim id
                     est.`}
-                </Body>
+                </BodyText>
             </View>
         }
     />
@@ -174,7 +169,7 @@ export const WithCustomCloseButton: StoryComponentType = () => {
             title="Single-line title"
             content={
                 <View>
-                    <Body>
+                    <BodyText>
                         {`Lorem ipsum dolor sit amet, consectetur
                         adipiscing elit, sed do eiusmod tempor incididunt
                         ut labore et dolore magna aliqua. Ut enim ad minim
@@ -185,7 +180,7 @@ export const WithCustomCloseButton: StoryComponentType = () => {
                         Excepteur sint occaecat cupidatat non proident,
                         sunt in culpa qui officia deserunt mollit anim id
                         est.`}
-                    </Body>
+                    </BodyText>
                 </View>
             }
             // No "X" close button in the top right corner
@@ -273,7 +268,7 @@ export const TriggeringProgrammatically: StoryComponentType = () => {
                         title="Triggered from action menu"
                         content={
                             <View>
-                                <Title>Hello, world</Title>
+                                <Heading size="xxlarge">Hello, world</Heading>
                             </View>
                         }
                         footer={
@@ -443,15 +438,15 @@ const SubModal = () => (
         title="Submodal"
         content={
             <View style={{gap: spacing.medium_16}}>
-                <Body>
+                <BodyText>
                     This modal demonstrates how the focus trap works when a
                     modal is opened from another modal.
-                </Body>
-                <Body>
+                </BodyText>
+                <BodyText>
                     Try navigating this modal with the keyboard and then close
                     it. The focus should be restored to the button that opened
                     the modal.
-                </Body>
+                </BodyText>
                 <LabeledTextField label="Label" value="" onChange={() => {}} />
                 <Button>A focusable element</Button>
             </View>
@@ -469,12 +464,12 @@ export const FocusTrap: StoryComponentType = () => {
             closeButtonVisible={false}
             content={
                 <>
-                    <Body id="focus-trap-story-body-text">
+                    <BodyText id="focus-trap-story-body-text">
                         This modal demonstrates how the focus trap works with
                         form elements (or focusable elements). Also demonstrates
                         how the focus trap is moved to the next modal when it is
                         opened (focus/tap on the `Open another modal` button).
-                    </Body>
+                    </BodyText>
                     <Strut size={spacing.large_24} />
                     <RadioGroup
                         label="A RadioGroup component inside a modal"
@@ -603,16 +598,16 @@ export const CreatingACustomModal: StoryComponentType = {
                                 }}
                             />
                             <Strut size={spacing.large_24} />
-                            <HeadingSmall id="ready-dialog-title">
+                            <Heading size="medium" id="ready-dialog-title">
                                 Hi, I’m Khanmigo!
-                            </HeadingSmall>
+                            </Heading>
                             <Strut size={spacing.xSmall_8} />
-                            <Body>
+                            <BodyText>
                                 I’m your new AI-powered assistant, tutor, and
                                 all around cheerleader to help you power up your
                                 learning journey. Let’s take a look around
                                 together!
-                            </Body>
+                            </BodyText>
                             <Strut size={spacing.large_24} />
                             {/* Footer */}
                             <View
@@ -623,7 +618,7 @@ export const CreatingACustomModal: StoryComponentType = {
                                     alignItems: "center",
                                 }}
                             >
-                                <LabelLarge>Step 1 of 4</LabelLarge>
+                                <BodyText weight="bold">Step 1 of 4</BodyText>
                                 <Button kind="primary" onClick={closeModal}>
                                     Next
                                 </Button>

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -10,7 +10,7 @@ import {
     semanticColor,
     spacing,
 } from "@khanacademy/wonder-blocks-tokens";
-import {Body, Title} from "@khanacademy/wonder-blocks-typography";
+import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import {
     ModalDialog,
@@ -49,12 +49,12 @@ const customViewports = {
 
 const longBody = (
     <>
-        <Body>
+        <BodyText>
             {`Let's make this body content long in order
 to test scroll overflow.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -65,9 +65,9 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -78,9 +78,9 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
         <br />
-        <Body>
+        <BodyText>
             {`Lorem ipsum dolor sit amet, consectetur
 adipiscing elit, sed do eiusmod tempor incididunt
 ut labore et dolore magna aliqua. Ut enim ad minim
@@ -91,7 +91,7 @@ esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident,
 sunt in culpa qui officia deserunt mollit anim id
 est.`}
-        </Body>
+        </BodyText>
     </>
 );
 
@@ -172,7 +172,9 @@ export const Default: StoryComponentType = {
                 {...args}
                 content={
                     <>
-                        <Title id="modal-title-0">Modal Title</Title>
+                        <Heading size="xxlarge" id="modal-title-0">
+                            Modal Title
+                        </Heading>
                         <Strut size={spacing.large_24} />
                         {longBody}
                     </>
@@ -210,7 +212,9 @@ export const WithFooter: StoryComponentType = {
             <ModalPanel
                 content={
                     <>
-                        <Title id="modal-title-3">Modal Title</Title>
+                        <Heading size="xxlarge" id="modal-title-3">
+                            Modal Title
+                        </Heading>
                         <Strut size={spacing.large_24} />
                         {longBody}
                     </>
@@ -271,15 +275,17 @@ export const TwoPanels: StoryComponentType = {
                     <ModalPanel
                         content={
                             <View>
-                                <Title id="sidebar-title-id">Sidebar</Title>
+                                <Heading size="xxlarge" id="sidebar-title-id">
+                                    Sidebar
+                                </Heading>
                                 <Strut size={spacing.large_24} />
-                                <Body>
+                                <BodyText>
                                     Lorem ipsum dolor sit amet, consectetur
                                     adipiscing elit, sed do eiusmod tempor
                                     incididunt ut labore et dolore magna aliqua.
                                     Ut enim ad minim veniam, quis nostrud
                                     exercitation ullamco laboris.
-                                </Body>
+                                </BodyText>
                             </View>
                         }
                         closeButtonVisible={false}
@@ -287,13 +293,13 @@ export const TwoPanels: StoryComponentType = {
                     <ModalPanel
                         content={
                             <View>
-                                <Title>Contents</Title>
+                                <Heading size="xxlarge">Contents</Heading>
                                 <Strut size={spacing.large_24} />
-                                <Body>
+                                <BodyText>
                                     Lorem ipsum dolor sit amet, consectetur
                                     adipiscing elit, sed do eiusmod tempor
                                     incididunt ut labore et dolore magna aliqua.
-                                </Body>
+                                </BodyText>
                                 <Strut size={spacing.large_24} />
                                 <Button>Primary action</Button>
                             </View>

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -4,12 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {
-    border,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -171,13 +166,12 @@ export const Default: StoryComponentType = {
             <ModalPanel
                 {...args}
                 content={
-                    <>
+                    <View style={styles.content}>
                         <Heading size="xxlarge" id="modal-title-0">
                             Modal Title
                         </Heading>
-                        <Strut size={spacing.large_24} />
                         {longBody}
-                    </>
+                    </View>
                 }
             />
         </ModalDialog>
@@ -211,13 +205,12 @@ export const WithFooter: StoryComponentType = {
         <ModalDialog aria-labelledby="modal-title-3" style={styles.dialog}>
             <ModalPanel
                 content={
-                    <>
+                    <View style={styles.content}>
                         <Heading size="xxlarge" id="modal-title-3">
                             Modal Title
                         </Heading>
-                        <Strut size={spacing.large_24} />
                         {longBody}
-                    </>
+                    </View>
                 }
                 footer={
                     <ModalFooter>
@@ -274,11 +267,10 @@ export const TwoPanels: StoryComponentType = {
                 <View style={panelGroupStyle}>
                     <ModalPanel
                         content={
-                            <View>
+                            <View style={styles.content}>
                                 <Heading size="xxlarge" id="sidebar-title-id">
                                     Sidebar
                                 </Heading>
-                                <Strut size={spacing.large_24} />
                                 <BodyText>
                                     Lorem ipsum dolor sit amet, consectetur
                                     adipiscing elit, sed do eiusmod tempor
@@ -292,15 +284,13 @@ export const TwoPanels: StoryComponentType = {
                     />
                     <ModalPanel
                         content={
-                            <View>
+                            <View style={styles.content}>
                                 <Heading size="xxlarge">Contents</Heading>
-                                <Strut size={spacing.large_24} />
                                 <BodyText>
                                     Lorem ipsum dolor sit amet, consectetur
                                     adipiscing elit, sed do eiusmod tempor
                                     incididunt ut labore et dolore magna aliqua.
                                 </BodyText>
-                                <Strut size={spacing.large_24} />
                                 <Button>Primary action</Button>
                             </View>
                         }
@@ -371,5 +361,8 @@ const styles = StyleSheet.create({
     example: {
         alignItems: "center",
         justifyContent: "center",
+    },
+    content: {
+        gap: sizing.size_240,
     },
 });

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -9,9 +9,8 @@ import {
 } from "@khanacademy/wonder-blocks-breadcrumbs";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
@@ -168,7 +167,6 @@ export const WithFooter: StoryComponentType = () => (
                         <BodyText weight="bold">Step 1 of 4</BodyText>
                         <View style={styles.row}>
                             <Button kind="tertiary">Previous</Button>
-                            <Strut size={16} />
                             <Button kind="primary">Next</Button>
                         </View>
                     </View>
@@ -389,7 +387,7 @@ WithStyle.parameters = {
 export const FlexibleModal: StoryComponentType = () => {
     const styles = StyleSheet.create({
         example: {
-            padding: spacing.xLarge_32,
+            padding: sizing.size_320,
             alignItems: "center",
         },
         row: {
@@ -437,7 +435,6 @@ export const FlexibleModal: StoryComponentType = () => {
                             <Button kind="tertiary" onClick={handlePrevButton}>
                                 Previous
                             </Button>
-                            <Strut size={16} />
                             <Button kind="primary" onClick={handleNextButton}>
                                 Next
                             </Button>
@@ -596,6 +593,7 @@ const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
         justifyContent: "flex-end",
+        gap: sizing.size_160,
     },
     footer: {
         alignItems: "center",

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -12,7 +12,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Link from "@khanacademy/wonder-blocks-link";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {Body, LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
@@ -98,7 +98,7 @@ export const Default: StoryComponentType = {
     ),
     args: {
         content: (
-            <Body>
+            <BodyText>
                 {`Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                 sed do eiusmod tempor incididunt ut labore et dolore magna
                 aliqua. Ut enim ad minim veniam, quis nostrud exercitation
@@ -107,7 +107,7 @@ export const Default: StoryComponentType = {
                 esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
                 occaecat cupidatat non proident, sunt in culpa qui officia
                 deserunt mollit anim id est.`}
-            </Body>
+            </BodyText>
         ),
         title: "Some title",
     },
@@ -119,7 +119,7 @@ export const Simple: StoryComponentType = () => (
             <OnePaneDialog
                 title="Hello, world! Here is an example of a long title that wraps to the next line."
                 content={
-                    <Body>
+                    <BodyText>
                         {`Lorem ipsum dolor sit amet, consectetur adipiscing
                             elit, sed do eiusmod tempor incididunt ut labore et
                             dolore magna aliqua. Ut enim ad minim veniam,
@@ -129,7 +129,7 @@ export const Simple: StoryComponentType = () => (
                             cillum dolore eu fugiat nulla pariatur. Excepteur
                             sint occaecat cupidatat non proident, sunt in culpa
                             qui officia deserunt mollit anim id est.`}
-                    </Body>
+                    </BodyText>
                 }
             />
         </View>
@@ -151,7 +151,7 @@ export const WithFooter: StoryComponentType = () => (
             <OnePaneDialog
                 title="Hello, world!"
                 content={
-                    <Body>
+                    <BodyText>
                         {`Lorem ipsum dolor sit amet, consectetur adipiscing
                             elit, sed do eiusmod tempor incididunt ut labore et
                             dolore magna aliqua. Ut enim ad minim veniam,
@@ -161,11 +161,11 @@ export const WithFooter: StoryComponentType = () => (
                             cillum dolore eu fugiat nulla pariatur. Excepteur
                             sint occaecat cupidatat non proident, sunt in culpa
                             qui officia deserunt mollit anim id est.`}
-                    </Body>
+                    </BodyText>
                 }
                 footer={
                     <View style={styles.footer}>
-                        <LabelLarge>Step 1 of 4</LabelLarge>
+                        <BodyText weight="bold">Step 1 of 4</BodyText>
                         <View style={styles.row}>
                             <Button kind="tertiary">Previous</Button>
                             <Strut size={16} />
@@ -190,7 +190,7 @@ export const WithSubtitle: StoryComponentType = () => (
             <OnePaneDialog
                 title="Hello, world!"
                 content={
-                    <Body>
+                    <BodyText>
                         {`Lorem ipsum dolor sit amet, consectetur adipiscing
                             elit, sed do eiusmod tempor incididunt ut labore et
                             dolore magna aliqua. Ut enim ad minim veniam,
@@ -200,7 +200,7 @@ export const WithSubtitle: StoryComponentType = () => (
                             cillum dolore eu fugiat nulla pariatur. Excepteur
                             sint occaecat cupidatat non proident, sunt in culpa
                             qui officia deserunt mollit anim id est.`}
-                    </Body>
+                    </BodyText>
                 }
                 subtitle={
                     "Subtitle that provides additional context to the title"
@@ -222,7 +222,7 @@ export const WithBreadcrumbs: StoryComponentType = () => (
             <OnePaneDialog
                 title="Hello, world!"
                 content={
-                    <Body>
+                    <BodyText>
                         {`Lorem ipsum dolor sit amet, consectetur adipiscing
                             elit, sed do eiusmod tempor incididunt ut labore et
                             dolore magna aliqua. Ut enim ad minim veniam,
@@ -232,7 +232,7 @@ export const WithBreadcrumbs: StoryComponentType = () => (
                             cillum dolore eu fugiat nulla pariatur. Excepteur
                             sint occaecat cupidatat non proident, sunt in culpa
                             qui officia deserunt mollit anim id est.`}
-                    </Body>
+                    </BodyText>
                 }
                 breadcrumbs={
                     <Breadcrumbs>
@@ -285,7 +285,7 @@ export const WithAboveAndBelow: StoryComponentType = () => {
                     title="Single-line title"
                     content={
                         <View>
-                            <Body>
+                            <BodyText>
                                 {`Lorem ipsum dolor sit amet, consectetur
                             adipiscing elit, sed do eiusmod tempor incididunt
                             ut labore et dolore magna aliqua. Ut enim ad minim
@@ -296,9 +296,9 @@ export const WithAboveAndBelow: StoryComponentType = () => {
                             Excepteur sint occaecat cupidatat non proident,
                             sunt in culpa qui officia deserunt mollit anim id
                             est.`}
-                            </Body>
+                            </BodyText>
                             <br />
-                            <Body>
+                            <BodyText>
                                 {`Lorem ipsum dolor sit amet, consectetur
                             adipiscing elit, sed do eiusmod tempor incididunt
                             ut labore et dolore magna aliqua. Ut enim ad minim
@@ -309,9 +309,9 @@ export const WithAboveAndBelow: StoryComponentType = () => {
                             Excepteur sint occaecat cupidatat non proident,
                             sunt in culpa qui officia deserunt mollit anim id
                             est.`}
-                            </Body>
+                            </BodyText>
                             <br />
-                            <Body>
+                            <BodyText>
                                 {`Lorem ipsum dolor sit amet, consectetur
                             adipiscing elit, sed do eiusmod tempor incididunt
                             ut labore et dolore magna aliqua. Ut enim ad minim
@@ -322,7 +322,7 @@ export const WithAboveAndBelow: StoryComponentType = () => {
                             Excepteur sint occaecat cupidatat non proident,
                             sunt in culpa qui officia deserunt mollit anim id
                             est.`}
-                            </Body>
+                            </BodyText>
                         </View>
                     }
                     above={<View style={aboveStyle} />}
@@ -355,7 +355,7 @@ export const WithStyle: StoryComponentType = () => (
             <OnePaneDialog
                 title="Hello, world!"
                 content={
-                    <Body>
+                    <BodyText>
                         {`Lorem ipsum dolor sit amet, consectetur adipiscing
                             elit, sed do eiusmod tempor incididunt ut labore et
                             dolore magna aliqua. Ut enim ad minim veniam,
@@ -365,7 +365,7 @@ export const WithStyle: StoryComponentType = () => (
                             cillum dolore eu fugiat nulla pariatur. Excepteur
                             sint occaecat cupidatat non proident, sunt in culpa
                             qui officia deserunt mollit anim id est.`}
-                    </Body>
+                    </BodyText>
                 }
                 style={{
                     color: semanticColor.status.notice.foreground,
@@ -423,14 +423,16 @@ export const FlexibleModal: StoryComponentType = () => {
                 title="Exercises"
                 content={
                     <View>
-                        <Body>This is the current question: {question}</Body>
+                        <BodyText>
+                            This is the current question: {question}
+                        </BodyText>
                     </View>
                 }
                 footer={
                     <View style={styles.footer}>
-                        <LabelLarge>
+                        <BodyText weight="bold">
                             Step {current + 1} of {total}
-                        </LabelLarge>
+                        </BodyText>
                         <View style={styles.row}>
                             <Button kind="tertiary" onClick={handlePrevButton}>
                                 Previous
@@ -521,7 +523,7 @@ export const WithLauncher: StoryComponentType = () => {
         <OnePaneDialog
             title="Single-line title"
             content={
-                <Body>
+                <BodyText>
                     {`Lorem ipsum dolor sit amet, consectetur
                     adipiscing elit, sed do eiusmod tempor incididunt
                     ut labore et dolore magna aliqua. Ut enim ad minim
@@ -532,7 +534,7 @@ export const WithLauncher: StoryComponentType = () => {
                     Excepteur sint occaecat cupidatat non proident,
                     sunt in culpa qui officia deserunt mollit anim id
                     est.`}
-                </Body>
+                </BodyText>
             }
             footer={<Button onClick={closeModal}>Close</Button>}
         />

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
         height: "100%",
         position: "relative",
         [small]: {
-            padding: theme.dialog.spacing.padding,
+            padding: theme.dialog.layout.padding,
             flexDirection: "column",
         },
     },

--- a/packages/wonder-blocks-modal/src/components/modal-footer.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-footer.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
-import theme from "../theme";
 
 type Props = {
     children: React.ReactNode;
@@ -48,6 +47,6 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "flex-end",
 
-        boxShadow: `0px -1px 0px ${theme.footer.color.border}`,
+        boxShadow: `0px -1px 0px ${semanticColor.core.border.neutral.subtle}`,
     },
 });

--- a/packages/wonder-blocks-modal/src/components/modal-header.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-header.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import {Breadcrumbs} from "@khanacademy/wonder-blocks-breadcrumbs";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {HeadingMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {Heading, BodyText} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import theme from "../theme";
 
 type Common = {
@@ -105,21 +106,23 @@ export default function ModalHeader(props: Props) {
             {breadcrumbs && (
                 <View style={styles.breadcrumbs}>{breadcrumbs}</View>
             )}
-            <HeadingMedium
+            <Heading
+                size="large"
                 tag="h2"
                 style={styles.title}
                 id={titleId}
                 testId={testId && `${testId}-title`}
             >
                 {title}
-            </HeadingMedium>
+            </Heading>
             {subtitle && (
-                <LabelSmall
+                <BodyText
+                    size="small"
                     style={styles.subtitle}
                     testId={testId && `${testId}-subtitle`}
                 >
                     {subtitle}
-                </LabelSmall>
+                </BodyText>
             )}
         </View>
     );
@@ -135,35 +138,35 @@ const small = "@media (max-width: 767px)";
 const styles = StyleSheet.create({
     header: {
         // TODO(WB-1878): Move this to an `elevation` theme token.
-        boxShadow: `0px 1px 0px ${theme.header.color.border}`,
+        boxShadow: `0px 1px 0px ${semanticColor.core.border.neutral.subtle}`,
         display: "flex",
         flexDirection: "column",
         minHeight: 66,
-        paddingBlock: theme.header.spacing.paddingBlockMd,
-        paddingInline: theme.header.spacing.paddingInlineMd,
+        paddingBlock: theme.header.layout.paddingBlockMd,
+        paddingInline: theme.header.layout.paddingInlineMd,
         position: "relative",
         width: "100%",
 
         [small as any]: {
-            paddingInline: theme.header.spacing.paddingInlineSm,
+            paddingInline: theme.header.layout.paddingInlineSm,
         },
     },
 
     breadcrumbs: {
-        color: theme.header.color.secondary,
-        marginBottom: theme.header.spacing.gap,
+        color: semanticColor.core.foreground.neutral.default,
+        marginBottom: theme.header.layout.gap,
     },
 
     title: {
         // Prevent title from overlapping the close button
-        paddingRight: theme.header.spacing.titleGapMd,
+        paddingRight: theme.header.layout.titleGapMd,
         [small as any]: {
-            paddingRight: theme.header.spacing.titleGapSm,
+            paddingRight: theme.header.layout.titleGapSm,
         },
     },
 
     subtitle: {
-        color: theme.header.color.secondary,
-        marginTop: theme.header.spacing.gap,
+        color: semanticColor.core.foreground.neutral.default,
+        marginTop: theme.header.layout.gap,
     },
 });

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -153,8 +153,8 @@ const styles = StyleSheet.create({
 
     closeButton: {
         position: "absolute",
-        right: theme.closeButton.spacing.gap,
-        top: theme.closeButton.spacing.gap,
+        right: theme.closeButton.layout.gap,
+        top: theme.closeButton.layout.gap,
         // This is to allow the button to be tab-ordered before the modal
         // content but still be above the header and content.
         zIndex: 1,
@@ -167,6 +167,6 @@ const styles = StyleSheet.create({
 
     hasFooter: {
         // The space between the content and the footer
-        paddingBlockEnd: theme.panel.spacing.gap,
+        paddingBlockEnd: theme.panel.layout.gap,
     },
 });

--- a/packages/wonder-blocks-modal/src/components/one-pane-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/one-pane-dialog.tsx
@@ -108,12 +108,12 @@ type DefaultProps = {
  *
  * ```jsx
  * import {OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
- * import {Body} from "@khanacademy/wonder-blocks-typography";
+ * import {BodyText} from "@khanacademy/wonder-blocks-typography";
  *
  * <OnePaneDialog
  *     title="Some title"
  *     content={
- *         <Body>
+ *         <BodyText>
  *             {`Lorem ipsum dolor sit amet, consectetur adipiscing
  *             elit, sed do eiusmod tempor incididunt ut labore et
  *             dolore magna aliqua. Ut enim ad minim veniam,
@@ -123,7 +123,7 @@ type DefaultProps = {
  *             cillum dolore eu fugiat nulla pariatur. Excepteur
  *             sint occaecat cupidatat non proident, sunt in culpa
  *             qui officia deserunt mollit anim id est.`}
- *         </Body>
+ *         </BodyText>
  *     }
  * />
  * ```

--- a/packages/wonder-blocks-modal/src/theme/default.ts
+++ b/packages/wonder-blocks-modal/src/theme/default.ts
@@ -1,4 +1,4 @@
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 const theme = {
     /**
@@ -13,21 +13,12 @@ const theme = {
      * Building blocks
      */
     dialog: {
-        spacing: {
+        layout: {
             padding: sizing.size_160,
         },
     },
-    footer: {
-        color: {
-            border: semanticColor.core.border.neutral.subtle,
-        },
-    },
     header: {
-        color: {
-            border: semanticColor.core.border.neutral.subtle,
-            secondary: semanticColor.text.secondary,
-        },
-        spacing: {
+        layout: {
             paddingBlockMd: sizing.size_240,
             paddingInlineMd: sizing.size_320,
             paddingInlineSm: sizing.size_160,
@@ -38,12 +29,12 @@ const theme = {
         },
     },
     panel: {
-        spacing: {
+        layout: {
             gap: sizing.size_320,
         },
     },
     closeButton: {
-        spacing: {
+        layout: {
             gap: sizing.size_080,
         },
     },

--- a/packages/wonder-blocks-modal/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-modal/src/theme/thunderblocks.ts
@@ -1,0 +1,16 @@
+import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
+import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import defaultTheme from "./default";
+
+export default mergeTheme(defaultTheme, {
+    root: {
+        border: {
+            radius: border.radius.radius_120,
+        },
+    },
+    closeButton: {
+        layout: {
+            gap: sizing.size_120,
+        },
+    },
+});


### PR DESCRIPTION
## Summary:

Last PR to add Thunderblocks theme to modal components.

- Adds ThunderBlocks theme to modal package.
- Updates typography to use BodyText and Heading.
- Removes Strut uses (including stories).

Figma: https://www.figma.com/design/EuFu0U7gqc1koXm8ZhlOLp/%E2%9A%A1%EF%B8%8F-Components?node-id=2213-141&m=dev

### Implementation plan

1. #2676
2. #2677
3. #2678


Issue: https://khanacademy.atlassian.net/browse/WB-1867

## Test plan:

Navigate to the Modal stories in Storybook and ensure that the modals render
correctly.

Make sure that the typography elements are looking as expected.