### PR TITLE
Add shared feedback tokens to semanticColor

### DIFF
--- a/.changeset/small-cats-kick.md
+++ b/.changeset/small-cats-kick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add new semanticColor tokens for feedback

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -204,6 +204,22 @@ and include an icon or label to provide more context and clarity."
     group="feedback.critical.subtle"
 />
 
+#### Shared Actions
+
+##### Subdued
+
+<ColorGroup
+    colors={semanticColor.feedback.shared.actions.subdued}
+    group="feedback.shared.actions.subdued"
+/>
+
+##### Strong
+
+<ColorGroup
+    colors={semanticColor.feedback.shared.actions.strong}
+    group="feedback.shared.actions.strong"
+/>
+
 ### Focus
 
 For focus states on interactive elements. This is meant to be used globally for

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -204,20 +204,20 @@ and include an icon or label to provide more context and clarity."
     group="feedback.critical.subtle"
 />
 
-#### Shared Actions
-
-##### Subdued
-
-<ColorGroup
-    colors={semanticColor.feedback.shared.actions.subdued}
-    group="feedback.shared.actions.subdued"
-/>
+#### Shared
 
 ##### Strong
 
 <ColorGroup
-    colors={semanticColor.feedback.shared.actions.strong}
-    group="feedback.shared.actions.strong"
+    colors={semanticColor.feedback.shared.strong}
+    group="feedback.shared.strong"
+/>
+
+##### Actions
+
+<ColorGroup
+    colors={semanticColor.feedback.shared.actions}
+    group="feedback.shared.actions"
 />
 
 ### Focus

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -177,6 +177,13 @@ and include an icon or label to provide more context and clarity."
     group="feedback.info.subtle"
 />
 
+#### Strong
+
+<ColorGroup
+    colors={semanticColor.feedback.info.strong}
+    group="feedback.info.strong"
+/>
+
 #### Success
 
 ##### Subtle
@@ -205,13 +212,6 @@ and include an icon or label to provide more context and clarity."
 />
 
 #### Shared
-
-##### Strong
-
-<ColorGroup
-    colors={semanticColor.feedback.shared.strong}
-    group="feedback.shared.strong"
-/>
 
 ##### Actions
 

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -177,7 +177,7 @@ and include an icon or label to provide more context and clarity."
     group="feedback.info.subtle"
 />
 
-#### Strong
+##### Strong
 
 <ColorGroup
     colors={semanticColor.feedback.info.strong}
@@ -193,6 +193,13 @@ and include an icon or label to provide more context and clarity."
     group="feedback.success.subtle"
 />
 
+##### Strong
+
+<ColorGroup
+    colors={semanticColor.feedback.success.strong}
+    group="feedback.success.strong"
+/>
+
 #### Warning
 
 ##### Subtle
@@ -200,6 +207,13 @@ and include an icon or label to provide more context and clarity."
 <ColorGroup
     colors={semanticColor.feedback.warning.subtle}
     group="feedback.warning.subtle"
+/>
+
+##### Strong
+
+<ColorGroup
+    colors={semanticColor.feedback.warning.strong}
+    group="feedback.warning.strong"
 />
 
 #### Critical
@@ -210,14 +224,11 @@ and include an icon or label to provide more context and clarity."
     colors={semanticColor.feedback.critical.subtle}
     group="feedback.critical.subtle"
 />
-
-#### Shared
-
-##### Actions
+##### Strong
 
 <ColorGroup
-    colors={semanticColor.feedback.shared.actions}
-    group="feedback.shared.actions"
+    colors={semanticColor.feedback.critical.strong}
+    group="feedback.critical.strong"
 />
 
 ### Focus

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -167,6 +167,12 @@ const text = {
     inverse: core.foreground.inverse.strong,
 };
 
+const sharedFeedbackStrongTokens = {
+    background: core.background.neutral.strong,
+    border: core.border.neutral.strong,
+    text: core.foreground.inverse.strong,
+};
+
 export const semanticColor = mergeTheme(defaultSemanticColor, {
     action: {
         primary: {
@@ -589,6 +595,10 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 icon: core.foreground.instructive.default,
                 text: core.foreground.instructive.strong,
             },
+            strong: {
+                ...sharedFeedbackStrongTokens,
+                icon: core.foreground.instructive.subtle,
+            },
         },
         success: {
             subtle: {
@@ -596,6 +606,10 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 border: core.border.success.subtle,
                 icon: core.foreground.success.default,
                 text: core.foreground.success.strong,
+            },
+            strong: {
+                ...sharedFeedbackStrongTokens,
+                icon: core.foreground.success.subtle,
             },
         },
         warning: {
@@ -605,6 +619,10 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 icon: core.foreground.warning.default,
                 text: core.foreground.warning.strong,
             },
+            strong: {
+                ...sharedFeedbackStrongTokens,
+                icon: core.foreground.warning.subtle,
+            },
         },
         critical: {
             subtle: {
@@ -612,6 +630,10 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 border: core.border.critical.subtle,
                 icon: core.foreground.critical.default,
                 text: core.foreground.critical.strong,
+            },
+            strong: {
+                ...sharedFeedbackStrongTokens,
+                icon: core.foreground.critical.subtle,
             },
         },
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -817,5 +817,15 @@ export const semanticColor = {
                 text: core.foreground.critical.strong,
             },
         },
+        shared: {
+            actions: {
+                subdued: {
+                    foreground: core.foreground.instructive.default,
+                },
+                strong: {
+                    foreground: core.foreground.inverse.strong,
+                },
+            },
+        },
     },
 };

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -157,6 +157,12 @@ const surface = {
     overlay: color.offBlack64,
 };
 
+const sharedFeedbackStrongTokens = {
+    background: core.background.neutral.strong,
+    border: core.border.neutral.strong,
+    text: core.foreground.inverse.strong,
+};
+
 /**
  * TODO(WB-1941): Remove text once we have migrated to the new core.foreground
  * tokens.
@@ -793,9 +799,7 @@ export const semanticColor = {
                 text: core.foreground.instructive.strong,
             },
             strong: {
-                background: core.background.neutral.strong,
-                border: core.border.neutral.strong,
-                text: core.foreground.inverse.strong,
+                ...sharedFeedbackStrongTokens,
                 icon: core.foreground.instructive.subtle,
             },
         },
@@ -806,6 +810,10 @@ export const semanticColor = {
                 icon: core.foreground.success.default,
                 text: core.foreground.success.strong,
             },
+            strong: {
+                ...sharedFeedbackStrongTokens,
+                icon: core.foreground.success.subtle,
+            },
         },
         warning: {
             subtle: {
@@ -813,6 +821,10 @@ export const semanticColor = {
                 border: core.border.warning.default,
                 icon: core.foreground.warning.default,
                 text: core.foreground.warning.strong,
+            },
+            strong: {
+                ...sharedFeedbackStrongTokens,
+                icon: core.foreground.warning.subtle,
             },
         },
         critical: {
@@ -822,11 +834,9 @@ export const semanticColor = {
                 icon: core.foreground.critical.default,
                 text: core.foreground.critical.strong,
             },
-        },
-        shared: {
-            actions: {
-                subdued: core.foreground.instructive.default,
-                strong: core.foreground.inverse.strong,
+            strong: {
+                ...sharedFeedbackStrongTokens,
+                icon: core.foreground.critical.subtle,
             },
         },
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -792,6 +792,12 @@ export const semanticColor = {
                 icon: core.foreground.instructive.default,
                 text: core.foreground.instructive.strong,
             },
+            strong: {
+                background: core.background.neutral.strong,
+                border: core.border.neutral.strong,
+                text: core.foreground.inverse.strong,
+                icon: core.foreground.instructive.subtle,
+            },
         },
         success: {
             subtle: {
@@ -818,11 +824,6 @@ export const semanticColor = {
             },
         },
         shared: {
-            strong: {
-                background: core.background.neutral.strong,
-                border: core.border.neutral.strong,
-                text: core.foreground.inverse.strong,
-            },
             actions: {
                 subdued: core.foreground.instructive.default,
                 strong: core.foreground.inverse.strong,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -818,13 +818,14 @@ export const semanticColor = {
             },
         },
         shared: {
+            strong: {
+                background: core.background.neutral.strong,
+                border: core.border.neutral.strong,
+                text: core.foreground.inverse.strong,
+            },
             actions: {
-                subdued: {
-                    foreground: core.foreground.instructive.default,
-                },
-                strong: {
-                    foreground: core.foreground.inverse.strong,
-                },
+                subdued: core.foreground.instructive.default,
+                strong: core.foreground.inverse.strong,
             },
         },
     },


### PR DESCRIPTION
## Summary:
There are some shared feedback tokens for Toasts to add to semanticColor. This PR introduces those colors for use in Toast components.

Issue: WB-1986

## Test plan:
1, Review foundations-color to see how colors are structured
2. Review naming and structure to ensure it aligns with Figma