### PR TITLE
Add `overdue` kind for `DueBadge` and include icons

### DIFF
--- a/.changeset/neat-news-chew.md
+++ b/.changeset/neat-news-chew.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-badge": major
+---
+
+DueBadge: Adds new `kind` prop which can be `due` (default) or `overdue`. The `icon` prop has become a `showIcon` prop now since the icon is provided by the component now. A new `iconAriaLabel` prop is supported now too

--- a/__docs__/wonder-blocks-badge/_overview_.mdx
+++ b/__docs__/wonder-blocks-badge/_overview_.mdx
@@ -37,9 +37,9 @@ A badge that represents a streak.
 
 ## DueBadge
 
-A badge that represents when something is due.
+A badge that represents when something is due or overdue.
 
-<Canvas of={DueBadgeStories.Default} />
+<Canvas of={DueBadgeStories.Kinds} />
 
 ## Badge (Custom Badges)
 

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -55,6 +55,7 @@ export default {
 type StoryComponentType = StoryObj<typeof Badge>;
 
 const statusKinds = ["info", "success", "warning", "critical"] as const;
+const dueKinds = ["due", "overdue"] as const;
 
 const states = [
     commonStates.rest,
@@ -100,6 +101,11 @@ export const StateSheetStory: StoryComponentType = {
         ];
 
         const statusRows = statusKinds.map((kind) => ({
+            name: kind,
+            props: {kind},
+        }));
+
+        const dueBadgeRows = dueKinds.map((kind) => ({
             name: kind,
             props: {kind},
         }));
@@ -153,7 +159,11 @@ export const StateSheetStory: StoryComponentType = {
                     {({props}) => <StreakBadge {...props} />}
                 </StateSheet>
                 <HeadingLarge>Due Badge</HeadingLarge>
-                <StateSheet rows={rows} columns={columns} states={states}>
+                <StateSheet
+                    rows={dueBadgeRows}
+                    columns={columnsWithShowIconProp}
+                    states={states}
+                >
                     {({props}) => <DueBadge {...props} />}
                 </StateSheet>
             </View>
@@ -294,7 +304,6 @@ export const AllBadgesScenarios: StoryComponentType = {
             ...statusKinds.map((kind) => (
                 <StatusBadge label="Badge" kind={kind} />
             )),
-            <DueBadge label="Badge" />,
         ].map((component) =>
             React.cloneElement(component, {
                 icon: <PhosphorIcon icon={IconMappings.cookie} />,
@@ -304,6 +313,7 @@ export const AllBadgesScenarios: StoryComponentType = {
         const badgesWithShowIcon = [
             <GemBadge label="Badge" />,
             <StreakBadge label="Badge" />,
+            ...dueKinds.map((kind) => <DueBadge label="Badge" kind={kind} />),
         ].map((component) =>
             React.cloneElement(component, {
                 showIcon: true,

--- a/__docs__/wonder-blocks-badge/badge.argtypes.ts
+++ b/__docs__/wonder-blocks-badge/badge.argtypes.ts
@@ -22,6 +22,7 @@ export const iconArgType = {
 export const showIconArgType = {
     showIcon: {
         description: "Whether to show the icon. Defaults to `false`.",
+        control: {type: "boolean"},
     },
     iconAriaLabel: {
         description:
@@ -30,7 +31,6 @@ export const showIconArgType = {
 };
 
 export default {
-    ...iconArgType,
     label: {
         // Explicitly adding label prop description since description is not
         // auto-generated due to the union type

--- a/__docs__/wonder-blocks-badge/due-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/due-badge.stories.tsx
@@ -3,21 +3,17 @@ import type {StoryObj} from "@storybook/react";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-badge/package.json";
 import {DueBadge} from "@khanacademy/wonder-blocks-badge";
-import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import singleColoredIcon from "../components/single-colored-icon.svg";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
-import badgeArgtypes, {iconArgType} from "./badge.argtypes";
-import {multiColoredIcon} from "../components/icons-for-testing";
+import badgeArgtypes, {showIconArgType} from "./badge.argtypes";
 import {allModes} from "../../.storybook/modes";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
     title: "Packages / Badge / DueBadge",
     component: DueBadge,
     argTypes: {
         ...badgeArgtypes,
-        ...iconArgType,
+        ...showIconArgType,
     },
     parameters: {
         componentSubtitle: (
@@ -35,50 +31,44 @@ export default {
             },
         },
     },
-    render: (
-        args: Omit<PropsFor<typeof DueBadge>, "icon"> & {icon: string},
-    ) => {
+    render: (args: PropsFor<typeof DueBadge>) => {
         return (
-            <DueBadge
-                {...args}
-                label={args.label || ""}
-                icon={
-                    args.icon ? (
-                        <PhosphorIcon
-                            icon={args.icon}
-                            aria-label={"Example icon"}
-                        />
-                    ) : undefined
-                }
-            />
+            <View style={{flexDirection: "row", gap: sizing.size_160}}>
+                <DueBadge {...args} label={args.label || ""} kind="due" />
+                <DueBadge {...args} label={args.label || ""} kind="overdue" />
+            </View>
         );
     },
 };
 
-type StoryComponentType = StoryObj<
-    // Omit original icon type and replace with string so we can use the IconMapping
-    // for PhosphorIcons
-    Omit<PropsFor<typeof DueBadge>, "icon"> & {icon?: string}
->;
+type StoryComponentType = StoryObj<typeof DueBadge>;
 
 export const Default = {
     args: {
         label: "Badge",
-        icon: "cookie",
+        showIcon: true,
     },
-    render: (
-        args: Omit<PropsFor<typeof DueBadge>, "icon"> & {icon: string},
-    ) => (
-        <DueBadge
-            {...args}
-            label={args.label || ""}
-            icon={
-                args.icon ? (
-                    <PhosphorIcon icon={args.icon} aria-label="Example icon" />
-                ) : undefined
-            }
-        />
-    ),
+    render: (args: PropsFor<typeof DueBadge>) => {
+        return <DueBadge {...args} label={args.label || ""} />;
+    },
+};
+
+/**
+ * The `DueBadge` supports two kinds: `due` and `overdue`. By default, the
+ * `due` kind is used.
+ */
+export const Kinds: StoryComponentType = {
+    args: {
+        showIcon: true,
+    },
+    render: (args: PropsFor<typeof DueBadge>) => {
+        return (
+            <View style={{flexDirection: "row", gap: sizing.size_160}}>
+                <DueBadge {...args} label={"Due"} kind="due" />
+                <DueBadge {...args} label={"Overdue"} kind="overdue" />
+            </View>
+        );
+    },
 };
 
 /**
@@ -91,84 +81,20 @@ export const LabelOnly: StoryComponentType = {
 };
 
 /**
- * A badge can be used with only an icon.
+ * Set `showIcon` to `true` to show the icon only. Alt text for the icon can be
+ * set using the `iconAriaLabel` prop.
  */
 export const IconOnly: StoryComponentType = {
-    args: {
-        icon: "cookie",
-    },
-};
-
-/**
- * For more details about using custom icons, see the Badge docs for custom icons.
- */
-export const CustomIcons: StoryComponentType = {
-    render: () => {
+    render: (args: PropsFor<typeof DueBadge>) => {
         return (
-            <View style={{gap: sizing.size_240}}>
-                <HeadingLarge>
-                    Custom single colored svg icon using PhosphorIcon
-                </HeadingLarge>
+            <View style={{flexDirection: "row", gap: sizing.size_160}}>
+                <DueBadge showIcon={true} iconAriaLabel="Due" kind="due" />
                 <DueBadge
-                    icon={
-                        <PhosphorIcon
-                            icon={singleColoredIcon}
-                            aria-label="Crown"
-                        />
-                    }
-                    label="Custom Icon"
-                />
-                <HeadingLarge>
-                    Custom single colored svg icon using PhosphorIcon and color
-                    prop
-                </HeadingLarge>
-                <DueBadge
-                    icon={
-                        <PhosphorIcon
-                            icon={singleColoredIcon}
-                            aria-label="Crown"
-                            color={semanticColor.icon.primary}
-                        />
-                    }
-                    label="Custom Icon"
-                />
-                <HeadingLarge>
-                    Custom multi-colored inline svg using the Icon component
-                </HeadingLarge>
-                <DueBadge
-                    icon={<Icon>{multiColoredIcon}</Icon>}
-                    label="Custom Icon"
-                />
-                <HeadingLarge>
-                    Custom img element using the Icon component with a svg src
-                </HeadingLarge>
-                <DueBadge
-                    icon={
-                        <Icon>
-                            <img src={"logo.svg"} alt="Wonder Blocks" />
-                        </Icon>
-                    }
-                    label="Custom Icon"
-                />
-                <HeadingLarge>
-                    Custom img element using the Icon component with a png src
-                </HeadingLarge>
-                <DueBadge
-                    icon={
-                        <Icon>
-                            <img src="avatar.png" alt="Example avatar" />
-                        </Icon>
-                    }
-                    label="Custom Icon"
+                    showIcon={true}
+                    iconAriaLabel="Overdue"
+                    kind="overdue"
                 />
             </View>
         );
-    },
-    parameters: {
-        chromatic: {
-            // Enable snapshots for this story so we can verify custom icons
-            // are used correctly
-            disableSnapshot: false,
-        },
     },
 };

--- a/packages/wonder-blocks-badge/package.json
+++ b/packages/wonder-blocks-badge/package.json
@@ -23,6 +23,7 @@
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
+    "@phosphor-icons/core": "catalog:",
     "aphrodite": "catalog:",
     "react": "catalog:"
   },

--- a/packages/wonder-blocks-badge/src/components/__tests__/badge.typestest.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/badge.typestest.tsx
@@ -43,9 +43,15 @@ const icon = <PhosphorIcon icon={cookie} aria-label="Cookie" />;
 
 <DueBadge label="Badge label" />;
 
-<DueBadge label="Badge label" icon={icon} />;
+<DueBadge showIcon={true} iconAriaLabel="Due" />;
 
-<DueBadge icon={icon} />;
+// @ts-expect-error -- iconAriaLabel is required when showIcon is true and there is no label
+<DueBadge showIcon={true} />;
+
+// iconAriaLabel is not required if label is provided
+<DueBadge showIcon={true} label="Badge" />;
+
+<DueBadge showIcon={true} label="Badge" iconAriaLabel="Due" />;
 
 /**
  * GemBadge

--- a/packages/wonder-blocks-badge/src/components/__tests__/due-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/due-badge.test.tsx
@@ -15,25 +15,48 @@ describe("DueBadge", () => {
         expect(badge).toBeInTheDocument();
     });
 
-    it("should render the icon", () => {
+    it("should render the icon with alt text", () => {
         // Arrange
-        const icon = <svg data-testid="icon-example" />;
-        render(<DueBadge icon={icon} />);
+        render(<DueBadge showIcon={true} iconAriaLabel="Due" />);
 
         // Act
-        const iconElement = screen.getByTestId("icon-example");
+        const iconElement = screen.getByRole("img", {
+            name: "Due",
+        });
 
         // Assert
         expect(iconElement).toBeInTheDocument();
     });
 
-    it("should not render anything if the label is an empty string and there is no icon", () => {
+    it("should not have an img role if showIcon is true and no alt text is provided", () => {
+        // Arrange
+        render(<DueBadge showIcon={true} label="Badge" />);
+
+        // Act
+        const iconElement = screen.queryByRole("img");
+
+        // Assert
+        expect(iconElement).not.toBeInTheDocument();
+    });
+
+    it("should not render anything if there is an empty label and showIcon is false", () => {
         // Arrange
         // Act
-        const {container} = render(<DueBadge label="" />);
+        const {container} = render(<DueBadge label="" showIcon={false} />);
 
         // Assert
         expect(container).toBeEmptyDOMElement();
+    });
+
+    it("should not render the icon if showIcon is not set", () => {
+        // Arrange
+        render(<DueBadge label="Badge" />);
+
+        // Act
+        const iconElement = screen.queryByRole("img");
+
+        // Assert
+        expect(iconElement).not.toBeInTheDocument();
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-badge/src/components/__tests__/due-badge.test.tsx
+++ b/packages/wonder-blocks-badge/src/components/__tests__/due-badge.test.tsx
@@ -67,33 +67,36 @@ describe("DueBadge", () => {
                 const {container} = render(
                     <DueBadge
                         label="Badge label"
-                        icon={<img src="/" alt="Example icon" />}
+                        showIcon={true}
+                        iconAriaLabel="Due"
                     />,
                 );
 
                 // Assert
                 await expect(container).toHaveNoA11yViolations();
             });
+        });
 
-            it("should not have violations if there is no label", async () => {
-                // Arrange
-                // Act
-                const {container} = render(
-                    <DueBadge icon={<img src="/" alt="Example icon" />} />,
-                );
+        it("should not have violations if there is no label", async () => {
+            // Arrange
+            // Act
+            const {container} = render(
+                <DueBadge showIcon={true} iconAriaLabel="Due" />,
+            );
 
-                // Assert
-                await expect(container).toHaveNoA11yViolations();
-            });
+            // Assert
+            await expect(container).toHaveNoA11yViolations();
+        });
 
-            it("should not have violations if there is no icon", async () => {
-                // Arrange
-                // Act
-                const {container} = render(<DueBadge label="Badge label" />);
+        it("should not have violations if there is no icon", async () => {
+            // Arrange
+            // Act
+            const {container} = render(
+                <DueBadge showIcon={false} label="Badge" />,
+            );
 
-                // Assert
-                await expect(container).toHaveNoA11yViolations();
-            });
+            // Assert
+            await expect(container).toHaveNoA11yViolations();
         });
     });
 });

--- a/packages/wonder-blocks-badge/src/components/due-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/due-badge.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import DateIcon from "@phosphor-icons/core/bold/calendar-blank-bold.svg";
+import WarningCircle from "@phosphor-icons/core/bold/warning-circle-bold.svg";
 import {Badge} from "./badge";
-import {BaseBadgeProps, IconLabelProps} from "../types";
+import {BaseBadgeProps, ShowIconProps} from "../types";
 
 type Props = BaseBadgeProps &
-    IconLabelProps & {
+    ShowIconProps & {
         /**
          * The kind of due badge. Defaults to `due`.
          */
@@ -16,14 +19,43 @@ type Props = BaseBadgeProps &
  * A badge that communicates when a task is due.
  *
  * `DueBadge` uses the `Badge` component and applies the appropriate styles
- * for the status kinds. For more details, see the `Badge` docs.
+ * for the kinds.
+ *
+ * Note: The `iconAriaLabel` prop can be used to set an `aria-label` on the icon
+ * if `showIcon` is `true`. This is helpful for providing context to screen
+ * readers about what the badge is communicating.
+ *
+ * For more details, see the `Badge` docs.
  */
 const DueBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
-    const {kind = "due", ...otherProps} = props;
+    const {
+        kind = "due",
+        showIcon = false,
+        label,
+        iconAriaLabel,
+        ...otherProps
+    } = props;
+
+    let icon;
+    switch (kind) {
+        case "due":
+            icon = DateIcon;
+            break;
+        case "overdue":
+            icon = WarningCircle;
+            break;
+    }
+
     return (
         <Badge
             ref={ref}
             {...otherProps}
+            label={label || ""}
+            icon={
+                showIcon ? (
+                    <PhosphorIcon icon={icon} aria-label={iconAriaLabel} />
+                ) : undefined
+            }
             styles={{
                 ...otherProps.styles,
                 root: [

--- a/packages/wonder-blocks-badge/src/components/due-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/due-badge.tsx
@@ -78,7 +78,8 @@ export {DueBadge};
 const styles = StyleSheet.create({
     dueBadge: {
         backgroundColor: semanticColor.learning.background.due.subtle,
-        borderColor: semanticColor.learning.background.due.subtle, // Border should be the same as the background
+        // Border should be the same as the background
+        borderColor: semanticColor.learning.background.due.subtle,
         color: semanticColor.learning.foreground.due.strong,
     },
     dueIcon: {

--- a/packages/wonder-blocks-badge/src/components/due-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/due-badge.tsx
@@ -4,7 +4,13 @@ import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {Badge} from "./badge";
 import {BaseBadgeProps, IconLabelProps} from "../types";
 
-type Props = BaseBadgeProps & IconLabelProps;
+type Props = BaseBadgeProps &
+    IconLabelProps & {
+        /**
+         * The kind of due badge. Defaults to `due`.
+         */
+        kind?: "due" | "overdue";
+    };
 
 /**
  * A badge that communicates when a task is due.
@@ -13,15 +19,23 @@ type Props = BaseBadgeProps & IconLabelProps;
  * for the status kinds. For more details, see the `Badge` docs.
  */
 const DueBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
-    const {...otherProps} = props;
+    const {kind = "due", ...otherProps} = props;
     return (
         <Badge
             ref={ref}
             {...otherProps}
             styles={{
                 ...otherProps.styles,
-                root: [styles.dueBadge, otherProps.styles?.root],
-                icon: [styles.dueIcon, otherProps.styles?.icon],
+                root: [
+                    kind === "due" && styles.dueBadge,
+                    kind === "overdue" && styles.overdueBadge,
+                    otherProps.styles?.root,
+                ],
+                icon: [
+                    kind === "due" && styles.dueIcon,
+                    kind === "overdue" && styles.overdueIcon,
+                    otherProps.styles?.icon,
+                ],
             }}
         />
     );
@@ -52,5 +66,14 @@ const styles = StyleSheet.create({
     },
     dueIcon: {
         color: dueBadgeTokens.icon.color.foreground,
+    },
+    overdueBadge: {
+        backgroundColor: semanticColor.core.background.critical.subtle,
+        // Border should be the same as the background
+        borderColor: semanticColor.core.background.critical.subtle,
+        color: semanticColor.core.foreground.critical.strong,
+    },
+    overdueIcon: {
+        color: semanticColor.core.foreground.critical.default,
     },
 });

--- a/packages/wonder-blocks-badge/src/components/due-badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/due-badge.tsx
@@ -43,29 +43,14 @@ const DueBadge = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
 
 export {DueBadge};
 
-const dueBadgeTokens = {
-    root: {
-        color: {
-            background: semanticColor.learning.background.due.subtle,
-            border: semanticColor.learning.background.due.subtle, // Border should be the same as the background
-            foreground: semanticColor.learning.foreground.due.strong,
-        },
-    },
-    icon: {
-        color: {
-            foreground: semanticColor.learning.foreground.due.default,
-        },
-    },
-};
-
 const styles = StyleSheet.create({
     dueBadge: {
-        backgroundColor: dueBadgeTokens.root.color.background,
-        borderColor: dueBadgeTokens.root.color.border,
-        color: dueBadgeTokens.root.color.foreground,
+        backgroundColor: semanticColor.learning.background.due.subtle,
+        borderColor: semanticColor.learning.background.due.subtle, // Border should be the same as the background
+        color: semanticColor.learning.foreground.due.strong,
     },
     dueIcon: {
-        color: dueBadgeTokens.icon.color.foreground,
+        color: semanticColor.learning.foreground.due.default,
     },
     overdueBadge: {
         backgroundColor: semanticColor.core.background.critical.subtle,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       '@khanacademy/wonder-blocks-typography':
         specifier: workspace:*
         version: link:../wonder-blocks-typography
+      '@phosphor-icons/core':
+        specifier: 'catalog:'
+        version: 2.1.1
       aphrodite:
         specifier: 'catalog:'
         version: 1.2.5


### PR DESCRIPTION
## Summary:

- DueBadge: Adds support for a `kind` prop that can be `due` (default) or `overdue`
- The icon is now provided by the component. There is now a `showIcon` and `iconAriaLabel` prop instead of an `icon` prop that supports any icon

Issue: WB-2009

Figma design: https://www.figma.com/design/e9qdyiDUBZ3rDabP9S7ulO/%E2%9A%A1%EF%B8%8F-Handshake?node-id=4033-12008&m=dev

## Test plan:

Confirm the styling and docs for the DueBadge with `kind="overdue"`
- `?path=/docs/packages-badge-duebadge--docs`
- `?path=/docs/packages-badge-testing-snapshots--docs`
- `?path=/docs/packages-badge-overview--docs`

<img width="200" alt="image" src="https://github.com/user-attachments/assets/5682a4ed-f692-4e46-9dc5-358c749fec42" />
