### PR TITLE
Use new typography styles for TextField and TextArea

### DIFF
--- a/__docs__/wonder-blocks-typography/typography.stories.tsx
+++ b/__docs__/wonder-blocks-typography/typography.stories.tsx
@@ -2,9 +2,9 @@ import * as React from "react";
 import {css, StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import {View} from "@khanacademy/wonder-blocks-core";
+import {addStyle, View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     Title,
     Heading,
@@ -24,6 +24,7 @@ import {
     Tagline,
     Caption,
     Footnote,
+    styles as typographyStyles,
 } from "@khanacademy/wonder-blocks-typography";
 import packageConfig from "../../packages/wonder-blocks-typography/package.json";
 
@@ -69,6 +70,8 @@ export default {
     },
     argTypes: TypographyArgTypes,
 } as Meta<typeof ComponentInfo>;
+
+const StyledDiv = addStyle("div");
 
 export const ControlProps: StoryObj<typeof Title> = {
     render: (args) => <Title {...args} />,
@@ -429,6 +432,35 @@ LineHeight.parameters = {
         description: {
             story: `This is a visualization of the line height
             for each typography element.`,
+        },
+    },
+};
+
+/**
+ * The following shows the typography styles available.
+ *
+ * ```
+ *     import { styles as typographyStyles } from "@khanacademy/wonder-blocks-typography";
+ * ```
+ */
+export const TypographyStyles: StoryObj = {
+    render: () => {
+        return (
+            <View style={{gap: sizing.size_200}}>
+                {Object.entries(typographyStyles).map(([key, styles]) => (
+                    <StyledDiv key={key} style={{...styles}}>
+                        {key}
+                    </StyledDiv>
+                ))}
+            </View>
+        );
+    },
+    parameters: {
+        chromatic: {
+            modes: {
+                default: allModes.themeDefault,
+                thunderblocks: allModes.themeThunderBlocks,
+            },
         },
     },
 };

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -274,7 +274,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     className={className}
                     style={[
                         styles.textarea,
-                        typographyStyles.LabelMedium,
+                        typographyStyles.BodyTextMediumMediumWeight,
                         resizeType && resizeStyles[resizeType],
                         styles.default,
                         disabled && styles.disabled,

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -229,7 +229,7 @@ const TextField = (props: PropsWithForwardRef) => {
                 <StyledInput
                     style={[
                         styles.input,
-                        typographyStyles.LabelMedium,
+                        typographyStyles.BodyTextMediumMediumWeight,
                         styles.default,
                         disabled && styles.disabled,
                         hasError && styles.error,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -726,7 +726,7 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
         default: {
             border: core.border.neutral.default,
             background: surface.primary,
-            foreground: core.foreground.neutral.default,
+            foreground: core.foreground.neutral.strong,
             placeholder: core.foreground.neutral.subtle,
         },
         checked: {

--- a/packages/wonder-blocks-typography/src/util/styles.ts
+++ b/packages/wonder-blocks-typography/src/util/styles.ts
@@ -6,6 +6,21 @@ const common = {
     display: "block",
 } as const;
 
+const Heading = {
+    ...common,
+    fontFamily: font.family.sans,
+    // weight and size are matched by props, using the combinations below
+    // lineHeight is determined by fontSize on REM scale
+};
+
+const BodyText = {
+    ...common,
+    fontFamily: font.family.sans,
+    margin: 0,
+    // weight and size are matched by props, using the combinations below
+    // lineHeight is determined by fontSize on REM scale
+};
+
 const styles: StyleDeclaration = StyleSheet.create({
     Title: {
         ...common,
@@ -27,130 +42,142 @@ const styles: StyleDeclaration = StyleSheet.create({
         fontSize: font.size.large,
         lineHeight: font.lineHeight.large,
     },
-    Heading: {
-        ...common,
-        fontFamily: font.family.sans,
-        // weight and size are matched by props, using the combinations below
-        // lineHeight is determined by fontSize on REM scale
-    },
+    Heading,
     HeadingSmallBoldWeight: {
+        ...Heading,
         fontSize: font.heading.size.small,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.small,
     },
     HeadingSmallSemiWeight: {
+        ...Heading,
         fontSize: font.heading.size.small,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.small,
     },
     HeadingSmallMediumWeight: {
+        ...Heading,
         fontSize: font.heading.size.small,
         fontWeight: font.weight.medium,
         lineHeight: font.heading.lineHeight.small,
     },
     HeadingMediumBoldWeight: {
+        ...Heading,
         fontSize: font.heading.size.medium,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.medium,
     },
     HeadingMediumSemiWeight: {
+        ...Heading,
         fontSize: font.heading.size.medium,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.medium,
     },
     HeadingMediumMediumWeight: {
+        ...Heading,
         fontSize: font.heading.size.medium,
         fontWeight: font.weight.medium,
         lineHeight: font.heading.lineHeight.medium,
     },
     HeadingLargeBoldWeight: {
+        ...Heading,
         fontSize: font.heading.size.large,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.large,
     },
     HeadingLargeSemiWeight: {
+        ...Heading,
         fontSize: font.heading.size.large,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.large,
     },
     HeadingLargeMediumWeight: {
+        ...Heading,
         fontSize: font.heading.size.large,
         fontWeight: font.weight.medium,
         lineHeight: font.heading.lineHeight.large,
     },
     HeadingXLargeBoldWeight: {
+        ...Heading,
         fontSize: font.heading.size.xlarge,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.xlarge,
     },
     HeadingXLargeMediumWeight: {
+        ...Heading,
         fontSize: font.heading.size.xlarge,
         fontWeight: font.weight.medium,
         lineHeight: font.heading.lineHeight.xlarge,
     },
     HeadingXLargeSemiWeight: {
+        ...Heading,
         fontSize: font.heading.size.xlarge,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.xlarge,
     },
     HeadingXxLargeSemiWeight: {
+        ...Heading,
         fontSize: font.heading.size.xxlarge,
         fontWeight: font.weight.semi,
         lineHeight: font.heading.lineHeight.xxlarge,
     },
     HeadingXxLargeBoldWeight: {
+        ...Heading,
         fontSize: font.heading.size.xxlarge,
         fontWeight: font.weight.bold,
         lineHeight: font.heading.lineHeight.xxlarge,
     },
-    BodyText: {
-        ...common,
-        fontFamily: font.family.sans,
-        margin: 0,
-        // weight and size are matched by props, using the combinations below
-        // lineHeight is determined by fontSize on REM scale
-    },
+    BodyText,
     BodyTextXSmallMediumWeight: {
+        ...BodyText,
         fontSize: font.body.size.xsmall,
         fontWeight: font.weight.medium,
         lineHeight: font.body.lineHeight.xsmall,
     },
     BodyTextXSmallSemiWeight: {
+        ...BodyText,
         fontSize: font.body.size.xsmall,
         fontWeight: font.weight.semi,
         lineHeight: font.body.lineHeight.xsmall,
     },
     BodyTextXSmallBoldWeight: {
+        ...BodyText,
         fontSize: font.body.size.xsmall,
         fontWeight: font.weight.bold,
         lineHeight: font.body.lineHeight.xsmall,
     },
     BodyTextSmallMediumWeight: {
+        ...BodyText,
         fontSize: font.body.size.small,
         fontWeight: font.weight.medium,
         lineHeight: font.body.lineHeight.small,
     },
     BodyTextSmallSemiWeight: {
+        ...BodyText,
         fontSize: font.body.size.small,
         fontWeight: font.weight.semi,
         lineHeight: font.body.lineHeight.small,
     },
     BodyTextSmallBoldWeight: {
+        ...BodyText,
         fontSize: font.body.size.small,
         fontWeight: font.weight.bold,
         lineHeight: font.body.lineHeight.small,
     },
     BodyTextMediumMediumWeight: {
+        ...BodyText,
         fontSize: font.body.size.medium,
         fontWeight: font.weight.medium,
         lineHeight: font.body.lineHeight.medium,
     },
     BodyTextMediumSemiWeight: {
+        ...BodyText,
         fontSize: font.body.size.medium,
         fontWeight: font.weight.semi,
         lineHeight: font.body.lineHeight.medium,
     },
     BodyTextMediumBoldWeight: {
+        ...BodyText,
         fontSize: font.body.size.medium,
         fontWeight: font.weight.bold,
         lineHeight: font.body.lineHeight.medium,


### PR DESCRIPTION
## Summary:

- Using the new typography styles for TextField and TextArea
- Also updated the shared typography styles so it included the base Heading/BodyText styles so that the different typography styles can be used on it's own
  - Also added stories so we can have visual regression tests for the typography styles we export 

Issue: WB-1863

## Test plan:

Confirm the styling of the typography in TextField and TextArea

Confirm the styling in the new typography styles story for Classic and TB themes (`?path=/story/packages-typography--typography-styles&globals=;theme:thunderblocks`)