### PR TITLE
LabeledField: Show the error icon for TB theme

### DIFF
--- a/.changeset/heavy-dolphins-lie.md
+++ b/.changeset/heavy-dolphins-lie.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update LabeledField component css variables

--- a/.changeset/short-spoons-approve.md
+++ b/.changeset/short-spoons-approve.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": patch
+---
+
+LabeledField: Show the error icon with the error message in the TB theme

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -15,6 +15,7 @@ import {
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 import Button from "@khanacademy/wonder-blocks-button";
 import {allModes} from "../../.storybook/modes";
+import {Heading} from "@khanacademy/wonder-blocks-typography";
 
 /**
  * The `LabeledField` component provides common elements for a form field such
@@ -75,10 +76,16 @@ const AllFields = (
         shouldValidateInStory?: boolean;
         showSubmitButtonInStory?: boolean;
         disabled?: boolean;
+        readOnly?: boolean;
     },
 ) => {
-    const {shouldValidateInStory, showSubmitButtonInStory, disabled, ...args} =
-        storyArgs;
+    const {
+        shouldValidateInStory,
+        showSubmitButtonInStory,
+        disabled,
+        readOnly,
+        ...args
+    } = storyArgs;
 
     /** Values */
     const [textFieldValue, setTextFieldValue] = React.useState("");
@@ -236,6 +243,7 @@ const AllFields = (
                         }
                         instantValidation={false}
                         disabled={disabled}
+                        readOnly={readOnly}
                     />
                 }
             />
@@ -255,76 +263,86 @@ const AllFields = (
                         }
                         instantValidation={false}
                         disabled={disabled}
+                        readOnly={readOnly}
                     />
                 }
             />
 
-            <LabeledField
-                {...args}
-                errorMessage={singleSelectErrorMessage}
-                label="Single Select"
-                description={selectDescription}
-                field={
-                    <SingleSelect
-                        // ref={singleSelectRef} // TODO(WB-1841) once SingleSelect supports ref
-                        placeholder="Choose a fruit"
-                        selectedValue={singleSelectValue}
-                        onChange={setSingleSelectValue}
-                        onValidate={setSingleSelectErrorMessage}
-                        validate={singleSelectValidate}
-                        disabled={disabled}
-                    >
-                        <OptionItem label="Mango" value="mango" />
-                        <OptionItem label="Strawberry" value="strawberry" />
-                        <OptionItem label="Banana" value="banana" />
-                    </SingleSelect>
-                }
-            />
+            {/* SingleSelect does not support readonly state */}
+            {!readOnly && (
+                <LabeledField
+                    {...args}
+                    errorMessage={singleSelectErrorMessage}
+                    label="Single Select"
+                    description={selectDescription}
+                    field={
+                        <SingleSelect
+                            // ref={singleSelectRef} // TODO(WB-1841) once SingleSelect supports ref
+                            placeholder="Choose a fruit"
+                            selectedValue={singleSelectValue}
+                            onChange={setSingleSelectValue}
+                            onValidate={setSingleSelectErrorMessage}
+                            validate={singleSelectValidate}
+                            disabled={disabled}
+                        >
+                            <OptionItem label="Mango" value="mango" />
+                            <OptionItem label="Strawberry" value="strawberry" />
+                            <OptionItem label="Banana" value="banana" />
+                        </SingleSelect>
+                    }
+                />
+            )}
 
-            <LabeledField
-                {...args}
-                errorMessage={multiSelectErrorMessage}
-                label="Multi Select"
-                description={selectDescription}
-                field={
-                    <MultiSelect
-                        // ref={multiSelectRef} // TODO(WB-1841) once MultiSelect supports ref
-                        selectedValues={multiSelectValue}
-                        onChange={setMultiSelectValue}
-                        onValidate={setMultiSelectErrorMessage}
-                        validate={
-                            shouldValidateInStory
-                                ? multiSelectValidate
-                                : undefined
-                        }
-                        disabled={disabled}
-                    >
-                        <OptionItem label="Mango" value="mango" />
-                        <OptionItem label="Strawberry" value="strawberry" />
-                        <OptionItem label="Banana" value="banana" />
-                    </MultiSelect>
-                }
-            />
+            {/* MultiSelect does not support readonly state */}
+            {!readOnly && (
+                <LabeledField
+                    {...args}
+                    errorMessage={multiSelectErrorMessage}
+                    label="Multi Select"
+                    description={selectDescription}
+                    field={
+                        <MultiSelect
+                            // ref={multiSelectRef} // TODO(WB-1841) once MultiSelect supports ref
+                            selectedValues={multiSelectValue}
+                            onChange={setMultiSelectValue}
+                            onValidate={setMultiSelectErrorMessage}
+                            validate={
+                                shouldValidateInStory
+                                    ? multiSelectValidate
+                                    : undefined
+                            }
+                            disabled={disabled}
+                        >
+                            <OptionItem label="Mango" value="mango" />
+                            <OptionItem label="Strawberry" value="strawberry" />
+                            <OptionItem label="Banana" value="banana" />
+                        </MultiSelect>
+                    }
+                />
+            )}
 
-            <LabeledField
-                {...args}
-                errorMessage={searchErrorMessage}
-                label="Search"
-                description={textDescription}
-                field={
-                    <SearchField
-                        ref={searchRef}
-                        value={searchValue}
-                        onChange={setSearchValue}
-                        validate={
-                            shouldValidateInStory ? textValidate : undefined
-                        }
-                        onValidate={setSearchErrorMessage}
-                        instantValidation={false}
-                        disabled={disabled}
-                    />
-                }
-            />
+            {/* SearchField does not support readonly state */}
+            {!readOnly && (
+                <LabeledField
+                    {...args}
+                    errorMessage={searchErrorMessage}
+                    label="Search"
+                    description={textDescription}
+                    field={
+                        <SearchField
+                            ref={searchRef}
+                            value={searchValue}
+                            onChange={setSearchValue}
+                            validate={
+                                shouldValidateInStory ? textValidate : undefined
+                            }
+                            onValidate={setSearchErrorMessage}
+                            instantValidation={false}
+                            disabled={disabled}
+                        />
+                    }
+                />
+            )}
 
             {showSubmitButtonInStory && <Button type="submit">Submit</Button>}
         </StyledForm>
@@ -355,9 +373,14 @@ export const Fields: StoryComponentType = {
     render: (args) => {
         return (
             <View style={{gap: sizing.size_240}}>
+                <Heading>Default</Heading>
                 <AllFields {...args} />
+                <Heading>Error</Heading>
                 <AllFields {...args} errorMessage="Message about the error" />
+                <Heading>Disabled</Heading>
                 <AllFields {...args} disabled />
+                <Heading>Read Only</Heading>
+                <AllFields {...args} readOnly={true} />
             </View>
         );
     },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -77,6 +77,7 @@ const AllFields = (
         showSubmitButtonInStory?: boolean;
         disabled?: boolean;
         readOnly?: boolean;
+        textValue?: string;
     },
 ) => {
     const {
@@ -84,12 +85,13 @@ const AllFields = (
         showSubmitButtonInStory,
         disabled,
         readOnly,
+        textValue,
         ...args
     } = storyArgs;
 
     /** Values */
-    const [textFieldValue, setTextFieldValue] = React.useState("");
-    const [textAreaValue, setTextAreaValue] = React.useState("");
+    const [textFieldValue, setTextFieldValue] = React.useState(textValue || "");
+    const [textAreaValue, setTextAreaValue] = React.useState(textValue || "");
     const [singleSelectValue, setSingleSelectValue] = React.useState("");
     const [multiSelectValue, setMultiSelectValue] = React.useState<string[]>(
         [],
@@ -380,7 +382,7 @@ export const Fields: StoryComponentType = {
                 <Heading>Disabled</Heading>
                 <AllFields {...args} disabled />
                 <Heading>Read Only</Heading>
-                <AllFields {...args} readOnly={true} />
+                <AllFields {...args} readOnly={true} textValue={"Value"} />
             </View>
         );
     },

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -314,6 +314,7 @@ const styles = StyleSheet.create({
         fontSize: theme.error.font.size,
         fontWeight: theme.error.font.weight,
         lineHeight: theme.error.font.lineHeight,
+        marginBlockStart: theme.error.layout.marginBlockStart,
     },
     required: {
         color: theme.requiredIndicator.color.foreground,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -307,7 +307,6 @@ const styles = StyleSheet.create({
         color: theme.error.color.foreground,
     },
     errorIcon: {
-        display: theme.errorIcon.layout.display,
         marginTop: sizing.size_010, // This vertically aligns the icon with the text
     },
     errorMessage: {

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -39,6 +39,9 @@ const theme = {
             weight: font.weight.regular,
             lineHeight: font.body.lineHeight.small,
         },
+        layout: {
+            marginBlockStart: sizing.size_0,
+        },
     },
     requiredIndicator: {
         color: {

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -30,11 +30,6 @@ const theme = {
             foreground: semanticColor.core.foreground.neutral.default,
         },
     },
-    errorIcon: {
-        layout: {
-            display: "block",
-        },
-    },
     error: {
         color: {
             foreground: semanticColor.core.foreground.critical.subtle,

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -41,6 +41,10 @@ export default mergeTheme(defaultTheme, {
             weight: font.weight.bold,
             lineHeight: font.body.lineHeight.xsmall,
         },
+        layout: {
+            // This aligns the error message with the error icon
+            marginBlockStart: sizing.size_020,
+        },
     },
     requiredIndicator: {
         color: {

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -32,12 +32,6 @@ export default mergeTheme(defaultTheme, {
             foreground: semanticColor.core.foreground.neutral.strong,
         },
     },
-    errorIcon: {
-        layout: {
-            // Error icon is hidden in TB because it is shown in the field instead
-            display: "none",
-        },
-    },
     error: {
         color: {
             foreground: semanticColor.core.foreground.critical.default,

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -43,7 +43,7 @@ export default mergeTheme(defaultTheme, {
         },
         layout: {
             // This aligns the error message with the error icon
-            marginBlockStart: sizing.size_020,
+            marginBlockStart: sizing.size_010,
         },
     },
     requiredIndicator: {


### PR DESCRIPTION
## Summary:

We now show the error icon in the `LabeledField` error message in the Thunderblocks theme too.

We were going to move the error icon and add a readonly icon inside the field in TB in PR https://github.com/Khan/wonder-blocks/pull/2689, however, this would require a change in the TextField DOM structure so that we can place icons in the field (we would need to wrap the underlying `input` element). This is a more involved change since this would mean testing and updating many instances of TextField in the other repos, to make sure layouts and custom styles don't break. 

Design has agreed with keeping the error icon with the message! Adding to the LabeledField component is more flexible, and will also be more consistent with the different form fields (for example, we wouldn't also need to add error/readonly icons to dropdown components too). Design is also working on updating some of the TB designs, which can come later in code once finalized

Issue: WB-1863

## Test plan:

- Confirm that LabeledField in the TB theme has the error icon
- Confirm error and readonly states look as expected (without the icon in the field)

I'll do some integration testing with `frontend` still to make sure there are no unexpected changes!