### PR TITLE
Add `readOnlyMessage` prop for `LabeledField`

### DIFF
--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -151,6 +151,7 @@ const scenarios = [
             description: "Helpful description text.",
             errorMessage: "Message about the error",
             required: "Custom required message",
+            readOnlyMessage: "Message about the read only state",
             styles: {
                 root: {
                     padding: sizing.size_080,
@@ -163,27 +164,6 @@ const scenarios = [
                 },
                 error: {
                     paddingBlockStart: sizing.size_020,
-                },
-            },
-        },
-    },
-    {
-        name: "Custom styles with read only message",
-        props: {
-            field: <TextField value="" onChange={() => {}} />,
-            label: "Name",
-            description: "Helpful description text.",
-            readOnlyMessage: "Message about the read only state",
-            required: "Custom required message",
-            styles: {
-                root: {
-                    padding: sizing.size_080,
-                },
-                label: {
-                    paddingBlockEnd: sizing.size_020,
-                },
-                description: {
-                    paddingBlockEnd: sizing.size_020,
                 },
                 readOnlyMessage: {
                     paddingBlockStart: sizing.size_020,

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -115,7 +115,6 @@ const scenarios = [
             description: "Helpful description text.",
             errorMessage: "Message about the error",
             required: "Custom required message",
-            readOnlyMessage: "Message about why it is read only",
         },
     },
     {
@@ -164,6 +163,30 @@ const scenarios = [
         },
     },
     {
+        name: "Custom styles with read only message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            readOnlyMessage: "Message about the read only state",
+            required: "Custom required message",
+            styles: {
+                root: {
+                    padding: sizing.size_080,
+                },
+                label: {
+                    paddingBlockEnd: sizing.size_020,
+                },
+                description: {
+                    paddingBlockEnd: sizing.size_020,
+                },
+                readOnlyMessage: {
+                    paddingBlockStart: sizing.size_020,
+                },
+            },
+        },
+    },
+    {
         name: "With disabled field",
         props: {
             field: <TextField value="" onChange={() => {}} disabled />,
@@ -200,6 +223,17 @@ const scenarios = [
             description: "Helpful description text.",
             required: true,
             readOnlyMessage: longTextWithNoWordBreak,
+        },
+    },
+    {
+        name: "Readonly + Error State",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            errorMessage: "Message about the error",
+            required: "Custom required message",
+            readOnlyMessage: "Message about the read only state",
         },
     },
 ];

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -115,6 +115,7 @@ const scenarios = [
             description: "Helpful description text.",
             errorMessage: "Message about the error",
             required: "Custom required message",
+            readOnlyMessage: "Read Only",
         },
     },
     {
@@ -179,6 +180,26 @@ const scenarios = [
             description: "Helpful description text.",
             required: true,
             readOnlyMessage: "Read Only",
+        },
+    },
+    {
+        name: "With long read only message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            required: true,
+            readOnlyMessage: longText,
+        },
+    },
+    {
+        name: "With long read only message and no word break",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            required: true,
+            readOnlyMessage: longTextWithNoWordBreak,
         },
     },
 ];

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -171,6 +171,16 @@ const scenarios = [
             required: true,
         },
     },
+    {
+        name: "With read only message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            required: true,
+            readOnlyMessage: "Read Only",
+        },
+    },
 ];
 
 /**

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -115,7 +115,7 @@ const scenarios = [
             description: "Helpful description text.",
             errorMessage: "Message about the error",
             required: "Custom required message",
-            readOnlyMessage: "Read Only",
+            readOnlyMessage: "Message about why it is read only",
         },
     },
     {
@@ -179,7 +179,7 @@ const scenarios = [
             label: "Name",
             description: "Helpful description text.",
             required: true,
-            readOnlyMessage: "Read Only",
+            readOnlyMessage: "Message about why it is read only",
         },
     },
     {

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -136,6 +136,11 @@ const scenarios = [
                     <b>Error</b> <i>using</i> <u>JSX</u>
                 </span>
             ),
+            readOnlyMessage: (
+                <span>
+                    <b>Read</b> <i>only </i> <u>message</u>
+                </span>
+            ),
         },
     },
     {

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -382,7 +382,11 @@ export const Fields: StoryComponentType = {
                 <Heading>Disabled</Heading>
                 <AllFields {...args} disabled />
                 <Heading>Read Only</Heading>
-                <AllFields {...args} readOnly={true} textValue={"Value"} />
+                <AllFields
+                    {...args}
+                    textValue={"Value"}
+                    readOnlyMessage="Read Only"
+                />
             </View>
         );
     },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -372,7 +372,7 @@ export const Fields: StoryComponentType = {
                 <AllFields
                     {...args}
                     textValue={"Value"}
-                    readOnlyMessage="Read Only"
+                    readOnlyMessage="Message about why it is read only"
                 />
             </View>
         );

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -76,7 +76,6 @@ const AllFields = (
         shouldValidateInStory?: boolean;
         showSubmitButtonInStory?: boolean;
         disabled?: boolean;
-        readOnly?: boolean;
         textValue?: string;
     },
 ) => {
@@ -84,7 +83,6 @@ const AllFields = (
         shouldValidateInStory,
         showSubmitButtonInStory,
         disabled,
-        readOnly,
         textValue,
         ...args
     } = storyArgs;
@@ -245,7 +243,6 @@ const AllFields = (
                         }
                         instantValidation={false}
                         disabled={disabled}
-                        readOnly={readOnly}
                     />
                 }
             />
@@ -265,86 +262,76 @@ const AllFields = (
                         }
                         instantValidation={false}
                         disabled={disabled}
-                        readOnly={readOnly}
                     />
                 }
             />
 
-            {/* SingleSelect does not support readonly state */}
-            {!readOnly && (
-                <LabeledField
-                    {...args}
-                    errorMessage={singleSelectErrorMessage}
-                    label="Single Select"
-                    description={selectDescription}
-                    field={
-                        <SingleSelect
-                            // ref={singleSelectRef} // TODO(WB-1841) once SingleSelect supports ref
-                            placeholder="Choose a fruit"
-                            selectedValue={singleSelectValue}
-                            onChange={setSingleSelectValue}
-                            onValidate={setSingleSelectErrorMessage}
-                            validate={singleSelectValidate}
-                            disabled={disabled}
-                        >
-                            <OptionItem label="Mango" value="mango" />
-                            <OptionItem label="Strawberry" value="strawberry" />
-                            <OptionItem label="Banana" value="banana" />
-                        </SingleSelect>
-                    }
-                />
-            )}
+            <LabeledField
+                {...args}
+                errorMessage={singleSelectErrorMessage}
+                label="Single Select"
+                description={selectDescription}
+                field={
+                    <SingleSelect
+                        // ref={singleSelectRef} // TODO(WB-1841) once SingleSelect supports ref
+                        placeholder="Choose a fruit"
+                        selectedValue={singleSelectValue}
+                        onChange={setSingleSelectValue}
+                        onValidate={setSingleSelectErrorMessage}
+                        validate={singleSelectValidate}
+                        disabled={disabled}
+                    >
+                        <OptionItem label="Mango" value="mango" />
+                        <OptionItem label="Strawberry" value="strawberry" />
+                        <OptionItem label="Banana" value="banana" />
+                    </SingleSelect>
+                }
+            />
 
-            {/* MultiSelect does not support readonly state */}
-            {!readOnly && (
-                <LabeledField
-                    {...args}
-                    errorMessage={multiSelectErrorMessage}
-                    label="Multi Select"
-                    description={selectDescription}
-                    field={
-                        <MultiSelect
-                            // ref={multiSelectRef} // TODO(WB-1841) once MultiSelect supports ref
-                            selectedValues={multiSelectValue}
-                            onChange={setMultiSelectValue}
-                            onValidate={setMultiSelectErrorMessage}
-                            validate={
-                                shouldValidateInStory
-                                    ? multiSelectValidate
-                                    : undefined
-                            }
-                            disabled={disabled}
-                        >
-                            <OptionItem label="Mango" value="mango" />
-                            <OptionItem label="Strawberry" value="strawberry" />
-                            <OptionItem label="Banana" value="banana" />
-                        </MultiSelect>
-                    }
-                />
-            )}
+            <LabeledField
+                {...args}
+                errorMessage={multiSelectErrorMessage}
+                label="Multi Select"
+                description={selectDescription}
+                field={
+                    <MultiSelect
+                        // ref={multiSelectRef} // TODO(WB-1841) once MultiSelect supports ref
+                        selectedValues={multiSelectValue}
+                        onChange={setMultiSelectValue}
+                        onValidate={setMultiSelectErrorMessage}
+                        validate={
+                            shouldValidateInStory
+                                ? multiSelectValidate
+                                : undefined
+                        }
+                        disabled={disabled}
+                    >
+                        <OptionItem label="Mango" value="mango" />
+                        <OptionItem label="Strawberry" value="strawberry" />
+                        <OptionItem label="Banana" value="banana" />
+                    </MultiSelect>
+                }
+            />
 
-            {/* SearchField does not support readonly state */}
-            {!readOnly && (
-                <LabeledField
-                    {...args}
-                    errorMessage={searchErrorMessage}
-                    label="Search"
-                    description={textDescription}
-                    field={
-                        <SearchField
-                            ref={searchRef}
-                            value={searchValue}
-                            onChange={setSearchValue}
-                            validate={
-                                shouldValidateInStory ? textValidate : undefined
-                            }
-                            onValidate={setSearchErrorMessage}
-                            instantValidation={false}
-                            disabled={disabled}
-                        />
-                    }
-                />
-            )}
+            <LabeledField
+                {...args}
+                errorMessage={searchErrorMessage}
+                label="Search"
+                description={textDescription}
+                field={
+                    <SearchField
+                        ref={searchRef}
+                        value={searchValue}
+                        onChange={setSearchValue}
+                        validate={
+                            shouldValidateInStory ? textValidate : undefined
+                        }
+                        onValidate={setSearchErrorMessage}
+                        instantValidation={false}
+                        disabled={disabled}
+                    />
+                }
+            />
 
             {showSubmitButtonInStory && <Button type="submit">Submit</Button>}
         </StyledForm>

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -75,6 +75,43 @@ describe("LabeledField", () => {
         expect(screen.getByText(errorMessage)).toBeInTheDocument();
     });
 
+    it("LabeledField renders the read only message text", () => {
+        // Arrange
+        const readOnlyMessage = "Read only message";
+
+        // Act
+        render(
+            <LabeledField
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                readOnlyMessage={readOnlyMessage}
+            />,
+            defaultOptions,
+        );
+
+        // Assert
+        expect(screen.getByText(readOnlyMessage)).toBeInTheDocument();
+    });
+
+    it("LabeledField does not render the read only message text if there is an error message", () => {
+        // Arrange
+        const readOnlyMessage = "Read only message";
+
+        // Act
+        render(
+            <LabeledField
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                readOnlyMessage={readOnlyMessage}
+                errorMessage="Error message"
+            />,
+            defaultOptions,
+        );
+
+        // Assert
+        expect(screen.queryByText(readOnlyMessage)).not.toBeInTheDocument();
+    });
+
     it("LabeledField adds testId to label", () => {
         // Arrange
         const testId = "testid";
@@ -683,6 +720,85 @@ describe("LabeledField", () => {
 
             // Assert
             await screen.findByText(requiredMessage);
+        });
+    });
+
+    describe("Read Only", () => {
+        it("Should set the readOnly prop on the field if the readOnlyMessage prop is set", () => {
+            // Arrange
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                    readOnlyMessage="Read only message"
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const field = screen.getByRole("textbox");
+
+            // Assert
+            expect(field).toHaveAttribute("readOnly");
+        });
+
+        it("Should not set the readOnly prop on the field if the readOnlyMessage prop is not set", () => {
+            // Arrange
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const field = screen.getByRole("textbox");
+
+            // Assert
+            expect(field).not.toHaveAttribute("readOnly");
+        });
+
+        it("Should persist the readOnly attribute on the field if it is set on the field", () => {
+            // Arrange
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} readOnly />}
+                    label="Label"
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const field = screen.getByRole("textbox");
+
+            // Assert
+            expect(field).toHaveAttribute("readOnly");
+        });
+
+        it("Should set an aria-label on the read only icon if provided", () => {
+            // Arrange
+            const readOnlyAriaLabel = "Aria label for read only icon";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                    readOnlyMessage="Read only message"
+                    labels={{readOnlyAriaLabel}}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const readOnlyIcon = screen.getByRole("img", {
+                name: readOnlyAriaLabel,
+            });
+
+            // Assert
+            expect(readOnlyIcon).toHaveAttribute(
+                "aria-label",
+                readOnlyAriaLabel,
+            );
         });
     });
 });

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -93,11 +93,9 @@ describe("LabeledField", () => {
         expect(screen.getByText(readOnlyMessage)).toBeInTheDocument();
     });
 
-    it("LabeledField does not render the read only message text if there is an error message", () => {
+    it("LabeledField renders the read only message text if there is an error message", () => {
         // Arrange
         const readOnlyMessage = "Read only message";
-
-        // Act
         render(
             <LabeledField
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
@@ -108,8 +106,31 @@ describe("LabeledField", () => {
             defaultOptions,
         );
 
+        // Act
+        const readOnlyMessageEl = screen.getByText(readOnlyMessage);
+
         // Assert
-        expect(screen.queryByText(readOnlyMessage)).not.toBeInTheDocument();
+        expect(readOnlyMessageEl).toBeInTheDocument();
+    });
+
+    it("LabeledField renders the error message text if there is also a read only message", () => {
+        // Arrange
+        const readOnlyMessage = "Read only message";
+        render(
+            <LabeledField
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                readOnlyMessage={readOnlyMessage}
+                errorMessage="Error message"
+            />,
+            defaultOptions,
+        );
+
+        // Act
+        const errorMessageEl = screen.getByText(errorMessage);
+
+        // Assert
+        expect(errorMessageEl).toBeInTheDocument();
     });
 
     it("LabeledField adds testId to label", () => {

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -16,11 +16,14 @@ describe("LabeledField", () => {
     const description = "Description of the field";
     const errorMessage = "Error message";
     const testId = "test-id";
+    const readOnlyMessage = "Read only message";
 
     const getLabel = () => screen.getByText(label);
     const getDescription = () => screen.getByText(description);
     const getField = () => screen.getByRole("textbox");
     const getError = () => screen.getByTestId("test-id-error");
+    const getReadOnlyMessage = () =>
+        screen.getByTestId("test-id-read-only-message");
 
     it("LabeledField renders the label text", () => {
         // Arrange
@@ -192,6 +195,28 @@ describe("LabeledField", () => {
         expect(error).toBeInTheDocument();
     });
 
+    it("LabeledField adds testId to read only message", () => {
+        // Arrange
+        const testId = "testid";
+
+        // Act
+        render(
+            <LabeledField
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                readOnlyMessage="Read only message"
+                testId={testId}
+            />,
+            defaultOptions,
+        );
+
+        // Assert
+        const readOnlyMessage = screen.getByTestId(
+            `${testId}-read-only-message`,
+        );
+        expect(readOnlyMessage).toBeInTheDocument();
+    });
+
     describe("Labels prop", () => {
         it("should use the errorIconAriaLabel for the error icon aria label", () => {
             // Arrange
@@ -233,6 +258,31 @@ describe("LabeledField", () => {
             // Assert
             expect(errorIcon).toHaveAttribute("aria-label", "Error:");
         });
+
+        it("Should set an aria-label on the read only icon if provided", () => {
+            // Arrange
+            const readOnlyAriaLabel = "Aria label for read only icon";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                    readOnlyMessage="Read only message"
+                    labels={{readOnlyAriaLabel}}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const readOnlyIcon = screen.getByRole("img", {
+                name: readOnlyAriaLabel,
+            });
+
+            // Assert
+            expect(readOnlyIcon).toHaveAttribute(
+                "aria-label",
+                readOnlyAriaLabel,
+            );
+        });
     });
 
     describe("Attributes", () => {
@@ -242,6 +292,11 @@ describe("LabeledField", () => {
                 ["description", `${id}-description`, getDescription],
                 ["field", `${id}-field`, getField],
                 ["error", `${id}-error`, getError],
+                [
+                    "read only message",
+                    `${id}-read-only-message`,
+                    getReadOnlyMessage,
+                ],
             ])(
                 "should have the id for the %s element set to %s",
                 (
@@ -258,6 +313,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             testId={testId}
+                            readOnlyMessage={readOnlyMessage}
                         />,
                         defaultOptions,
                     );
@@ -275,6 +331,7 @@ describe("LabeledField", () => {
                 ["description", "-description", getDescription],
                 ["field", "-field", getField],
                 ["error", "-error", getError],
+                ["read only message", "-read-only-message", getReadOnlyMessage],
             ])(
                 "should have an auto-generated id for the %s element that ends with %s",
                 (
@@ -290,6 +347,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             testId={testId}
+                            readOnlyMessage={readOnlyMessage}
                         />,
                         defaultOptions,
                     );
@@ -309,6 +367,11 @@ describe("LabeledField", () => {
                 ["description", `${testId}-description`, getDescription],
                 ["field", `${testId}-field`, getField],
                 ["error", `${testId}-error`, getError],
+                [
+                    "read only message",
+                    `${testId}-read-only-message`,
+                    getReadOnlyMessage,
+                ],
             ])(
                 "should use the testId prop to set the %s element's data-testid attribute to %s",
                 (
@@ -324,6 +387,7 @@ describe("LabeledField", () => {
                             label={label}
                             description={description}
                             errorMessage={errorMessage}
+                            readOnlyMessage={readOnlyMessage}
                         />,
                         defaultOptions,
                     );
@@ -356,6 +420,23 @@ describe("LabeledField", () => {
                         return el;
                     },
                 ],
+                [
+                    "read only message",
+                    () => {
+                        // In order to get the read error message section (icon + message)
+                        // without using testId, we get the parent of the read error
+                        // text
+                        const el =
+                            // eslint-disable-next-line testing-library/no-node-access
+                            screen.getByText(readOnlyMessage).parentElement;
+                        if (!el) {
+                            throw Error(
+                                "Read only message section in LabeledField not found",
+                            );
+                        }
+                        return el;
+                    },
+                ],
             ])(
                 "should not set the data-testid attribute on the %s element if the testId prop is not set",
                 (
@@ -369,6 +450,7 @@ describe("LabeledField", () => {
                             label={label}
                             description={description}
                             errorMessage={errorMessage}
+                            readOnlyMessage={readOnlyMessage}
                         />,
                         defaultOptions,
                     );
@@ -419,6 +501,23 @@ describe("LabeledField", () => {
                     />,
                     defaultOptions,
                 );
+                // Act
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+
+            it("should have no accessibility violations if the readOnlyMessage prop is set", async () => {
+                // Arrange
+                const {container} = render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        readOnlyMessage="Read only message"
+                    />,
+                    defaultOptions,
+                );
+
                 // Act
 
                 // Assert
@@ -539,6 +638,60 @@ describe("LabeledField", () => {
 
                 // Assert
                 expect(errorSectionEl).toHaveAttribute("aria-atomic", "true");
+            });
+
+            it("Should set aria-describedby on the field to the id of the read only message", () => {
+                // Arrange
+                const readOnlyMessage = "Read only message";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        readOnlyMessage={readOnlyMessage}
+                        testId="labeled-field"
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const readOnlyMessageEl = screen.getByTestId(
+                    "labeled-field-read-only-message",
+                );
+                const inputEl = screen.getByRole("textbox");
+
+                // Assert
+                expect(inputEl).toHaveAttribute(
+                    "aria-describedby",
+                    readOnlyMessageEl.id,
+                );
+            });
+
+            it("Should support multiple aria-describedby attributes on the field", () => {
+                // Arrange
+                const readOnlyMessage = "Read only message";
+                const errorMessage = "Error message";
+                const description = "Description of the field";
+                const id = "example-id";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        readOnlyMessage={readOnlyMessage}
+                        errorMessage={errorMessage}
+                        description={description}
+                        id={id}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const field = screen.getByRole("textbox");
+
+                // Assert
+                expect(field).toHaveAttribute(
+                    "aria-describedby",
+                    `${id}-description ${id}-error ${id}-read-only-message`,
+                );
             });
         });
     });
@@ -795,31 +948,6 @@ describe("LabeledField", () => {
 
             // Assert
             expect(field).toHaveAttribute("readOnly");
-        });
-
-        it("Should set an aria-label on the read only icon if provided", () => {
-            // Arrange
-            const readOnlyAriaLabel = "Aria label for read only icon";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    label="Label"
-                    readOnlyMessage="Read only message"
-                    labels={{readOnlyAriaLabel}}
-                />,
-                defaultOptions,
-            );
-
-            // Act
-            const readOnlyIcon = screen.getByRole("img", {
-                name: readOnlyAriaLabel,
-            });
-
-            // Assert
-            expect(readOnlyIcon).toHaveAttribute(
-                "aria-label",
-                readOnlyAriaLabel,
-            );
         });
     });
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -356,7 +356,7 @@ const styles = StyleSheet.create({
     },
     helperTextSectionWithContent: {
         paddingBlockStart:
-            theme.root.layout.paddingBlockEnd.errorSectionWithContent,
+            theme.root.layout.paddingBlockEnd.helperTextSectionWithContent,
     },
     helperTextMessage: {
         minWidth: sizing.size_0, // This enables the wrapping behaviour on the error message

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -82,6 +82,7 @@ type Props = {
      * - The description will have an id formatted as `${id}-description`
      * - The field will have an id formatted as `${id}-field`
      * - The error will have an id formatted as `${id}-error`
+     * - The read only message will have an id formatted as `${id}-read-only-message`
      *
      * If the `id` prop is not provided, a base unique id will be auto-generated.
      * This is important so that the different elements can be wired up together
@@ -98,6 +99,7 @@ type Props = {
      * - The description will have a testId formatted as `${testId}-description`
      * - The field will have a testId formatted as `${testId}-field`
      * - The error will have a testId formatted as `${testId}-error`
+     * - The read only message will have a testId formatted as `${testId}-read-only-message`
      */
     testId?: string;
     /**
@@ -267,8 +269,8 @@ export default function LabeledField(props: Props) {
         return React.cloneElement(field, {
             id: fieldId,
             "aria-describedby": [
-                errorMessage && errorId,
                 description && descriptionId,
+                errorMessage && errorId,
                 readOnlyMessage && readOnlyMessageId,
             ]
                 .filter(Boolean)
@@ -293,6 +295,7 @@ export default function LabeledField(props: Props) {
                     stylesProp?.readOnlyMessage,
                 ]}
                 id={readOnlyMessageId}
+                testId={testId && `${testId}-read-only-message`}
             >
                 <PhosphorIcon
                     icon={LockIcon}

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -247,6 +247,7 @@ export default function LabeledField(props: Props) {
                             <BodyText
                                 style={[
                                     styles.textWordBreak,
+                                    styles.helperTextMessage,
                                     styles.errorMessage,
                                     styles.error,
                                 ]}
@@ -301,6 +302,7 @@ export default function LabeledField(props: Props) {
                 <BodyText
                     style={[
                         styles.textWordBreak,
+                        styles.helperTextMessage,
                         typographyStyles.BodyTextXSmallMediumWeight,
                     ]}
                 >
@@ -352,6 +354,9 @@ const styles = StyleSheet.create({
         paddingBlockStart:
             theme.root.layout.paddingBlockEnd.errorSectionWithContent,
     },
+    helperTextMessage: {
+        minWidth: sizing.size_0, // This enables the wrapping behaviour on the error message
+    },
     error: {
         color: theme.error.color.foreground,
     },
@@ -359,7 +364,6 @@ const styles = StyleSheet.create({
         marginTop: sizing.size_010, // This vertically aligns the icon with the text
     },
     errorMessage: {
-        minWidth: sizing.size_0, // This enables the wrapping behaviour on the error message
         fontSize: theme.error.font.size,
         fontWeight: theme.error.font.weight,
         lineHeight: theme.error.font.lineHeight,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -276,7 +276,10 @@ export default function LabeledField(props: Props) {
     }
 
     function maybeRenderReadOnlyMessage() {
-        if (!readOnlyMessage) {
+        if (!readOnlyMessage || errorMessage) {
+            // Don't render the read only message if:
+            // - There is no read only message
+            // - There is an error message
             return null;
         }
 

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -271,6 +271,7 @@ export default function LabeledField(props: Props) {
             required: required || field.props.required,
             error: hasError,
             testId: testId ? `${testId}-field` : undefined,
+            readOnly: readOnlyMessage || field.props.readOnly,
         });
     }
 

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -73,6 +73,7 @@ type Props = {
         label?: StyleType;
         description?: StyleType;
         error?: StyleType;
+        readOnlyMessage?: StyleType;
     };
     /**
      * A unique id to use as the base of the ids for the elements within the component.
@@ -280,10 +281,7 @@ export default function LabeledField(props: Props) {
     }
 
     function maybeRenderReadOnlyMessage() {
-        if (!readOnlyMessage || errorMessage) {
-            // Don't render the read only message if:
-            // - There is no read only message
-            // - There is an error message
+        if (!readOnlyMessage) {
             return null;
         }
 
@@ -292,6 +290,7 @@ export default function LabeledField(props: Props) {
                 style={[
                     styles.helperTextSection,
                     !!readOnlyMessage && styles.helperTextSectionWithContent,
+                    stylesProp?.readOnlyMessage,
                 ]}
                 id={readOnlyMessageId}
             >
@@ -318,8 +317,8 @@ export default function LabeledField(props: Props) {
             {renderLabel()}
             {maybeRenderDescription()}
             {renderField()}
-            {maybeRenderError()}
             {maybeRenderReadOnlyMessage()}
+            {maybeRenderError()}
         </View>
     );
 }

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -293,10 +293,10 @@ export default function LabeledField(props: Props) {
                     styles.helperTextSection,
                     !!readOnlyMessage && styles.helperTextSectionWithContent,
                 ]}
+                id={readOnlyMessageId}
             >
                 <PhosphorIcon
                     icon={LockIcon}
-                    role="img"
                     aria-label={labels.readOnlyAriaLabel}
                     color={semanticColor.core.foreground.neutral.subtle}
                 />

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -202,6 +202,7 @@ export default function LabeledField(props: Props) {
                         styles.textWordBreak,
                         styles.description,
                         stylesProp?.description,
+                        isDisabled && styles.disabledDescription,
                     ]}
                     testId={testId && `${testId}-description`}
                     id={descriptionId}
@@ -345,6 +346,9 @@ const styles = StyleSheet.create({
         paddingBlockEnd: theme.root.layout.paddingBlockEnd.description,
         fontSize: theme.description.font.size,
         lineHeight: theme.description.font.lineHeight,
+    },
+    disabledDescription: {
+        color: theme.description.color.disabled.foreground,
     },
     helperTextSection: {
         flexDirection: "row",

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import WarningCircle from "@phosphor-icons/core/bold/warning-circle-bold.svg";
-
+import LockIcon from "@phosphor-icons/core/bold/lock-bold.svg";
+import {
+    styles as typographyStyles,
+    BodyText,
+} from "@khanacademy/wonder-blocks-typography";
 import {View, addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import theme from "../theme";
 
 type Props = {
@@ -55,6 +58,13 @@ type Props = {
      */
     errorMessage?: React.ReactNode;
     /**
+     * The helpful text message to display when the field is read only.
+     *
+     * Use the `labels.readOnlyAriaLabel` prop to set the `aria-label` for
+     * the read only icon.
+     */
+    readOnlyMessage?: React.ReactNode;
+    /**
      * Custom styles for the elements of LabeledField. Useful if there are
      * specific cases where spacing between elements needs to be customized.
      */
@@ -98,7 +108,8 @@ type Props = {
 };
 
 export type LabeledFieldLabels = {
-    errorIconAriaLabel: string;
+    errorIconAriaLabel?: string;
+    readOnlyAriaLabel?: string;
 };
 
 const defaultLabeledFieldLabels: LabeledFieldLabels = {
@@ -122,6 +133,7 @@ export default function LabeledField(props: Props) {
         testId,
         description,
         errorMessage,
+        readOnlyMessage,
         labels = defaultLabeledFieldLabels,
     } = props;
 
@@ -204,9 +216,9 @@ export default function LabeledField(props: Props) {
             <React.Fragment>
                 <View
                     style={[
-                        styles.errorSection,
+                        styles.helperTextSection,
                         errorMessage
-                            ? styles.errorSectionWithContent
+                            ? styles.helperTextSectionWithContent
                             : undefined,
                         stylesProp?.error,
                     ]}
@@ -262,12 +274,43 @@ export default function LabeledField(props: Props) {
         });
     }
 
+    function maybeRenderReadOnlyMessage() {
+        if (!readOnlyMessage) {
+            return null;
+        }
+
+        return (
+            <View
+                style={[
+                    styles.helperTextSection,
+                    !!readOnlyMessage && styles.helperTextSectionWithContent,
+                ]}
+            >
+                <PhosphorIcon
+                    icon={LockIcon}
+                    role="img"
+                    aria-label={labels.readOnlyAriaLabel}
+                    color={semanticColor.core.foreground.neutral.subtle}
+                />
+                <BodyText
+                    style={[
+                        styles.textWordBreak,
+                        typographyStyles.BodyTextXSmallMediumWeight,
+                    ]}
+                >
+                    {readOnlyMessage}
+                </BodyText>
+            </View>
+        );
+    }
+
     return (
         <View style={stylesProp?.root}>
             {renderLabel()}
             {maybeRenderDescription()}
             {renderField()}
             {maybeRenderError()}
+            {maybeRenderReadOnlyMessage()}
         </View>
     );
 }
@@ -295,11 +338,11 @@ const styles = StyleSheet.create({
         fontSize: theme.description.font.size,
         lineHeight: theme.description.font.lineHeight,
     },
-    errorSection: {
+    helperTextSection: {
         flexDirection: "row",
         gap: sizing.size_080,
     },
-    errorSectionWithContent: {
+    helperTextSectionWithContent: {
         paddingBlockStart:
             theme.root.layout.paddingBlockEnd.errorSectionWithContent,
     },

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -143,6 +143,7 @@ export default function LabeledField(props: Props) {
     const descriptionId = `${uniqueId}-description`;
     const fieldId = `${uniqueId}-field`;
     const errorId = `${uniqueId}-error`;
+    const readOnlyMessageId = `${uniqueId}-read-only-message`;
 
     const isRequired = !!required || !!field.props.required;
     const hasError = !!errorMessage || !!field.props.error;
@@ -265,6 +266,7 @@ export default function LabeledField(props: Props) {
             "aria-describedby": [
                 errorMessage && errorId,
                 description && descriptionId,
+                readOnlyMessage && readOnlyMessageId,
             ]
                 .filter(Boolean)
                 .join(" "),

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -341,7 +341,7 @@ const styles = StyleSheet.create({
     },
     helperTextSection: {
         flexDirection: "row",
-        gap: sizing.size_080,
+        gap: theme.helperText.layout.gap,
     },
     helperTextSectionWithContent: {
         paddingBlockStart:

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -28,6 +28,9 @@ const theme = {
         },
         color: {
             foreground: semanticColor.core.foreground.neutral.default,
+            disabled: {
+                foreground: semanticColor.core.foreground.neutral.default,
+            },
         },
     },
     error: {

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -7,7 +7,7 @@ const theme = {
                 labelWithDescription: sizing.size_040,
                 labelWithNoDescription: sizing.size_120,
                 description: sizing.size_120,
-                errorSectionWithContent: sizing.size_120,
+                helperTextSectionWithContent: sizing.size_120,
             },
         },
     },

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -48,6 +48,11 @@ const theme = {
             foreground: semanticColor.core.foreground.critical.subtle,
         },
     },
+    helperText: {
+        layout: {
+            gap: sizing.size_080,
+        },
+    },
 };
 
 export default theme;

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -9,7 +9,7 @@ export default mergeTheme(defaultTheme, {
                 labelWithDescription: sizing.size_100,
                 labelWithNoDescription: sizing.size_100,
                 description: sizing.size_100,
-                errorSectionWithContent: sizing.size_100,
+                helperTextSectionWithContent: sizing.size_100,
             },
         },
     },

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -51,4 +51,9 @@ export default mergeTheme(defaultTheme, {
             foreground: semanticColor.core.foreground.critical.default,
         },
     },
+    helperText: {
+        layout: {
+            gap: sizing.size_040,
+        },
+    },
 });

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -19,7 +19,7 @@ export default mergeTheme(defaultTheme, {
                 foreground: semanticColor.core.foreground.critical.default,
             },
             disabled: {
-                foreground: semanticColor.core.foreground.disabled.subtle,
+                foreground: semanticColor.core.foreground.disabled.strong,
             },
         },
     },
@@ -30,6 +30,9 @@ export default mergeTheme(defaultTheme, {
         },
         color: {
             foreground: semanticColor.core.foreground.neutral.strong,
+            disabled: {
+                foreground: semanticColor.core.foreground.disabled.strong,
+            },
         },
     },
     error: {


### PR DESCRIPTION
## Summary:

set the readOnly prop on the field if the message is set. This is similar to setting the error prop when there is an error message
[wb-2011-labeled-field] add custom styles readonly case
[wb-2011-labeled-field] add jsx example for read only message prop
[wb-2011-labeled-field] add coverage for id and test id props for readonly section
[wb-2011-labeled-field] allow both read only and error message text to be shown
[wb-2011-labeled-field] support custom styling for readonly message
[wb-2011-labeled-field] add tests for readonly
[wb-2011-labeled-field] rename component token so it can be used for helper text
[wb-2011-labeled-field] testing things with sr
[wb-2011-labeled-field] fix disabled styling on description
[wb-2011-labeled-field] fix wrapping in helper text read only
[wb-2011-labeled-field] set aria-describedby on the field to the id of the readOnlyMessageId
[wb-2011-labeled-field] handle if both errorMessage and readOnlyMessage are set
[wb-2011-labeled-field] add more testing stories
[wb-2011-labeled-field] theme the gap between helper text and icon
[wb-2011-labeled-field] Add readOnlyMessage prop

Issue: WB-2011

## Test plan: