### PR TITLE
Ensure tablist doesn't disappear

### DIFF
--- a/packages/wonder-blocks-tabs/src/components/tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs.tsx
@@ -432,5 +432,6 @@ const styles = StyleSheet.create({
     tablistWrapper: {
         position: "relative",
         overflowX: "auto",
+        flexShrink: 0,
     },
 });


### PR DESCRIPTION
In certain situations, the tabs component can be vertically compressed, which causes the tablist to disappear since it's flex-shrinking.

Adding `flexShrink: 0` prevents that issue.

https://github.com/user-attachments/assets/02f2bcdc-a19b-406e-9c56-fe9793c9831e
