### PR TITLE
Include readonly and error icon in fields

### DIFF
--- a/.changeset/big-houses-help.md
+++ b/.changeset/big-houses-help.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Update combobox styles so it works with TextField updates to support end accessiories for TB

--- a/.changeset/fast-seahorses-occur.md
+++ b/.changeset/fast-seahorses-occur.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Add component tokens for `form` and `search-field` packages

--- a/.changeset/new-bees-grow.md
+++ b/.changeset/new-bees-grow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+TextArea and TextField in the Thunderblocks theme show an end icon when it is in an error or readonly state

--- a/.changeset/real-pumpkins-pump.md
+++ b/.changeset/real-pumpkins-pump.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-search-field": patch
+---
+
+SearchField: Update styling so that it works with the TextField component updates to support TB and icons in the input

--- a/.changeset/sharp-teachers-deliver.md
+++ b/.changeset/sharp-teachers-deliver.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+TextField input element is now wrapped with a `div` so that end accessory icons can be supported within the component for readonly and error states. A `styles` prop is also introduced so that both the root and input elements in the component can be styled

--- a/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
@@ -147,6 +147,14 @@ export const Scenarios: Story = {
                 name: "With Placeholder (long, no word breaks)",
                 props: {placeholder: longTextWithNoWordBreak},
             },
+            {
+                name: "With Long Text and Error",
+                props: {value: longText, error: true},
+            },
+            {
+                name: "With Long Text and Readonly",
+                props: {value: longText, readOnly: true},
+            },
         ];
         return (
             <ScenariosLayout scenarios={scenarios}>

--- a/__docs__/wonder-blocks-form/text-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field-testing-snapshots.stories.tsx
@@ -147,6 +147,14 @@ export const Scenarios: Story = {
                 name: "With Placeholder (long, no word breaks)",
                 props: {placeholder: longTextWithNoWordBreak},
             },
+            {
+                name: "With Long Text and Error",
+                props: {value: longText, error: true},
+            },
+            {
+                name: "With Long Text and Readonly",
+                props: {value: longText, readOnly: true},
+            },
         ];
         return (
             <ScenariosLayout scenarios={scenarios}>

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -5,7 +5,12 @@ import type {Meta, StoryObj} from "@storybook/react";
 
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    semanticColor,
+    sizing,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
 import Button from "@khanacademy/wonder-blocks-button";
 import {LabelLarge, Body} from "@khanacademy/wonder-blocks-typography";
 
@@ -624,6 +629,30 @@ Disabled.parameters = {
     },
 };
 
+/**
+ * A TextField can be used with custom styles. The following parts can be styled:
+ * - `root`: Styles the root element
+ * - `input`: Styles the underlying `input` element
+ */
+export const CustomStyles: StoryComponentType = {
+    args: {
+        value: "Value",
+        styles: {
+            root: {
+                backgroundColor:
+                    semanticColor.core.background.instructive.subtle,
+                padding: sizing.size_140,
+            },
+            input: {
+                backgroundColor: semanticColor.surface.secondary,
+                border: `${border.width.thin} solid ${semanticColor.core.border.instructive.default}`,
+                color: semanticColor.core.foreground.instructive.strong,
+            },
+        },
+    },
+};
+
+// TODO(WB-2004): Remove this story once `style` prop is removed.
 export const CustomStyle: StoryComponentType = () => {
     const [value, setValue] = React.useState("");
 
@@ -653,7 +682,7 @@ export const CustomStyle: StoryComponentType = () => {
 CustomStyle.parameters = {
     docs: {
         description: {
-            story: `\`TextField\` can take in custom styles that
+            story: `**DEPRECATED:** Use \`styles\` prop instead.\`TextField\` can take in custom styles that
         override the default styles. This example has custom styles for the
         \`backgroundColor\`, \`color\`, \`border\`, \`maxWidth\`, and
         placeholder \`color\` properties.`,

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -569,7 +569,10 @@ export default function Combobox({
                 <TextField
                     id={textFieldId}
                     testId={testId}
-                    style={styles.combobox}
+                    styles={{
+                        root: styles.textFieldRoot,
+                        input: styles.combobox,
+                    }}
                     value={inputValue}
                     onChange={handleTextFieldChange}
                     disabled={disabled}
@@ -753,14 +756,21 @@ const styles = StyleSheet.create({
         border: "none",
         outline: "none",
         padding: 0,
-        minWidth: spacing.xxxSmall_4,
-        width: "auto",
-        display: "inline-grid",
-        gridArea: "1 / 2",
         ":focus-visible": {
             outline: "none",
             border: "none",
+            boxShadow: "none",
         },
+        [":active:not([aria-disabled='true']):not([readonly])" as any]: {
+            // Override press styles from TextField.
+            boxShadow: "none",
+        },
+    },
+    textFieldRoot: {
+        width: "auto",
+        minWidth: spacing.xxxSmall_4,
+        display: "inline-grid",
+        gridArea: "1 / 2",
     },
     /**
      * Listbox custom styles

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -7,12 +7,15 @@ import {
     addStyle,
     View,
 } from "@khanacademy/wonder-blocks-core";
-import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {useId} from "react";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
-import {useFieldValidation} from "../hooks/use-field-validation";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import errorIcon from "@phosphor-icons/core/fill/warning-diamond-fill.svg";
+import readOnlyIcon from "@phosphor-icons/core/bold/lock-bold.svg";
 import theme from "../theme";
+import {useFieldValidation} from "../hooks/use-field-validation";
 
 type TextAreaProps = AriaProps & {
     /**
@@ -182,6 +185,7 @@ type TextAreaProps = AriaProps & {
     resizeType?: "horizontal" | "vertical" | "both" | "none";
 };
 
+const StyledDiv = addStyle("div");
 const StyledTextarea = addStyle("textarea");
 
 /**
@@ -265,8 +269,27 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             }
         };
 
+        let icon;
+        if (hasError) {
+            icon = (
+                <PhosphorIcon
+                    icon={errorIcon}
+                    size="small"
+                    color={semanticColor.core.foreground.critical.default}
+                />
+            );
+        } else if (readOnly) {
+            icon = (
+                <PhosphorIcon
+                    icon={readOnlyIcon}
+                    size="small"
+                    color={semanticColor.core.foreground.neutral.subtle}
+                />
+            );
+        }
+
         return (
-            <View style={[{width: "100%"}, rootStyle]}>
+            <View style={[styles.root, rootStyle]}>
                 <StyledTextarea
                     id={uniqueId}
                     data-testid={testId}
@@ -280,6 +303,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                         disabled && styles.disabled,
                         hasError && styles.error,
                         readOnly && styles.readOnly,
+                        icon && styles.withIcon,
                         style,
                     ]}
                     value={value}
@@ -305,12 +329,19 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     {...otherProps}
                     aria-invalid={hasError}
                 />
+                {icon && (
+                    <StyledDiv style={styles.endAccessory}>{icon}</StyledDiv>
+                )}
             </View>
         );
     },
 );
 
 const styles = StyleSheet.create({
+    root: {
+        width: "100%",
+        position: "relative",
+    },
     textarea: {
         borderRadius: theme.field.border.radius,
         boxSizing: "border-box",
@@ -318,6 +349,10 @@ const styles = StyleSheet.create({
         paddingBlock: theme.field.layout.paddingBlock,
         // This minHeight is equivalent to when the textarea has one row
         minHeight: theme.field.sizing.height,
+    },
+    withIcon: {
+        // If there is an icon and the theme supports end accessories, the end padding needs to be adjusted to account for the icon
+        paddingInlineEnd: `calc(${theme.field.layout.paddingInline} + ${theme.endAccessory.sizing.width} + ${theme.endAccessory.layout.paddingInlineStart})`,
     },
     readOnly: {
         background: semanticColor.input.readOnly.background,
@@ -354,6 +389,12 @@ const styles = StyleSheet.create({
         "::placeholder": {
             color: semanticColor.input.default.placeholder,
         },
+    },
+    endAccessory: {
+        display: theme.endAccessory.layout.display,
+        position: "absolute",
+        insetBlock: sizing.size_140,
+        insetInlineEnd: sizing.size_120,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -342,10 +342,8 @@ const styles = StyleSheet.create({
     endAccessory: {
         display: theme.endAccessory.layout.display,
         position: "absolute",
-        insetBlock: 0, // sizing.size_140,
+        insetBlock: sizing.size_140,
         insetInlineEnd: sizing.size_120,
-        alignItems: "center",
-        justifyContent: "center",
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -301,7 +301,7 @@ const TextField = (props: PropsWithForwardRef) => {
 const styles = StyleSheet.create({
     root: {
         position: "relative",
-        display: "flex",
+        width: "100%",
     },
     input: {
         width: "100%",

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
-import {Id, addStyle} from "@khanacademy/wonder-blocks-core";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 
@@ -168,7 +168,7 @@ type PropsWithForwardRef = Props & WithForwardRef;
  */
 const TextField = (props: PropsWithForwardRef) => {
     const {
-        id,
+        id: idProp,
         type = "text",
         value,
         name,
@@ -202,6 +202,8 @@ const TextField = (props: PropsWithForwardRef) => {
             onValidate,
         });
     const hasError = error || !!errorMessage;
+    const uniqueId = React.useId();
+    const id = idProp || uniqueId;
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         const newValue = event.target.value;
@@ -224,39 +226,35 @@ const TextField = (props: PropsWithForwardRef) => {
     };
 
     return (
-        <Id id={id}>
-            {(uniqueId) => (
-                <StyledInput
-                    style={[
-                        styles.input,
-                        typographyStyles.LabelMedium,
-                        styles.default,
-                        disabled && styles.disabled,
-                        hasError && styles.error,
-                        readOnly && styles.readOnly,
-                        style,
-                    ]}
-                    id={uniqueId}
-                    type={type}
-                    placeholder={placeholder}
-                    value={value}
-                    name={name}
-                    aria-disabled={disabled}
-                    aria-required={!!required}
-                    onChange={handleChange}
-                    onKeyDown={disabled ? undefined : onKeyDown}
-                    onFocus={handleFocus} // TextField can be focused if disabled
-                    onBlur={handleBlur} // TextField can be blurred if disabled
-                    data-testid={testId}
-                    readOnly={readOnly || disabled} // Set readOnly also if it is disabled, otherwise users can type in the field
-                    autoFocus={autoFocus}
-                    autoComplete={autoComplete}
-                    ref={forwardedRef}
-                    aria-invalid={hasError}
-                    {...otherProps}
-                />
-            )}
-        </Id>
+        <StyledInput
+            style={[
+                styles.input,
+                typographyStyles.LabelMedium,
+                styles.default,
+                disabled && styles.disabled,
+                hasError && styles.error,
+                readOnly && styles.readOnly,
+                style,
+            ]}
+            id={id}
+            type={type}
+            placeholder={placeholder}
+            value={value}
+            name={name}
+            aria-disabled={disabled}
+            aria-required={!!required}
+            onChange={handleChange}
+            onKeyDown={disabled ? undefined : onKeyDown}
+            onFocus={handleFocus} // TextField can be focused if disabled
+            onBlur={handleBlur} // TextField can be blurred if disabled
+            data-testid={testId}
+            readOnly={readOnly || disabled} // Set readOnly also if it is disabled, otherwise users can type in the field
+            autoFocus={autoFocus}
+            autoComplete={autoComplete}
+            ref={forwardedRef}
+            aria-invalid={hasError}
+            {...otherProps}
+        />
     );
 };
 

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -121,8 +121,19 @@ type CommonProps = AriaProps & {
     required?: boolean | string;
     /**
      * Custom styles for the input.
+     *
+     * @deprecated Use `styles` prop instead.
      */
-    style?: StyleType;
+    style?: StyleType; // TODO(WB-2004): Remove this prop in favour of `styles` prop
+    /**
+     * Custom styles for the elements in the TextField.
+     * - `root`: Styles the root element
+     * - `input`: Styles the underlying `input` element
+     */
+    styles?: {
+        root?: StyleType;
+        input?: StyleType;
+    };
     /**
      * Optional test ID for e2e testing.
      */
@@ -183,6 +194,7 @@ const TextField = (props: PropsWithForwardRef) => {
         required,
         placeholder,
         style,
+        styles: stylesProp,
         testId,
         readOnly,
         autoFocus,
@@ -249,7 +261,7 @@ const TextField = (props: PropsWithForwardRef) => {
     }
 
     return (
-        <StyledDiv style={styles.root}>
+        <StyledDiv style={[styles.root, stylesProp?.root]}>
             <StyledInput
                 style={[
                     styles.input,
@@ -260,6 +272,7 @@ const TextField = (props: PropsWithForwardRef) => {
                     readOnly && styles.readOnly,
                     icon && styles.withIcon,
                     style,
+                    stylesProp?.input,
                 ]}
                 id={id}
                 type={type}

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -7,6 +7,8 @@ import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography"
 
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
+import errorIcon from "@phosphor-icons/core/fill/warning-diamond-fill.svg";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {OmitConstrained} from "../util/types";
 import {useFieldValidation} from "../hooks/use-field-validation";
 import theme from "../theme";
@@ -17,6 +19,7 @@ type WithForwardRef = {
     forwardedRef: React.ForwardedRef<HTMLInputElement>;
 };
 
+const StyledDiv = addStyle("div");
 const StyledInput = addStyle("input");
 
 type CommonProps = AriaProps & {
@@ -225,40 +228,59 @@ const TextField = (props: PropsWithForwardRef) => {
         }
     };
 
+    let icon;
+    if (hasError) {
+        icon = (
+            <PhosphorIcon
+                icon={errorIcon}
+                size="small"
+                color={theme.errorIcon.color.foreground}
+            />
+        );
+    }
+
     return (
-        <StyledInput
-            style={[
-                styles.input,
-                typographyStyles.LabelMedium,
-                styles.default,
-                disabled && styles.disabled,
-                hasError && styles.error,
-                readOnly && styles.readOnly,
-                style,
-            ]}
-            id={id}
-            type={type}
-            placeholder={placeholder}
-            value={value}
-            name={name}
-            aria-disabled={disabled}
-            aria-required={!!required}
-            onChange={handleChange}
-            onKeyDown={disabled ? undefined : onKeyDown}
-            onFocus={handleFocus} // TextField can be focused if disabled
-            onBlur={handleBlur} // TextField can be blurred if disabled
-            data-testid={testId}
-            readOnly={readOnly || disabled} // Set readOnly also if it is disabled, otherwise users can type in the field
-            autoFocus={autoFocus}
-            autoComplete={autoComplete}
-            ref={forwardedRef}
-            aria-invalid={hasError}
-            {...otherProps}
-        />
+        <StyledDiv style={styles.root}>
+            <StyledInput
+                style={[
+                    styles.input,
+                    typographyStyles.LabelMedium,
+                    styles.default,
+                    disabled && styles.disabled,
+                    hasError && styles.error,
+                    readOnly && styles.readOnly,
+                    icon && styles.withIcon,
+                    style,
+                ]}
+                id={id}
+                type={type}
+                placeholder={placeholder}
+                value={value}
+                name={name}
+                aria-disabled={disabled}
+                aria-required={!!required}
+                onChange={handleChange}
+                onKeyDown={disabled ? undefined : onKeyDown}
+                onFocus={handleFocus} // TextField can be focused if disabled
+                onBlur={handleBlur} // TextField can be blurred if disabled
+                data-testid={testId}
+                readOnly={readOnly || disabled} // Set readOnly also if it is disabled, otherwise users can type in the field
+                autoFocus={autoFocus}
+                autoComplete={autoComplete}
+                ref={forwardedRef}
+                aria-invalid={hasError}
+                {...otherProps}
+            />
+            {icon && <StyledDiv style={styles.endAccessory}>{icon}</StyledDiv>}
+        </StyledDiv>
     );
 };
 
 const styles = StyleSheet.create({
+    root: {
+        position: "relative",
+        display: "flex",
+    },
     input: {
         width: "100%",
         height: theme.field.sizing.height,
@@ -267,6 +289,10 @@ const styles = StyleSheet.create({
         paddingInline: theme.field.layout.paddingInline,
         paddingBlock: theme.field.layout.paddingBlock,
         margin: sizing.size_0,
+    },
+    withIcon: {
+        // If there is an icon and the theme supports end accessories, the end padding needs to be adjusted to account for the icon
+        paddingInlineEnd: `calc(${theme.field.layout.paddingInline} + ${theme.endAccessory.sizing.width} + ${theme.endAccessory.layout.paddingInlineStart})`,
     },
     readOnly: {
         background: semanticColor.input.readOnly.background,
@@ -303,6 +329,14 @@ const styles = StyleSheet.create({
             color: semanticColor.input.disabled.placeholder,
         },
         cursor: "not-allowed",
+    },
+    endAccessory: {
+        display: theme.endAccessory.layout.display,
+        position: "absolute",
+        insetBlock: 0, // sizing.size_140,
+        insetInlineEnd: sizing.size_120,
+        alignItems: "center",
+        justifyContent: "center",
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -8,6 +8,7 @@ import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography"
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import errorIcon from "@phosphor-icons/core/fill/warning-diamond-fill.svg";
+import readOnlyIcon from "@phosphor-icons/core/bold/lock-bold.svg";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {OmitConstrained} from "../util/types";
 import {useFieldValidation} from "../hooks/use-field-validation";
@@ -234,7 +235,15 @@ const TextField = (props: PropsWithForwardRef) => {
             <PhosphorIcon
                 icon={errorIcon}
                 size="small"
-                color={theme.errorIcon.color.foreground}
+                color={semanticColor.core.foreground.critical.default}
+            />
+        );
+    } else if (readOnly) {
+        icon = (
+            <PhosphorIcon
+                icon={readOnlyIcon}
+                size="small"
+                color={semanticColor.core.foreground.neutral.subtle}
             />
         );
     }

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -1,4 +1,4 @@
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 const theme = {
     field: {

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -27,11 +27,6 @@ const theme = {
             width: sizing.size_0,
         },
     },
-    errorIcon: {
-        color: {
-            foreground: semanticColor.core.transparent,
-        },
-    },
 };
 
 export default theme;

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -1,4 +1,4 @@
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 const theme = {
     field: {
@@ -16,6 +16,20 @@ const theme = {
         layout: {
             paddingBlock: sizing.size_100,
             paddingInline: sizing.size_160,
+        },
+    },
+    endAccessory: {
+        layout: {
+            display: "none",
+            paddingInlineStart: sizing.size_0,
+        },
+        sizing: {
+            width: sizing.size_0,
+        },
+    },
+    errorIcon: {
+        color: {
+            foreground: semanticColor.core.transparent,
         },
     },
 };

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,8 +1,9 @@
 import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
 
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import defaultTheme from "./default";
 
+const fieldPaddingInline = sizing.size_120;
 export default mergeTheme(defaultTheme, {
     field: {
         border: {
@@ -21,7 +22,21 @@ export default mergeTheme(defaultTheme, {
         },
         layout: {
             paddingBlock: sizing.size_100,
-            paddingInline: sizing.size_120,
+            paddingInline: fieldPaddingInline,
+        },
+    },
+    endAccessory: {
+        layout: {
+            display: "flex",
+            paddingInlineStart: fieldPaddingInline,
+        },
+        sizing: {
+            width: sizing.size_160,
+        },
+    },
+    errorIcon: {
+        color: {
+            foreground: semanticColor.core.foreground.critical.default,
         },
     },
 });

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -34,9 +34,4 @@ export default mergeTheme(defaultTheme, {
             width: sizing.size_160,
         },
     },
-    errorIcon: {
-        color: {
-            foreground: semanticColor.core.foreground.critical.default,
-        },
-    },
 });

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,6 +1,6 @@
 import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
 
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
 import defaultTheme from "./default";
 
 const fieldPaddingInline = sizing.size_120;

--- a/packages/wonder-blocks-search-field/package.json
+++ b/packages/wonder-blocks-search-field/package.json
@@ -3,10 +3,19 @@
   "version": "5.1.27",
   "design": "v1",
   "description": "Search Field components for Wonder Blocks.",
+  "exports": {
+    ".": {
+      "import": "./dist/es/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./styles.css": "./dist/css/vars.css"
+  },
   "main": "dist/index.js",
   "module": "dist/es/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "build:css": "pnpm exec wonder-blocks-tokens .",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -239,7 +239,7 @@ const SearchField: React.ForwardRefExoticComponent<
                         style={[
                             styles.inputStyleReset,
                             typographyStyles.LabelMedium,
-                            error && styles.inputWithError,
+                            error && !!value && styles.inputWithErrorAndValue,
                         ]}
                         testId={testId}
                         {...otherProps}
@@ -279,7 +279,7 @@ const styles = StyleSheet.create({
         paddingInlineStart: sizing.size_320,
         paddingRight: sizing.size_400,
     },
-    inputWithError: {
+    inputWithErrorAndValue: {
         paddingInlineEnd: theme.input.layout.withError.paddingInlineEnd,
     },
 });

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -9,11 +9,7 @@ import {View, Id} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {
-    border,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {defaultLabels} from "../util/constants";
@@ -264,15 +260,14 @@ const styles = StyleSheet.create({
         height: 40,
     },
     searchIcon: {
-        marginLeft: spacing.xSmall_8,
-        marginRight: spacing.xSmall_8,
+        marginInline: sizing.size_080,
         position: "absolute",
         zIndex: 1,
     },
     dismissIcon: {
         margin: 0,
         position: "absolute",
-        insetInlineEnd: spacing.xxxSmall_4,
+        insetInlineEnd: sizing.size_040,
     },
     dismissIconWithError: {
         insetInlineEnd: theme.dismissButton.layout.withError.insetInlineEnd,
@@ -281,8 +276,8 @@ const styles = StyleSheet.create({
         display: "flex",
         flex: 1,
         width: "100%",
-        paddingLeft: spacing.xLarge_32,
-        paddingRight: spacing.large_24 + spacing.medium_16,
+        paddingInlineStart: sizing.size_320,
+        paddingRight: sizing.size_400,
     },
     inputWithError: {
         paddingInlineEnd: theme.input.layout.withError.paddingInlineEnd,

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -277,7 +277,7 @@ const styles = StyleSheet.create({
         flex: 1,
         width: "100%",
         paddingInlineStart: sizing.size_320,
-        paddingRight: sizing.size_400,
+        paddingInlineEnd: sizing.size_400,
     },
     inputWithErrorAndValue: {
         paddingInlineEnd: theme.input.layout.withError.paddingInlineEnd,

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -17,6 +17,7 @@ import {
 import type {StyleType, AriaProps} from "@khanacademy/wonder-blocks-core";
 
 import {defaultLabels} from "../util/constants";
+import theme from "../theme";
 
 type Props = AriaProps & {
     /**
@@ -192,7 +193,10 @@ const SearchField: React.ForwardRefExoticComponent<
                 kind="tertiary"
                 actionType="neutral"
                 onClick={handleClear}
-                style={styles.dismissIcon}
+                style={[
+                    styles.dismissIcon,
+                    error && styles.dismissIconWithError,
+                ]}
                 aria-label={clearAriaLabel}
             />
         );
@@ -239,6 +243,7 @@ const SearchField: React.ForwardRefExoticComponent<
                         style={[
                             styles.inputStyleReset,
                             typographyStyles.LabelMedium,
+                            error && styles.inputWithError,
                         ]}
                         testId={testId}
                         {...otherProps}
@@ -267,7 +272,10 @@ const styles = StyleSheet.create({
     dismissIcon: {
         margin: 0,
         position: "absolute",
-        right: spacing.xxxSmall_4,
+        insetInlineEnd: spacing.xxxSmall_4,
+    },
+    dismissIconWithError: {
+        insetInlineEnd: theme.dismissButton.layout.withError.insetInlineEnd,
     },
     inputStyleReset: {
         display: "flex",
@@ -275,6 +283,9 @@ const styles = StyleSheet.create({
         width: "100%",
         paddingLeft: spacing.xLarge_32,
         paddingRight: spacing.large_24 + spacing.medium_16,
+    },
+    inputWithError: {
+        paddingInlineEnd: theme.input.layout.withError.paddingInlineEnd,
     },
 });
 

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -262,6 +262,7 @@ const styles = StyleSheet.create({
         marginLeft: spacing.xSmall_8,
         marginRight: spacing.xSmall_8,
         position: "absolute",
+        zIndex: 1,
     },
     dismissIcon: {
         margin: 0,

--- a/packages/wonder-blocks-search-field/src/theme/default.ts
+++ b/packages/wonder-blocks-search-field/src/theme/default.ts
@@ -1,0 +1,22 @@
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+
+const theme = {
+    input: {
+        layout: {
+            withError: {
+                // The right padding of the input when there is an error
+                paddingInlineEnd: sizing.size_400,
+            },
+        },
+    },
+    dismissButton: {
+        layout: {
+            withError: {
+                // The right position of the dismiss button
+                insetInlineEnd: sizing.size_040,
+            },
+        },
+    },
+};
+
+export default theme;

--- a/packages/wonder-blocks-search-field/src/theme/index.ts
+++ b/packages/wonder-blocks-search-field/src/theme/index.ts
@@ -1,0 +1,4 @@
+import {mapValuesToCssVars} from "@khanacademy/wonder-blocks-tokens";
+import themeDefault from "./default";
+
+export default mapValuesToCssVars(themeDefault, "--wb-c-search-field-");

--- a/packages/wonder-blocks-search-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-search-field/src/theme/thunderblocks.ts
@@ -1,0 +1,25 @@
+import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import defaultTheme from "./default";
+
+export default mergeTheme(defaultTheme, {
+    input: {
+        layout: {
+            withError: {
+                // The right padding of the input when there is an error. This
+                // accounts for the error icon and the dismiss button in
+                // TextFields for the TB theme
+                paddingInlineEnd: sizing.size_560,
+            },
+        },
+    },
+    dismissButton: {
+        layout: {
+            withError: {
+                // The right position of the dismiss button. This accounts for
+                // the error icon in TextFields for the TB theme
+                insetInlineEnd: sizing.size_320,
+            },
+        },
+    },
+});


### PR DESCRIPTION
## Summary:

- Form
  - Add an error icon and read only icon for TextField and TextArea in the TB theme. It is not shown in the classic theme
  - In order to support this new icon in `TextField`, we now wrap the `input` element with a `div`. This changes the DOM structure, we will need to test to make sure there are no layout changes in `frontend`/`perseus` because of this change. `TextArea` already had a wrapping div so we were able to add styles to that existing `div`. 
  - TextField: A `styles` prop was also added so that this newly introduced wrapping `div` can be styled (most likely for layout purposes)
 
- SearchField
  - Since the TextField in TB has an error icon now, we shift the `dismiss` icon button in the SearchField so that it doesn't overlap with the error icon or field value 

- Dropdown Combobox
  - Minor UI modifications since it uses TextField to address visual diffs that were original found in Chromatic

![image](https://github.com/user-attachments/assets/f93db129-47c9-4ee0-ae4c-53d16f25d4d2)

Issue: WB-1863

Figma designs: https://www.figma.com/design/EuFu0U7gqc1koXm8ZhlOLp/%E2%9A%A1%EF%B8%8F-Components?node-id=5302-354&m=dev

## Test plan:

- Review TextField and TextArea error and readonly states. Confirm icons are shown in TB, but not in OG
- Combobox, and SearchField stories to make sure things look as expected since they use TextField
- Test with the snapshot package in `frontend` and `perseus` to check for visual layout changes in the TextField component 

