### PR TITLE
[🔥AUDIT🔥] Dropdown: Fix dropdown labels to use div/span

### DIFF
--- a/.changeset/ninety-feet-guess.md
+++ b/.changeset/ninety-feet-guess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Updates dropdown option item labels to use div/span instead of p to avoid nesting issues

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -151,7 +151,7 @@ export default class ActionItem extends React.Component<ActionProps> {
 
         const labelComponent =
             typeof label === "string" ? (
-                <BodyText lang={lang} style={styles.label}>
+                <BodyText tag="div" lang={lang} style={styles.label}>
                     {label}
                 </BodyText>
             ) : (

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -248,7 +248,11 @@ export default class OptionItem extends React.Component<OptionProps> {
                 }
                 rightAccessory={rightAccessory}
                 subtitle1={subtitle1}
-                title={<BodyText style={styles.label}>{label}</BodyText>}
+                title={
+                    <BodyText tag="div" style={styles.label}>
+                        {label}
+                    </BodyText>
+                }
                 subtitle2={subtitle2}
                 onClick={this.handleClick}
                 tabIndex={parentComponent === "listbox" ? -1 : undefined}

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -177,7 +177,7 @@ export default class SelectOpener extends React.Component<
                 onKeyUp={!disabled ? this.handleKeyUp : undefined}
                 onBlur={onBlur}
             >
-                <BodyText style={styles.text}>
+                <BodyText tag="span" style={styles.text}>
                     {/* Note(tamarab): Prevents unwanted vertical
                                 shift for empty selection.
                         Note2(marcysutton): aria-hidden prevents "space"


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:

Updates dropdown option item labels to use div/span instead of p to avoid
nesting issues

Issue: "none"

## Test plan:

Verify that the dropdown still works as expected, and that the labels
are rendered correctly without any nesting issues.