### PR TITLE
Change core background success strong to green 20

### DIFF
--- a/.changeset/metal-pans-call.md
+++ b/.changeset/metal-pans-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update semantic color core background success strong token to use green 20 instead of green 10 for the Thunderblocks theme

--- a/.changeset/popular-bats-fly.md
+++ b/.changeset/popular-bats-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update learning.foreground.progress.complete.strong to green 10

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -701,7 +701,7 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                     strong: color.yellow_10,
                 },
                 complete: {
-                    strong: color.green_50,
+                    strong: color.green_10,
                 },
             },
         },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -63,7 +63,7 @@ const core = {
         success: {
             subtle: color.green_90,
             default: color.green_30,
-            strong: color.green_10,
+            strong: color.green_20,
         },
         warning: {
             subtle: color.yellow_90,


### PR DESCRIPTION
## Summary:

- Updating core background success strong token value to match updated Figma token value for TB. 
- Also updating learning.foreground.progress.complete strong to green 10

Issue: WB-2010

## Test plan:
- Confirm green 20 is used for the core background success strong token
  - Note: in the docs `?path=/docs/foundations-using-color--docs`, there is a bug with the hex code for the colors. If the color swatch is inspected, it should be using the correct color (`#3C6D4A`)

<img width="289" alt="image" src="https://github.com/user-attachments/assets/165ccb67-60ec-4df7-a4cb-7fc9c2242fa0" />


<img width="302" alt="image" src="https://github.com/user-attachments/assets/94bd1981-12d5-48ff-917c-54d132b0ab11" />

