### PR TITLE
LabeledField: Add helper text props

### DIFF
--- a/.changeset/chilly-beans-call.md
+++ b/.changeset/chilly-beans-call.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update LabeledField component token value

--- a/.changeset/chilly-beans-call.md
+++ b/.changeset/chilly-beans-call.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tokens": patch
 ---
 
-Update LabeledField component token value
+Update LabeledField component tokens

--- a/.changeset/stale-suits-applaud.md
+++ b/.changeset/stale-suits-applaud.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": minor
+---
+
+Add `elementBeforeFieldStart`, `elementBeforeFieldEnd`, `elementAfterFieldStart`, and `elementAfterFieldEnd` props

--- a/__docs__/components/text-for-testing.ts
+++ b/__docs__/components/text-for-testing.ts
@@ -1,7 +1,10 @@
 export const rtlText = "هذا الرابط مكتوب باللغة العربية";
+
 export const longText =
     "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua";
 export const longTextWithNoWordBreak =
     "Loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliqua";
 export const reallyLongText =
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+export const reallyLongTextWithNoWordBreak =
+    "LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequatDuisauteiruredolorinreprehenderitinvoluptatevelitessecillumdoloreeufugiatnullapariaturExcepteursintoccaecatcupidatatnonproidentsuntinculpaquiofficiadeseruntmollitanimidestlaborum";

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -11,6 +11,8 @@ import {TextField} from "@khanacademy/wonder-blocks-form";
 import {
     longText,
     longTextWithNoWordBreak,
+    reallyLongText,
+    reallyLongTextWithNoWordBreak,
 } from "../components/text-for-testing";
 
 export default {
@@ -141,6 +143,11 @@ const scenarios = [
                     <b>Read</b> <i>only </i> <u>message</u>
                 </span>
             ),
+            elementAfterFieldEnd: (
+                <span>
+                    <b>End</b> <i>helper</i> <u>text</u>
+                </span>
+            ),
         },
     },
     {
@@ -219,6 +226,116 @@ const scenarios = [
             errorMessage: "Message about the error",
             required: "Custom required message",
             readOnlyMessage: "Message about the read only state",
+        },
+    },
+    {
+        name: "Helper text after field end",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldEnd: "End Helper Text",
+        },
+    },
+    {
+        name: "Helper text after field end with error message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldEnd: "End Helper Text",
+            errorMessage: "Message about the error",
+        },
+    },
+    {
+        name: "After field end element with long error message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldEnd: "End Helper Text",
+            errorMessage: reallyLongText,
+        },
+    },
+    {
+        name: "After field end element with long error message and no word break",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldEnd: "End Helper Text",
+            errorMessage: reallyLongTextWithNoWordBreak,
+        },
+    },
+    {
+        name: "Long error message and long element after field end",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            errorMessage: reallyLongText,
+            elementAfterFieldEnd: reallyLongText,
+        },
+    },
+    {
+        name: "Long error message and long element after field end with no word break",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            errorMessage: reallyLongTextWithNoWordBreak,
+            elementAfterFieldEnd: reallyLongTextWithNoWordBreak,
+        },
+    },
+
+    {
+        name: "Helper text after field end with read only message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldEnd: "End Helper Text",
+            readOnlyMessage: "Message about the read only state",
+        },
+    },
+    {
+        name: "After field end element with long read only message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldEnd: "End Helper Text",
+            readOnlyMessage: reallyLongText,
+        },
+    },
+    {
+        name: "After field end element with long read only message and no word break",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldEnd: "End Helper Text",
+            readOnlyMessage: reallyLongTextWithNoWordBreak,
+        },
+    },
+    {
+        name: "Long read only message and long element after field end",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            readOnlyMessage: reallyLongText,
+            elementAfterFieldEnd: reallyLongText,
+        },
+    },
+    {
+        name: "Long read only message and long element after field end with no word break",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            readOnlyMessage: reallyLongTextWithNoWordBreak,
+            elementAfterFieldEnd: reallyLongTextWithNoWordBreak,
         },
     },
 ];

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -159,6 +159,7 @@ const scenarios = [
             errorMessage: "Message about the error",
             required: "Custom required message",
             readOnlyMessage: "Message about the read only state",
+            elementAfterFieldEnd: "End helper text",
             styles: {
                 root: {
                     padding: sizing.size_080,
@@ -173,6 +174,9 @@ const scenarios = [
                     paddingBlockStart: sizing.size_020,
                 },
                 readOnlyMessage: {
+                    paddingBlockStart: sizing.size_020,
+                },
+                elementAfterFieldEnd: {
                     paddingBlockStart: sizing.size_020,
                 },
             },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -426,6 +426,28 @@ const scenarios = [
             elementAfterFieldEnd: reallyLongTextWithNoWordBreak,
         },
     },
+    {
+        name: "All helper text with field in disabled state",
+        props: {
+            field: <TextField value="" onChange={() => {}} disabled={true} />,
+            label: "Name",
+            elementBeforeFieldStart: "Start helper text",
+            elementBeforeFieldEnd: "End helper text",
+            elementAfterFieldStart: "Start helper text",
+            elementAfterFieldEnd: "End helper text",
+        },
+    },
+    {
+        name: "All helper text with field in error state",
+        props: {
+            field: <TextField value="" onChange={() => {}} error={true} />,
+            label: "Name",
+            elementBeforeFieldStart: "Start helper text",
+            elementBeforeFieldEnd: "End helper text",
+            elementAfterFieldStart: "Start helper text",
+            elementAfterFieldEnd: "End helper text",
+        },
+    },
 ];
 
 /**

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -263,27 +263,25 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text after field end with error message",
+        name: "elementAfterFieldEnd with errorMessage",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
-            description: "Helpful description text.",
             elementAfterFieldEnd: "End Helper Text",
             errorMessage: "Message about the error",
         },
     },
     {
-        name: "After field end element with long error message",
+        name: "elementAfterFieldEnd with long errorMessage",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
-            description: "Helpful description text.",
             elementAfterFieldEnd: "End Helper Text",
             errorMessage: reallyLongText,
         },
     },
     {
-        name: "After field end element with long error message and no word break",
+        name: "elementAfterFieldEnd with long errorMessage and no word break",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -293,7 +291,7 @@ const scenarios = [
         },
     },
     {
-        name: "Long error message and long element after field end",
+        name: "Long elementAfterFieldEnd and long errorMssage",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -303,7 +301,7 @@ const scenarios = [
         },
     },
     {
-        name: "Long error message and long element after field end with no word break",
+        name: "Long elementAfterFieldEnd and long errorMssage with no word break",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -314,7 +312,7 @@ const scenarios = [
     },
 
     {
-        name: "Helper text after field end with read only message",
+        name: "elementAfterFieldEnd with readOnlyMessage",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -324,7 +322,7 @@ const scenarios = [
         },
     },
     {
-        name: "After field end element with long read only message",
+        name: "elementAfterFieldEnd with long readOnlyMessage",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -334,7 +332,7 @@ const scenarios = [
         },
     },
     {
-        name: "After field end element with long read only message and no word break",
+        name: "elementAfterFieldEnd with long readOnlyMessage and no word break",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -344,7 +342,7 @@ const scenarios = [
         },
     },
     {
-        name: "Long read only message and long element after field end",
+        name: "Long readOnlyMessage and long elementAfterFieldEnd",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -354,7 +352,7 @@ const scenarios = [
         },
     },
     {
-        name: "Long read only message and long element after field end with no word break",
+        name: "Long readOnlyMessage and long elementAfterFieldEnd with no word break",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -364,7 +362,7 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text before field start",
+        name: "elementBeforeFieldStart",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -372,7 +370,7 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text before field end",
+        name: "elementBeforeFieldEnd",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -380,7 +378,7 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text after field start",
+        name: "elementAfterFieldStart",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -388,7 +386,7 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text after field end",
+        name: "elementAfterFieldEnd",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -396,7 +394,7 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text before and after field start and end",
+        name: "All helper text",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -407,7 +405,7 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text with long text",
+        name: "All helper text with long text",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
@@ -418,7 +416,7 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text with long text and no word break",
+        name: "All helper text with long text and no word break",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -146,6 +146,16 @@ const scenarios = [
                     <b>Read</b> <i>only </i> <u>message</u>
                 </span>
             ),
+            elementBeforeFieldStart: (
+                <span>
+                    <b>Start</b> <i>helper</i> <u>text</u>
+                </span>
+            ),
+            elementBeforeFieldEnd: (
+                <span>
+                    <b>End</b> <i>helper</i> <u>text</u>
+                </span>
+            ),
             elementAfterFieldStart: (
                 <span>
                     <b>Start</b> <i>helper</i> <u>text</u>
@@ -167,6 +177,8 @@ const scenarios = [
             errorMessage: "Message about the error",
             required: "Custom required message",
             readOnlyMessage: "Message about the read only state",
+            elementBeforeFieldStart: "Start helper text",
+            elementBeforeFieldEnd: "End helper text",
             elementAfterFieldStart: "Start helper text",
             elementAfterFieldEnd: "End helper text",
             styles: {
@@ -184,6 +196,12 @@ const scenarios = [
                 },
                 readOnlyMessage: {
                     paddingBlockStart: sizing.size_020,
+                },
+                elementBeforeFieldStart: {
+                    paddingBlockEnd: sizing.size_020,
+                },
+                elementBeforeFieldEnd: {
+                    paddingBlockEnd: sizing.size_020,
                 },
                 elementAfterFieldStart: {
                     paddingBlockStart: sizing.size_020,
@@ -353,7 +371,14 @@ const scenarios = [
             elementBeforeFieldStart: "Start helper text",
         },
     },
-
+    {
+        name: "Helper text before field end",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            elementBeforeFieldEnd: "End helper text",
+        },
+    },
     {
         name: "Helper text after field start",
         props: {
@@ -376,6 +401,7 @@ const scenarios = [
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
             elementBeforeFieldStart: "Start helper text",
+            elementBeforeFieldEnd: "End helper text",
             elementAfterFieldStart: "Start helper text",
             elementAfterFieldEnd: "End helper text",
         },
@@ -386,6 +412,7 @@ const scenarios = [
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
             elementBeforeFieldStart: reallyLongText,
+            elementBeforeFieldEnd: reallyLongText,
             elementAfterFieldStart: reallyLongText,
             elementAfterFieldEnd: reallyLongText,
         },
@@ -396,6 +423,7 @@ const scenarios = [
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
             elementBeforeFieldStart: reallyLongTextWithNoWordBreak,
+            elementBeforeFieldEnd: reallyLongTextWithNoWordBreak,
             elementAfterFieldStart: reallyLongTextWithNoWordBreak,
             elementAfterFieldEnd: reallyLongTextWithNoWordBreak,
         },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -117,6 +117,9 @@ const scenarios = [
             description: "Helpful description text.",
             errorMessage: "Message about the error",
             required: "Custom required message",
+            readOnlyMessage: "Message about the read only state",
+            elementAfterFieldStart: "Start helper text",
+            elementAfterFieldEnd: "End helper text",
         },
     },
     {
@@ -143,6 +146,11 @@ const scenarios = [
                     <b>Read</b> <i>only </i> <u>message</u>
                 </span>
             ),
+            elementAfterFieldStart: (
+                <span>
+                    <b>Start</b> <i>helper</i> <u>text</u>
+                </span>
+            ),
             elementAfterFieldEnd: (
                 <span>
                     <b>End</b> <i>helper</i> <u>text</u>
@@ -159,6 +167,7 @@ const scenarios = [
             errorMessage: "Message about the error",
             required: "Custom required message",
             readOnlyMessage: "Message about the read only state",
+            elementAfterFieldStart: "Start helper text",
             elementAfterFieldEnd: "End helper text",
             styles: {
                 root: {
@@ -174,6 +183,9 @@ const scenarios = [
                     paddingBlockStart: sizing.size_020,
                 },
                 readOnlyMessage: {
+                    paddingBlockStart: sizing.size_020,
+                },
+                elementAfterFieldStart: {
                     paddingBlockStart: sizing.size_020,
                 },
                 elementAfterFieldEnd: {
@@ -339,6 +351,45 @@ const scenarios = [
             label: "Name",
             description: "Helpful description text.",
             readOnlyMessage: reallyLongTextWithNoWordBreak,
+            elementAfterFieldEnd: reallyLongTextWithNoWordBreak,
+        },
+    },
+    {
+        name: "Helper text after field start",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldStart: "Start helper text",
+        },
+    },
+    {
+        name: "Helper text after field start and end",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldStart: "Start helper text",
+            elementAfterFieldEnd: "End helper text",
+        },
+    },
+    {
+        name: "Helper text after field start and end with long text",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldStart: reallyLongText,
+            elementAfterFieldEnd: reallyLongText,
+        },
+    },
+    {
+        name: "Helper text after field start and end with long text and no word break",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            description: "Helpful description text.",
+            elementAfterFieldStart: reallyLongTextWithNoWordBreak,
             elementAfterFieldEnd: reallyLongTextWithNoWordBreak,
         },
     },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -245,15 +245,6 @@ const scenarios = [
         },
     },
     {
-        name: "Helper text after field end",
-        props: {
-            field: <TextField value="" onChange={() => {}} />,
-            label: "Name",
-            description: "Helpful description text.",
-            elementAfterFieldEnd: "End Helper Text",
-        },
-    },
-    {
         name: "Helper text after field end with error message",
         props: {
             field: <TextField value="" onChange={() => {}} />,
@@ -355,40 +346,56 @@ const scenarios = [
         },
     },
     {
+        name: "Helper text before field start",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            elementBeforeFieldStart: "Start helper text",
+        },
+    },
+
+    {
         name: "Helper text after field start",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
-            description: "Helpful description text.",
             elementAfterFieldStart: "Start helper text",
         },
     },
     {
-        name: "Helper text after field start and end",
+        name: "Helper text after field end",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
-            description: "Helpful description text.",
+            elementAfterFieldEnd: "End helper text",
+        },
+    },
+    {
+        name: "Helper text before and after field start and end",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            elementBeforeFieldStart: "Start helper text",
             elementAfterFieldStart: "Start helper text",
             elementAfterFieldEnd: "End helper text",
         },
     },
     {
-        name: "Helper text after field start and end with long text",
+        name: "Helper text with long text",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
-            description: "Helpful description text.",
+            elementBeforeFieldStart: reallyLongText,
             elementAfterFieldStart: reallyLongText,
             elementAfterFieldEnd: reallyLongText,
         },
     },
     {
-        name: "Helper text after field start and end with long text and no word break",
+        name: "Helper text with long text and no word break",
         props: {
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
-            description: "Helpful description text.",
+            elementBeforeFieldStart: reallyLongTextWithNoWordBreak,
             elementAfterFieldStart: reallyLongTextWithNoWordBreak,
             elementAfterFieldEnd: reallyLongTextWithNoWordBreak,
         },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -440,12 +440,13 @@ const scenarios = [
     {
         name: "All helper text with field in error state",
         props: {
-            field: <TextField value="" onChange={() => {}} error={true} />,
+            field: <TextField value="" onChange={() => {}} />,
             label: "Name",
             elementBeforeFieldStart: "Start helper text",
             elementBeforeFieldEnd: "End helper text",
             elementAfterFieldStart: "Start helper text",
             elementAfterFieldEnd: "End helper text",
+            errorMessage: "Message about the error",
         },
     },
 ];

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -74,6 +74,7 @@ export const HelperText: StoryComponentType = {
         field: <TextField value="" onChange={() => {}} />,
         label: "Name",
         description: "Helpful description text.",
+        elementAfterFieldStart: "Start Helper Text",
         elementAfterFieldEnd: "End Helper Text",
     },
 };
@@ -536,6 +537,11 @@ export const Custom = {
                 <b>Read</b> <i>only</i> <u>message</u>
             </span>
         ),
+        elementAfterFieldStart: (
+            <span>
+                <b>Start</b> <i>helper</i> <u>text</u>
+            </span>
+        ),
         elementAfterFieldEnd: (
             <span>
                 <b>End</b> <i>helper</i> <u>text</u>
@@ -560,6 +566,7 @@ export const CustomStyles = {
         errorMessage: "Message about the error",
         required: "Custom required message",
         readOnlyMessage: "Read only message",
+        elementAfterFieldStart: "Start helper text",
         elementAfterFieldEnd: "End helper text",
         styles: {
             root: {
@@ -575,6 +582,9 @@ export const CustomStyles = {
                 paddingBlockStart: sizing.size_020,
             },
             readOnlyMessage: {
+                paddingBlockStart: sizing.size_020,
+            },
+            elementAfterFieldStart: {
                 paddingBlockStart: sizing.size_020,
             },
             elementAfterFieldEnd: {

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -559,6 +559,7 @@ export const CustomStyles = {
         description: "Helpful description text.",
         errorMessage: "Message about the error",
         required: "Custom required message",
+        readOnlyMessage: "Read only message",
         elementAfterFieldEnd: "End helper text",
         styles: {
             root: {
@@ -571,6 +572,9 @@ export const CustomStyles = {
                 paddingBlockEnd: sizing.size_020,
             },
             error: {
+                paddingBlockStart: sizing.size_020,
+            },
+            readOnlyMessage: {
                 paddingBlockStart: sizing.size_020,
             },
             elementAfterFieldEnd: {

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -73,7 +73,7 @@ export const HelperText: StoryComponentType = {
     args: {
         field: <TextField value="" onChange={() => {}} />,
         label: "Name",
-        description: "Helpful description text.",
+        elementBeforeFieldStart: "Start Helper Text",
         elementAfterFieldStart: "Start Helper Text",
         elementAfterFieldEnd: "End Helper Text",
     },
@@ -537,6 +537,11 @@ export const Custom = {
                 <b>Read</b> <i>only</i> <u>message</u>
             </span>
         ),
+        elementBeforeFieldStart: (
+            <span>
+                <b>Start</b> <i>helper</i> <u>text</u>
+            </span>
+        ),
         elementAfterFieldStart: (
             <span>
                 <b>Start</b> <i>helper</i> <u>text</u>
@@ -566,6 +571,7 @@ export const CustomStyles = {
         errorMessage: "Message about the error",
         required: "Custom required message",
         readOnlyMessage: "Read only message",
+        elementBeforeFieldStart: "Start helper text",
         elementAfterFieldStart: "Start helper text",
         elementAfterFieldEnd: "End helper text",
         styles: {
@@ -583,6 +589,9 @@ export const CustomStyles = {
             },
             readOnlyMessage: {
                 paddingBlockStart: sizing.size_020,
+            },
+            elementBeforeFieldStart: {
+                paddingBlockEnd: sizing.size_020,
             },
             elementAfterFieldStart: {
                 paddingBlockStart: sizing.size_020,

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -536,6 +536,11 @@ export const Custom = {
                 <b>Read</b> <i>only</i> <u>message</u>
             </span>
         ),
+        elementAfterFieldEnd: (
+            <span>
+                <b>End</b> <i>helper</i> <u>text</u>
+            </span>
+        ),
     },
 };
 
@@ -554,6 +559,7 @@ export const CustomStyles = {
         description: "Helpful description text.",
         errorMessage: "Message about the error",
         required: "Custom required message",
+        elementAfterFieldEnd: "End helper text",
         styles: {
             root: {
                 padding: sizing.size_080,
@@ -565,6 +571,9 @@ export const CustomStyles = {
                 paddingBlockEnd: sizing.size_020,
             },
             error: {
+                paddingBlockStart: sizing.size_020,
+            },
+            elementAfterFieldEnd: {
                 paddingBlockStart: sizing.size_020,
             },
         },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -74,6 +74,7 @@ export const HelperText: StoryComponentType = {
         field: <TextField value="" onChange={() => {}} />,
         label: "Name",
         elementBeforeFieldStart: "Start Helper Text",
+        elementBeforeFieldEnd: "End Helper Text",
         elementAfterFieldStart: "Start Helper Text",
         elementAfterFieldEnd: "End Helper Text",
     },
@@ -542,6 +543,11 @@ export const Custom = {
                 <b>Start</b> <i>helper</i> <u>text</u>
             </span>
         ),
+        elementBeforeFieldEnd: (
+            <span>
+                <b>End</b> <i>helper</i> <u>text</u>
+            </span>
+        ),
         elementAfterFieldStart: (
             <span>
                 <b>Start</b> <i>helper</i> <u>text</u>
@@ -572,6 +578,7 @@ export const CustomStyles = {
         required: "Custom required message",
         readOnlyMessage: "Read only message",
         elementBeforeFieldStart: "Start helper text",
+        elementBeforeFieldEnd: "End helper text",
         elementAfterFieldStart: "Start helper text",
         elementAfterFieldEnd: "End helper text",
         styles: {
@@ -591,6 +598,9 @@ export const CustomStyles = {
                 paddingBlockStart: sizing.size_020,
             },
             elementBeforeFieldStart: {
+                paddingBlockEnd: sizing.size_020,
+            },
+            elementBeforeFieldEnd: {
                 paddingBlockEnd: sizing.size_020,
             },
             elementAfterFieldStart: {

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -69,6 +69,15 @@ export const Default: StoryComponentType = {
     },
 };
 
+export const HelperText: StoryComponentType = {
+    args: {
+        field: <TextField value="" onChange={() => {}} />,
+        label: "Name",
+        description: "Helpful description text.",
+        elementAfterFieldEnd: "End Helper Text",
+    },
+};
+
 const StyledForm = addStyle("form");
 
 const AllFields = (

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -64,19 +64,47 @@ export const Default: StoryComponentType = {
         field: <TextField value="" onChange={() => {}} />,
         label: "Name",
         description: "Helpful description text.",
-        errorMessage: "Message about the error",
         required: "Custom required message",
     },
 };
 
+/**
+ * Consider the following when providing helper text:
+ * - If providing an error message for the field, use the `errorMessage` prop
+ * - If providing a message related to the read only state for the field, use
+ *   the `readOnlyMessage` prop
+ *
+ * For all other kinds of helper text, the following props are available:
+ * - `elementBeforeFieldStart`
+ * - `elementBeforeFieldEnd`
+ * - `elementAfterFieldStart`
+ * - `elementAfterFieldEnd`
+ *
+ * When any of these props are used, the field's `aria-describedby` attribute
+ * will include the id of the element for the corresponding prop.
+ */
 export const HelperText: StoryComponentType = {
+    render: (args) => {
+        return (
+            <View style={{gap: sizing.size_240}}>
+                <Heading>A field with an error message</Heading>
+                <LabeledField {...args} errorMessage="Error message" />
+                <Heading>A field with a read only message</Heading>
+                <LabeledField {...args} readOnlyMessage="Read only message" />
+                <Heading>A field with customizable helper text</Heading>
+                <LabeledField
+                    {...args}
+                    elementBeforeFieldStart="Start helper text"
+                    elementBeforeFieldEnd="End helper text"
+                    elementAfterFieldStart="Start helper text"
+                    elementAfterFieldEnd="End helper text"
+                />
+            </View>
+        );
+    },
     args: {
         field: <TextField value="" onChange={() => {}} />,
         label: "Name",
-        elementBeforeFieldStart: "Start Helper Text",
-        elementBeforeFieldEnd: "End Helper Text",
-        elementAfterFieldStart: "Start Helper Text",
-        elementAfterFieldEnd: "End Helper Text",
     },
 };
 

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -394,61 +394,6 @@ describe("LabeledField", () => {
 
         describe("testId", () => {
             it.each([
-                {propName: "label", testIdPostfix: "-label"},
-                {propName: "description", testIdPostfix: "-description"},
-                {propName: "errorMessage", testIdPostfix: "-error"},
-                {
-                    propName: "readOnlyMessage",
-                    testIdPostfix: "-read-only-message",
-                },
-                {
-                    propName: "elementBeforeFieldStart",
-                    testIdPostfix: "-element-before-field-start",
-                },
-                {
-                    propName: "elementBeforeFieldEnd",
-                    testIdPostfix: "-element-before-field-end",
-                },
-                {
-                    propName: "elementAfterFieldStart",
-                    testIdPostfix: "-element-after-field-start",
-                },
-                {
-                    propName: "elementAfterFieldEnd",
-                    testIdPostfix: "-element-after-field-end",
-                },
-            ])(
-                "Should have a testId for $propName",
-                ({propName, testIdPostfix}) => {
-                    // Arrange
-                    const testId = "testid";
-                    const props = {[propName]: "Value"};
-                    // Act
-                    render(
-                        <LabeledField
-                            field={
-                                <TextField
-                                    id="tf-1"
-                                    value=""
-                                    onChange={() => {}}
-                                />
-                            }
-                            label="Label"
-                            {...props}
-                            testId={testId}
-                        />,
-                        defaultOptions,
-                    );
-
-                    // Assert
-                    const label = screen.getByTestId(
-                        `${testId}${testIdPostfix}`,
-                    );
-                    expect(label).toBeInTheDocument();
-                },
-            );
-
-            it.each([
                 ["label", `${testId}-label`, getLabel],
                 ["description", `${testId}-description`, getDescription],
                 ["field", `${testId}-field`, getField],

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -777,12 +777,12 @@ describe("LabeledField", () => {
                     "aria-describedby",
                     [
                         `${id}-description`,
-                        `${id}-error`,
-                        `${id}-read-only-message`,
                         `${id}-element-before-field-start`,
                         `${id}-element-before-field-end`,
                         `${id}-element-after-field-start`,
                         `${id}-element-after-field-end`,
+                        `${id}-read-only-message`,
+                        `${id}-error`,
                     ].join(" "),
                 );
             });

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -17,6 +17,7 @@ describe("LabeledField", () => {
     const errorMessage = "Error message";
     const testId = "test-id";
     const readOnlyMessage = "Read only message";
+    const elementAfterFieldEnd = "End helper text";
 
     const getLabel = () => screen.getByText(label);
     const getDescription = () => screen.getByText(description);
@@ -24,6 +25,8 @@ describe("LabeledField", () => {
     const getError = () => screen.getByTestId("test-id-error");
     const getReadOnlyMessage = () =>
         screen.getByTestId("test-id-read-only-message");
+    const getElementAfterFieldEnd = () =>
+        screen.getByText(elementAfterFieldEnd);
 
     it("LabeledField renders the label text", () => {
         // Arrange
@@ -217,6 +220,26 @@ describe("LabeledField", () => {
         expect(readOnlyMessage).toBeInTheDocument();
     });
 
+    it("LabeledField adds testId to elementAfterFieldEnd", () => {
+        // Arrange
+        const testId = "testid";
+        render(
+            <LabeledField
+                field={<TextField value="" onChange={() => {}} />}
+                label="Label"
+                elementAfterFieldEnd="Helper text"
+                testId={testId}
+            />,
+            defaultOptions,
+        );
+
+        // Assert
+        const elementAfterFieldEnd = screen.getByTestId(
+            `${testId}-element-after-field-end`,
+        );
+        expect(elementAfterFieldEnd).toBeInTheDocument();
+    });
+
     describe("Labels prop", () => {
         it("should use the errorIconAriaLabel for the error icon aria label", () => {
             // Arrange
@@ -297,6 +320,11 @@ describe("LabeledField", () => {
                     `${id}-read-only-message`,
                     getReadOnlyMessage,
                 ],
+                [
+                    "elementAfterFieldEnd",
+                    `${id}-element-after-field-end`,
+                    getElementAfterFieldEnd,
+                ],
             ])(
                 "should have the id for the %s element set to %s",
                 (
@@ -314,6 +342,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
+                            elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
                         defaultOptions,
                     );
@@ -332,6 +361,11 @@ describe("LabeledField", () => {
                 ["field", "-field", getField],
                 ["error", "-error", getError],
                 ["read only message", "-read-only-message", getReadOnlyMessage],
+                [
+                    "elementAfterFieldEnd",
+                    "-element-after-field-end",
+                    getElementAfterFieldEnd,
+                ],
             ])(
                 "should have an auto-generated id for the %s element that ends with %s",
                 (
@@ -348,6 +382,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
+                            elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
                         defaultOptions,
                     );
@@ -372,6 +407,11 @@ describe("LabeledField", () => {
                     `${testId}-read-only-message`,
                     getReadOnlyMessage,
                 ],
+                [
+                    "elementAfterFieldEnd",
+                    `${testId}-element-after-field-end`,
+                    getElementAfterFieldEnd,
+                ],
             ])(
                 "should use the testId prop to set the %s element's data-testid attribute to %s",
                 (
@@ -388,6 +428,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
+                            elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
                         defaultOptions,
                     );
@@ -437,6 +478,7 @@ describe("LabeledField", () => {
                         return el;
                     },
                 ],
+                ["elementAfterFieldEnd", getElementAfterFieldEnd],
             ])(
                 "should not set the data-testid attribute on the %s element if the testId prop is not set",
                 (
@@ -451,6 +493,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
+                            elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
                         defaultOptions,
                     );
@@ -680,6 +723,7 @@ describe("LabeledField", () => {
                         errorMessage={errorMessage}
                         description={description}
                         id={id}
+                        elementAfterFieldEnd="End helper text"
                     />,
                     defaultOptions,
                 );
@@ -690,7 +734,48 @@ describe("LabeledField", () => {
                 // Assert
                 expect(field).toHaveAttribute(
                     "aria-describedby",
-                    `${id}-description ${id}-error ${id}-read-only-message`,
+                    `${id}-description ${id}-error ${id}-read-only-message ${id}-element-after-field-end`,
+                );
+            });
+
+            it("Should have no aria-describedby values on the field if there is no helper text for the field", () => {
+                // Arrange
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const field = screen.getByRole("textbox");
+
+                // Assert
+                expect(field).toHaveAttribute("aria-describedby", "");
+            });
+
+            it("Should set aria-describedby on the field to the id of the elementAfterFieldEnd", () => {
+                // Arrange
+                const elementAfterFieldEnd = "Helper text";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        elementAfterFieldEnd={elementAfterFieldEnd}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const elementAfterFieldEndEl =
+                    screen.getByText(elementAfterFieldEnd);
+                const field = screen.getByRole("textbox");
+
+                // Assert
+                expect(field).toHaveAttribute(
+                    "aria-describedby",
+                    elementAfterFieldEndEl.id,
                 );
             });
         });
@@ -948,6 +1033,28 @@ describe("LabeledField", () => {
 
             // Assert
             expect(field).toHaveAttribute("readOnly");
+        });
+    });
+
+    describe("Helper text", () => {
+        it("Should render the elementAfterFieldEnd prop if it is provided", () => {
+            // Arrange
+            const elementAfterFieldEnd = "Helper text";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                    elementAfterFieldEnd={elementAfterFieldEnd}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const elementAfterFieldEndEl =
+                screen.getByText(elementAfterFieldEnd);
+
+            // Assert
+            expect(elementAfterFieldEndEl).toBeInTheDocument();
         });
     });
 });

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -200,167 +200,6 @@ describe("LabeledField", () => {
         },
     );
 
-    it("LabeledField adds testId to label", () => {
-        // Arrange
-        const testId = "testid";
-
-        // Act
-        render(
-            <LabeledField
-                field={<TextField id="tf-1" value="" onChange={() => {}} />}
-                label="Label"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const label = screen.getByTestId(`${testId}-label`);
-        expect(label).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to description", () => {
-        // Arrange
-        const testId = "testid";
-
-        // Act
-        render(
-            <LabeledField
-                field={<TextField id="tf-1" value="" onChange={() => {}} />}
-                label="Label"
-                description="Description"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const description = screen.getByTestId(`${testId}-description`);
-        expect(description).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to error", () => {
-        // Arrange
-        const testId = "testid";
-
-        // Act
-        render(
-            <LabeledField
-                field={<TextField id="tf-1" value="" onChange={() => {}} />}
-                label="Label"
-                errorMessage="Error"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const error = screen.getByTestId(`${testId}-error`);
-        expect(error).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to read only message", () => {
-        // Arrange
-        const testId = "testid";
-
-        // Act
-        render(
-            <LabeledField
-                field={<TextField id="tf-1" value="" onChange={() => {}} />}
-                label="Label"
-                readOnlyMessage="Read only message"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const readOnlyMessage = screen.getByTestId(
-            `${testId}-read-only-message`,
-        );
-        expect(readOnlyMessage).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to elementBeforeFieldStart", () => {
-        // Arrange
-        const testId = "testid";
-        render(
-            <LabeledField
-                field={<TextField value="" onChange={() => {}} />}
-                label="Label"
-                elementBeforeFieldStart="Helper text"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const elementBeforeFieldStart = screen.getByTestId(
-            `${testId}-element-before-field-start`,
-        );
-        expect(elementBeforeFieldStart).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to elementBeforeFieldEnd", () => {
-        // Arrange
-        const testId = "testid";
-        render(
-            <LabeledField
-                field={<TextField value="" onChange={() => {}} />}
-                label="Label"
-                elementBeforeFieldEnd="Helper text"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const elementBeforeFieldEnd = screen.getByTestId(
-            `${testId}-element-before-field-end`,
-        );
-        expect(elementBeforeFieldEnd).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to elementAfterFieldStart", () => {
-        // Arrange
-        const testId = "testid";
-        render(
-            <LabeledField
-                field={<TextField value="" onChange={() => {}} />}
-                label="Label"
-                elementAfterFieldStart="Helper text"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const elementAfterFieldStart = screen.getByTestId(
-            `${testId}-element-after-field-start`,
-        );
-        expect(elementAfterFieldStart).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to elementAfterFieldEnd", () => {
-        // Arrange
-        const testId = "testid";
-        render(
-            <LabeledField
-                field={<TextField value="" onChange={() => {}} />}
-                label="Label"
-                elementAfterFieldEnd="Helper text"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const elementAfterFieldEnd = screen.getByTestId(
-            `${testId}-element-after-field-end`,
-        );
-        expect(elementAfterFieldEnd).toBeInTheDocument();
-    });
-
     describe("Labels prop", () => {
         it("should use the errorIconAriaLabel for the error icon aria label", () => {
             // Arrange
@@ -554,6 +393,61 @@ describe("LabeledField", () => {
         });
 
         describe("testId", () => {
+            it.each([
+                {propName: "label", testIdPostfix: "-label"},
+                {propName: "description", testIdPostfix: "-description"},
+                {propName: "errorMessage", testIdPostfix: "-error"},
+                {
+                    propName: "readOnlyMessage",
+                    testIdPostfix: "-read-only-message",
+                },
+                {
+                    propName: "elementBeforeFieldStart",
+                    testIdPostfix: "-element-before-field-start",
+                },
+                {
+                    propName: "elementBeforeFieldEnd",
+                    testIdPostfix: "-element-before-field-end",
+                },
+                {
+                    propName: "elementAfterFieldStart",
+                    testIdPostfix: "-element-after-field-start",
+                },
+                {
+                    propName: "elementAfterFieldEnd",
+                    testIdPostfix: "-element-after-field-end",
+                },
+            ])(
+                "Should have a testId for $propName",
+                ({propName, testIdPostfix}) => {
+                    // Arrange
+                    const testId = "testid";
+                    const props = {[propName]: "Value"};
+                    // Act
+                    render(
+                        <LabeledField
+                            field={
+                                <TextField
+                                    id="tf-1"
+                                    value=""
+                                    onChange={() => {}}
+                                />
+                            }
+                            label="Label"
+                            {...props}
+                            testId={testId}
+                        />,
+                        defaultOptions,
+                    );
+
+                    // Assert
+                    const label = screen.getByTestId(
+                        `${testId}${testIdPostfix}`,
+                    );
+                    expect(label).toBeInTheDocument();
+                },
+            );
+
             it.each([
                 ["label", `${testId}-label`, getLabel],
                 ["description", `${testId}-description`, getDescription],

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -109,7 +109,7 @@ describe("LabeledField", () => {
         expect(screen.getByText(readOnlyMessage)).toBeInTheDocument();
     });
 
-    it("LabeledField renders the read only message text if there is an error message", () => {
+    it("LabeledField renders the read only message text if there is an error message and elementAfterFieldStart is provided", () => {
         // Arrange
         const readOnlyMessage = "Read only message";
         render(
@@ -118,6 +118,7 @@ describe("LabeledField", () => {
                 label="Label"
                 readOnlyMessage={readOnlyMessage}
                 errorMessage="Error message"
+                elementAfterFieldStart="After field start helper text"
             />,
             defaultOptions,
         );
@@ -129,7 +130,7 @@ describe("LabeledField", () => {
         expect(readOnlyMessageEl).toBeInTheDocument();
     });
 
-    it("LabeledField renders the error message text if there is also a read only message", () => {
+    it("LabeledField renders the error message text if there is also a read only message and elementAfterFieldStart is provided", () => {
         // Arrange
         const readOnlyMessage = "Read only message";
         render(
@@ -138,6 +139,7 @@ describe("LabeledField", () => {
                 label="Label"
                 readOnlyMessage={readOnlyMessage}
                 errorMessage="Error message"
+                elementAfterFieldStart="After field start helper text"
             />,
             defaultOptions,
         );
@@ -148,6 +150,55 @@ describe("LabeledField", () => {
         // Assert
         expect(errorMessageEl).toBeInTheDocument();
     });
+
+    it("LabeledField renders elementAfterFieldStart if there is also a read only message and an error message", () => {
+        // Arrange
+        const elementAfterFieldStart = "After field start helper text";
+        render(
+            <LabeledField
+                field={<TextField id="tf-1" value="" onChange={() => {}} />}
+                label="Label"
+                readOnlyMessage="Read only message"
+                errorMessage="Error message"
+                elementAfterFieldStart={elementAfterFieldStart}
+            />,
+            defaultOptions,
+        );
+
+        // Act
+        const elementAfterFieldEndEl = screen.getByText(elementAfterFieldStart);
+
+        // Assert
+        expect(elementAfterFieldEndEl).toBeInTheDocument();
+    });
+
+    it.each([
+        "elementBeforeFieldStart",
+        "elementAfterFieldStart",
+        "elementBeforeFieldEnd",
+        "elementAfterFieldEnd",
+    ])(
+        "HelperText: Should render the %s prop if it is provided",
+        (propName) => {
+            // Arrange
+            const propValue = "Helper text";
+            const props = {[propName]: propValue};
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                    {...props}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const element = screen.getByText(propValue);
+
+            // Assert
+            expect(element).toBeInTheDocument();
+        },
+    );
 
     it("LabeledField adds testId to label", () => {
         // Arrange
@@ -1267,91 +1318,6 @@ describe("LabeledField", () => {
 
             // Assert
             expect(field).toHaveAttribute("readOnly");
-        });
-    });
-
-    describe("Helper text", () => {
-        it("Should render the elementBeforeFieldStart prop if it is provided", () => {
-            // Arrange
-            const elementBeforeFieldStart = "Helper text";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    label="Label"
-                    elementBeforeFieldStart={elementBeforeFieldStart}
-                />,
-                defaultOptions,
-            );
-
-            // Act
-            const elementBeforeFieldStartEl = screen.getByText(
-                elementBeforeFieldStart,
-            );
-
-            // Assert
-            expect(elementBeforeFieldStartEl).toBeInTheDocument();
-        });
-
-        it("Should render the elementBeforeFieldEnd prop if it is provided", () => {
-            // Arrange
-            const elementBeforeFieldEnd = "Helper text";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    label="Label"
-                    elementBeforeFieldEnd={elementBeforeFieldEnd}
-                />,
-                defaultOptions,
-            );
-
-            // Act
-            const elementBeforeFieldEndEl = screen.getByText(
-                elementBeforeFieldEnd,
-            );
-
-            // Assert
-            expect(elementBeforeFieldEndEl).toBeInTheDocument();
-        });
-
-        it("Should render the elementAfterFieldStart prop if it is provided", () => {
-            // Arrange
-            const elementAfterFieldStart = "Helper text";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    label="Label"
-                    elementAfterFieldStart={elementAfterFieldStart}
-                />,
-                defaultOptions,
-            );
-
-            // Act
-            const elementAfterFieldStartEl = screen.getByText(
-                elementAfterFieldStart,
-            );
-
-            // Assert
-            expect(elementAfterFieldStartEl).toBeInTheDocument();
-        });
-
-        it("Should render the elementAfterFieldEnd prop if it is provided", () => {
-            // Arrange
-            const elementAfterFieldEnd = "Helper text";
-            render(
-                <LabeledField
-                    field={<TextField value="" onChange={() => {}} />}
-                    label="Label"
-                    elementAfterFieldEnd={elementAfterFieldEnd}
-                />,
-                defaultOptions,
-            );
-
-            // Act
-            const elementAfterFieldEndEl =
-                screen.getByText(elementAfterFieldEnd);
-
-            // Assert
-            expect(elementAfterFieldEndEl).toBeInTheDocument();
         });
     });
 });

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -18,6 +18,7 @@ describe("LabeledField", () => {
     const errorMessage = "Error message";
     const testId = "test-id";
     const readOnlyMessage = "Read only message";
+    const elementBeforeFieldStart = "Before field start helper text";
     const elementAfterFieldStart = "After field start helper text";
     const elementAfterFieldEnd = "After field end helper text";
 
@@ -27,6 +28,8 @@ describe("LabeledField", () => {
     const getError = () => screen.getByTestId("test-id-error");
     const getReadOnlyMessage = () =>
         screen.getByTestId("test-id-read-only-message");
+    const getElementBeforeFieldStart = () =>
+        screen.getByText(elementBeforeFieldStart);
     const getElementAfterFieldStart = () =>
         screen.getByText(elementAfterFieldStart);
     const getElementAfterFieldEnd = () =>
@@ -224,6 +227,26 @@ describe("LabeledField", () => {
         expect(readOnlyMessage).toBeInTheDocument();
     });
 
+    it("LabeledField adds testId to elementBeforeFieldStart", () => {
+        // Arrange
+        const testId = "testid";
+        render(
+            <LabeledField
+                field={<TextField value="" onChange={() => {}} />}
+                label="Label"
+                elementBeforeFieldStart="Helper text"
+                testId={testId}
+            />,
+            defaultOptions,
+        );
+
+        // Assert
+        const elementBeforeFieldStart = screen.getByTestId(
+            `${testId}-element-before-field-start`,
+        );
+        expect(elementBeforeFieldStart).toBeInTheDocument();
+    });
+
     it("LabeledField adds testId to elementAfterFieldStart", () => {
         // Arrange
         const testId = "testid";
@@ -239,7 +262,7 @@ describe("LabeledField", () => {
 
         // Assert
         const elementAfterFieldStart = screen.getByTestId(
-            `${testId}-element-after-field-end`,
+            `${testId}-element-after-field-start`,
         );
         expect(elementAfterFieldStart).toBeInTheDocument();
     });
@@ -345,6 +368,11 @@ describe("LabeledField", () => {
                     getReadOnlyMessage,
                 ],
                 [
+                    "elementBeforeFieldStart",
+                    `${id}-element-before-field-start`,
+                    getElementBeforeFieldStart,
+                ],
+                [
                     "elementAfterFieldStart",
                     `${id}-element-after-field-start`,
                     getElementAfterFieldStart,
@@ -371,6 +399,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
+                            elementBeforeFieldStart={elementBeforeFieldStart}
                             elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
@@ -391,6 +420,11 @@ describe("LabeledField", () => {
                 ["field", "-field", getField],
                 ["error", "-error", getError],
                 ["read only message", "-read-only-message", getReadOnlyMessage],
+                [
+                    "elementBeforeFieldStart",
+                    "-element-before-field-start",
+                    getElementBeforeFieldStart,
+                ],
                 [
                     "elementAfterFieldStart",
                     "-element-after-field-start",
@@ -417,6 +451,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
+                            elementBeforeFieldStart={elementBeforeFieldStart}
                             elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
@@ -444,6 +479,11 @@ describe("LabeledField", () => {
                     getReadOnlyMessage,
                 ],
                 [
+                    "elementBeforeFieldStart",
+                    `${testId}-element-before-field-start`,
+                    getElementBeforeFieldStart,
+                ],
+                [
                     "elementAfterFieldStart",
                     `${testId}-element-after-field-start`,
                     getElementAfterFieldStart,
@@ -469,6 +509,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
+                            elementBeforeFieldStart={elementBeforeFieldStart}
                             elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
@@ -520,6 +561,7 @@ describe("LabeledField", () => {
                         return el;
                     },
                 ],
+                ["elementBeforeFieldStart", getElementBeforeFieldStart],
                 ["elementAfterFieldStart", getElementAfterFieldStart],
                 ["elementAfterFieldEnd", getElementAfterFieldEnd],
             ])(
@@ -536,6 +578,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
+                            elementBeforeFieldStart={elementBeforeFieldStart}
                             elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
@@ -617,6 +660,7 @@ describe("LabeledField", () => {
                     <LabeledField
                         field={<TextField value="" onChange={() => {}} />}
                         label="Label"
+                        elementBeforeFieldStart="Start helper text"
                         elementAfterFieldStart="Start helper text"
                         elementAfterFieldEnd="End helper text"
                     />,
@@ -783,6 +827,7 @@ describe("LabeledField", () => {
                         errorMessage={errorMessage}
                         description={description}
                         id={id}
+                        elementBeforeFieldStart="Start helper text"
                         elementAfterFieldStart="Start helper text"
                         elementAfterFieldEnd="End helper text"
                     />,
@@ -795,7 +840,7 @@ describe("LabeledField", () => {
                 // Assert
                 expect(field).toHaveAttribute(
                     "aria-describedby",
-                    `${id}-description ${id}-error ${id}-read-only-message ${id}-element-after-field-start ${id}-element-after-field-end`,
+                    `${id}-description ${id}-error ${id}-read-only-message ${id}-element-before-field-start ${id}-element-after-field-start ${id}-element-after-field-end`,
                 );
             });
 
@@ -814,6 +859,31 @@ describe("LabeledField", () => {
 
                 // Assert
                 expect(field).toHaveAttribute("aria-describedby", "");
+            });
+
+            it("Should set aria-describedby on the field to the id of the elementBeforeFieldStart", () => {
+                // Arrange
+                const elementBeforeFieldStart = "Helper text";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        elementBeforeFieldStart={elementBeforeFieldStart}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const elementBeforeFieldStartEl = screen.getByText(
+                    elementBeforeFieldStart,
+                );
+                const field = screen.getByRole("textbox");
+
+                // Assert
+                expect(field).toHaveAttribute(
+                    "aria-describedby",
+                    elementBeforeFieldStartEl.id,
+                );
             });
 
             it("Should set aria-describedby on the field to the id of the elementAfterFieldStart", () => {
@@ -1123,6 +1193,48 @@ describe("LabeledField", () => {
     });
 
     describe("Helper text", () => {
+        it("Should render the elementBeforeFieldStart prop if it is provided", () => {
+            // Arrange
+            const elementBeforeFieldStart = "Helper text";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                    elementBeforeFieldStart={elementBeforeFieldStart}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const elementBeforeFieldStartEl = screen.getByText(
+                elementBeforeFieldStart,
+            );
+
+            // Assert
+            expect(elementBeforeFieldStartEl).toBeInTheDocument();
+        });
+
+        it("Should render the elementAfterFieldStart prop if it is provided", () => {
+            // Arrange
+            const elementAfterFieldStart = "Helper text";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                    elementAfterFieldStart={elementAfterFieldStart}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const elementAfterFieldStartEl = screen.getByText(
+                elementAfterFieldStart,
+            );
+
+            // Assert
+            expect(elementAfterFieldStartEl).toBeInTheDocument();
+        });
+
         it("Should render the elementAfterFieldEnd prop if it is provided", () => {
             // Arrange
             const elementAfterFieldEnd = "Helper text";

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import * as React from "react";
 import {render, screen, within} from "@testing-library/react";
 
@@ -17,7 +18,8 @@ describe("LabeledField", () => {
     const errorMessage = "Error message";
     const testId = "test-id";
     const readOnlyMessage = "Read only message";
-    const elementAfterFieldEnd = "End helper text";
+    const elementAfterFieldStart = "After field start helper text";
+    const elementAfterFieldEnd = "After field end helper text";
 
     const getLabel = () => screen.getByText(label);
     const getDescription = () => screen.getByText(description);
@@ -25,6 +27,8 @@ describe("LabeledField", () => {
     const getError = () => screen.getByTestId("test-id-error");
     const getReadOnlyMessage = () =>
         screen.getByTestId("test-id-read-only-message");
+    const getElementAfterFieldStart = () =>
+        screen.getByText(elementAfterFieldStart);
     const getElementAfterFieldEnd = () =>
         screen.getByText(elementAfterFieldEnd);
 
@@ -220,6 +224,26 @@ describe("LabeledField", () => {
         expect(readOnlyMessage).toBeInTheDocument();
     });
 
+    it("LabeledField adds testId to elementAfterFieldStart", () => {
+        // Arrange
+        const testId = "testid";
+        render(
+            <LabeledField
+                field={<TextField value="" onChange={() => {}} />}
+                label="Label"
+                elementAfterFieldStart="Helper text"
+                testId={testId}
+            />,
+            defaultOptions,
+        );
+
+        // Assert
+        const elementAfterFieldStart = screen.getByTestId(
+            `${testId}-element-after-field-end`,
+        );
+        expect(elementAfterFieldStart).toBeInTheDocument();
+    });
+
     it("LabeledField adds testId to elementAfterFieldEnd", () => {
         // Arrange
         const testId = "testid";
@@ -321,6 +345,11 @@ describe("LabeledField", () => {
                     getReadOnlyMessage,
                 ],
                 [
+                    "elementAfterFieldStart",
+                    `${id}-element-after-field-start`,
+                    getElementAfterFieldStart,
+                ],
+                [
                     "elementAfterFieldEnd",
                     `${id}-element-after-field-end`,
                     getElementAfterFieldEnd,
@@ -342,6 +371,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
+                            elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
                         defaultOptions,
@@ -361,6 +391,11 @@ describe("LabeledField", () => {
                 ["field", "-field", getField],
                 ["error", "-error", getError],
                 ["read only message", "-read-only-message", getReadOnlyMessage],
+                [
+                    "elementAfterFieldStart",
+                    "-element-after-field-start",
+                    getElementAfterFieldStart,
+                ],
                 [
                     "elementAfterFieldEnd",
                     "-element-after-field-end",
@@ -382,6 +417,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
+                            elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
                         defaultOptions,
@@ -408,6 +444,11 @@ describe("LabeledField", () => {
                     getReadOnlyMessage,
                 ],
                 [
+                    "elementAfterFieldStart",
+                    `${testId}-element-after-field-start`,
+                    getElementAfterFieldStart,
+                ],
+                [
                     "elementAfterFieldEnd",
                     `${testId}-element-after-field-end`,
                     getElementAfterFieldEnd,
@@ -428,6 +469,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
+                            elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
                         defaultOptions,
@@ -478,6 +520,7 @@ describe("LabeledField", () => {
                         return el;
                     },
                 ],
+                ["elementAfterFieldStart", getElementAfterFieldStart],
                 ["elementAfterFieldEnd", getElementAfterFieldEnd],
             ])(
                 "should not set the data-testid attribute on the %s element if the testId prop is not set",
@@ -493,6 +536,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
+                            elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
                         defaultOptions,
@@ -552,6 +596,7 @@ describe("LabeledField", () => {
 
             it("should have no accessibility violations if the readOnlyMessage prop is set", async () => {
                 // Arrange
+                // Act
                 const {container} = render(
                     <LabeledField
                         field={<TextField value="" onChange={() => {}} />}
@@ -561,7 +606,22 @@ describe("LabeledField", () => {
                     defaultOptions,
                 );
 
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+
+            it("should have no accessibility violations if the helper text props are set", async () => {
+                // Arrange
                 // Act
+                const {container} = render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        elementAfterFieldStart="Start helper text"
+                        elementAfterFieldEnd="End helper text"
+                    />,
+                    defaultOptions,
+                );
 
                 // Assert
                 await expect(container).toHaveNoA11yViolations();
@@ -723,6 +783,7 @@ describe("LabeledField", () => {
                         errorMessage={errorMessage}
                         description={description}
                         id={id}
+                        elementAfterFieldStart="Start helper text"
                         elementAfterFieldEnd="End helper text"
                     />,
                     defaultOptions,
@@ -734,7 +795,7 @@ describe("LabeledField", () => {
                 // Assert
                 expect(field).toHaveAttribute(
                     "aria-describedby",
-                    `${id}-description ${id}-error ${id}-read-only-message ${id}-element-after-field-end`,
+                    `${id}-description ${id}-error ${id}-read-only-message ${id}-element-after-field-start ${id}-element-after-field-end`,
                 );
             });
 
@@ -753,6 +814,31 @@ describe("LabeledField", () => {
 
                 // Assert
                 expect(field).toHaveAttribute("aria-describedby", "");
+            });
+
+            it("Should set aria-describedby on the field to the id of the elementAfterFieldStart", () => {
+                // Arrange
+                const elementAfterFieldStart = "Helper text";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        elementAfterFieldStart={elementAfterFieldStart}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const elementAfterFieldStartEl = screen.getByText(
+                    elementAfterFieldStart,
+                );
+                const field = screen.getByRole("textbox");
+
+                // Assert
+                expect(field).toHaveAttribute(
+                    "aria-describedby",
+                    elementAfterFieldStartEl.id,
+                );
             });
 
             it("Should set aria-describedby on the field to the id of the elementAfterFieldEnd", () => {

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -19,6 +19,7 @@ describe("LabeledField", () => {
     const testId = "test-id";
     const readOnlyMessage = "Read only message";
     const elementBeforeFieldStart = "Before field start helper text";
+    const elementBeforeFieldEnd = "Before field end helper text";
     const elementAfterFieldStart = "After field start helper text";
     const elementAfterFieldEnd = "After field end helper text";
 
@@ -30,6 +31,8 @@ describe("LabeledField", () => {
         screen.getByTestId("test-id-read-only-message");
     const getElementBeforeFieldStart = () =>
         screen.getByText(elementBeforeFieldStart);
+    const getElementBeforeFieldEnd = () =>
+        screen.getByText(elementBeforeFieldEnd);
     const getElementAfterFieldStart = () =>
         screen.getByText(elementAfterFieldStart);
     const getElementAfterFieldEnd = () =>
@@ -247,6 +250,26 @@ describe("LabeledField", () => {
         expect(elementBeforeFieldStart).toBeInTheDocument();
     });
 
+    it("LabeledField adds testId to elementBeforeFieldEnd", () => {
+        // Arrange
+        const testId = "testid";
+        render(
+            <LabeledField
+                field={<TextField value="" onChange={() => {}} />}
+                label="Label"
+                elementBeforeFieldEnd="Helper text"
+                testId={testId}
+            />,
+            defaultOptions,
+        );
+
+        // Assert
+        const elementBeforeFieldEnd = screen.getByTestId(
+            `${testId}-element-before-field-end`,
+        );
+        expect(elementBeforeFieldEnd).toBeInTheDocument();
+    });
+
     it("LabeledField adds testId to elementAfterFieldStart", () => {
         // Arrange
         const testId = "testid";
@@ -373,6 +396,11 @@ describe("LabeledField", () => {
                     getElementBeforeFieldStart,
                 ],
                 [
+                    "elementBeforeFieldEnd",
+                    `${id}-element-before-field-end`,
+                    getElementBeforeFieldEnd,
+                ],
+                [
                     "elementAfterFieldStart",
                     `${id}-element-after-field-start`,
                     getElementAfterFieldStart,
@@ -400,6 +428,7 @@ describe("LabeledField", () => {
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
                             elementBeforeFieldStart={elementBeforeFieldStart}
+                            elementBeforeFieldEnd={elementBeforeFieldEnd}
                             elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
@@ -424,6 +453,11 @@ describe("LabeledField", () => {
                     "elementBeforeFieldStart",
                     "-element-before-field-start",
                     getElementBeforeFieldStart,
+                ],
+                [
+                    "elementBeforeFieldEnd",
+                    "-element-before-field-end",
+                    getElementBeforeFieldEnd,
                 ],
                 [
                     "elementAfterFieldStart",
@@ -452,6 +486,7 @@ describe("LabeledField", () => {
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
                             elementBeforeFieldStart={elementBeforeFieldStart}
+                            elementBeforeFieldEnd={elementBeforeFieldEnd}
                             elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
@@ -484,6 +519,11 @@ describe("LabeledField", () => {
                     getElementBeforeFieldStart,
                 ],
                 [
+                    "elementBeforeFieldEnd",
+                    `${testId}-element-before-field-end`,
+                    getElementBeforeFieldEnd,
+                ],
+                [
                     "elementAfterFieldStart",
                     `${testId}-element-after-field-start`,
                     getElementAfterFieldStart,
@@ -510,6 +550,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
                             elementBeforeFieldStart={elementBeforeFieldStart}
+                            elementBeforeFieldEnd={elementBeforeFieldEnd}
                             elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
@@ -562,6 +603,7 @@ describe("LabeledField", () => {
                     },
                 ],
                 ["elementBeforeFieldStart", getElementBeforeFieldStart],
+                ["elementBeforeFieldEnd", getElementBeforeFieldEnd],
                 ["elementAfterFieldStart", getElementAfterFieldStart],
                 ["elementAfterFieldEnd", getElementAfterFieldEnd],
             ])(
@@ -579,6 +621,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
                             elementBeforeFieldStart={elementBeforeFieldStart}
+                            elementBeforeFieldEnd={elementBeforeFieldEnd}
                             elementAfterFieldStart={elementAfterFieldStart}
                             elementAfterFieldEnd={elementAfterFieldEnd}
                         />,
@@ -661,6 +704,7 @@ describe("LabeledField", () => {
                         field={<TextField value="" onChange={() => {}} />}
                         label="Label"
                         elementBeforeFieldStart="Start helper text"
+                        elementBeforeFieldEnd="End helper text"
                         elementAfterFieldStart="Start helper text"
                         elementAfterFieldEnd="End helper text"
                     />,
@@ -828,6 +872,7 @@ describe("LabeledField", () => {
                         description={description}
                         id={id}
                         elementBeforeFieldStart="Start helper text"
+                        elementBeforeFieldEnd="End helper text"
                         elementAfterFieldStart="Start helper text"
                         elementAfterFieldEnd="End helper text"
                     />,
@@ -840,7 +885,15 @@ describe("LabeledField", () => {
                 // Assert
                 expect(field).toHaveAttribute(
                     "aria-describedby",
-                    `${id}-description ${id}-error ${id}-read-only-message ${id}-element-before-field-start ${id}-element-after-field-start ${id}-element-after-field-end`,
+                    [
+                        `${id}-description`,
+                        `${id}-error`,
+                        `${id}-read-only-message`,
+                        `${id}-element-before-field-start`,
+                        `${id}-element-before-field-end`,
+                        `${id}-element-after-field-start`,
+                        `${id}-element-after-field-end`,
+                    ].join(" "),
                 );
             });
 
@@ -883,6 +936,31 @@ describe("LabeledField", () => {
                 expect(field).toHaveAttribute(
                     "aria-describedby",
                     elementBeforeFieldStartEl.id,
+                );
+            });
+
+            it("Should set aria-describedby on the field to the id of the elementBeforeFieldEnd", () => {
+                // Arrange
+                const elementBeforeFieldEnd = "Helper text";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        elementBeforeFieldEnd={elementBeforeFieldEnd}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const elementBeforeFieldEndEl = screen.getByText(
+                    elementBeforeFieldEnd,
+                );
+                const field = screen.getByRole("textbox");
+
+                // Assert
+                expect(field).toHaveAttribute(
+                    "aria-describedby",
+                    elementBeforeFieldEndEl.id,
                 );
             });
 
@@ -1212,6 +1290,27 @@ describe("LabeledField", () => {
 
             // Assert
             expect(elementBeforeFieldStartEl).toBeInTheDocument();
+        });
+
+        it("Should render the elementBeforeFieldEnd prop if it is provided", () => {
+            // Arrange
+            const elementBeforeFieldEnd = "Helper text";
+            render(
+                <LabeledField
+                    field={<TextField value="" onChange={() => {}} />}
+                    label="Label"
+                    elementBeforeFieldEnd={elementBeforeFieldEnd}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const elementBeforeFieldEndEl = screen.getByText(
+                elementBeforeFieldEnd,
+            );
+
+            // Assert
+            expect(elementBeforeFieldEndEl).toBeInTheDocument();
         });
 
         it("Should render the elementAfterFieldStart prop if it is provided", () => {

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -859,104 +859,34 @@ describe("LabeledField", () => {
                 expect(field).toHaveAttribute("aria-describedby", "");
             });
 
-            it("Should set aria-describedby on the field to the id of the elementBeforeFieldStart", () => {
-                // Arrange
-                const elementBeforeFieldStart = "Helper text";
-                render(
-                    <LabeledField
-                        field={<TextField value="" onChange={() => {}} />}
-                        label="Label"
-                        elementBeforeFieldStart={elementBeforeFieldStart}
-                    />,
-                    defaultOptions,
-                );
+            it.each([
+                "elementBeforeFieldStart",
+                "elementBeforeFieldEnd",
+                "elementAfterFieldStart",
+                "elementAfterFieldEnd",
+            ])(
+                "Should set aria-describedby on the field to the id of the %s",
+                (propName) => {
+                    // Arrange
+                    const propValue = "Helper text";
+                    const props = {[propName]: propValue};
+                    render(
+                        <LabeledField
+                            field={<TextField value="" onChange={() => {}} />}
+                            label="Label"
+                            {...props}
+                        />,
+                        defaultOptions,
+                    );
 
-                // Act
-                const elementBeforeFieldStartEl = screen.getByText(
-                    elementBeforeFieldStart,
-                );
-                const field = screen.getByRole("textbox");
+                    // Act
+                    const el = screen.getByText(propValue);
+                    const field = screen.getByRole("textbox");
 
-                // Assert
-                expect(field).toHaveAttribute(
-                    "aria-describedby",
-                    elementBeforeFieldStartEl.id,
-                );
-            });
-
-            it("Should set aria-describedby on the field to the id of the elementBeforeFieldEnd", () => {
-                // Arrange
-                const elementBeforeFieldEnd = "Helper text";
-                render(
-                    <LabeledField
-                        field={<TextField value="" onChange={() => {}} />}
-                        label="Label"
-                        elementBeforeFieldEnd={elementBeforeFieldEnd}
-                    />,
-                    defaultOptions,
-                );
-
-                // Act
-                const elementBeforeFieldEndEl = screen.getByText(
-                    elementBeforeFieldEnd,
-                );
-                const field = screen.getByRole("textbox");
-
-                // Assert
-                expect(field).toHaveAttribute(
-                    "aria-describedby",
-                    elementBeforeFieldEndEl.id,
-                );
-            });
-
-            it("Should set aria-describedby on the field to the id of the elementAfterFieldStart", () => {
-                // Arrange
-                const elementAfterFieldStart = "Helper text";
-                render(
-                    <LabeledField
-                        field={<TextField value="" onChange={() => {}} />}
-                        label="Label"
-                        elementAfterFieldStart={elementAfterFieldStart}
-                    />,
-                    defaultOptions,
-                );
-
-                // Act
-                const elementAfterFieldStartEl = screen.getByText(
-                    elementAfterFieldStart,
-                );
-                const field = screen.getByRole("textbox");
-
-                // Assert
-                expect(field).toHaveAttribute(
-                    "aria-describedby",
-                    elementAfterFieldStartEl.id,
-                );
-            });
-
-            it("Should set aria-describedby on the field to the id of the elementAfterFieldEnd", () => {
-                // Arrange
-                const elementAfterFieldEnd = "Helper text";
-                render(
-                    <LabeledField
-                        field={<TextField value="" onChange={() => {}} />}
-                        label="Label"
-                        elementAfterFieldEnd={elementAfterFieldEnd}
-                    />,
-                    defaultOptions,
-                );
-
-                // Act
-                const elementAfterFieldEndEl =
-                    screen.getByText(elementAfterFieldEnd);
-                const field = screen.getByRole("textbox");
-
-                // Assert
-                expect(field).toHaveAttribute(
-                    "aria-describedby",
-                    elementAfterFieldEndEl.id,
-                );
-            });
+                    // Assert
+                    expect(field).toHaveAttribute("aria-describedby", el.id);
+                },
+            );
         });
     });
 

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -309,12 +309,12 @@ export default function LabeledField(props: Props) {
             id: fieldId,
             "aria-describedby": [
                 description && descriptionId,
-                errorMessage && errorId,
-                readOnlyMessage && readOnlyMessageId,
                 elementBeforeFieldStart && elementBeforeFieldStartId,
                 elementBeforeFieldEnd && elementBeforeFieldEndId,
                 elementAfterFieldStart && elementAfterFieldStartId,
                 elementAfterFieldEnd && elementAfterFieldEndId,
+                readOnlyMessage && readOnlyMessageId,
+                errorMessage && errorId,
             ]
                 .filter(Boolean)
                 .join(" "),
@@ -455,9 +455,9 @@ export default function LabeledField(props: Props) {
             {renderField()}
             <View style={styles.helperTextContainer}>
                 <View>
+                    {maybeRenderElementAfterFieldStart()}
                     {maybeRenderReadOnlyMessage()}
                     {maybeRenderError()}
-                    {maybeRenderElementAfterFieldStart()}
                 </View>
                 {maybeRenderElementAfterFieldEnd()}
             </View>

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -190,7 +190,7 @@ export default function LabeledField(props: Props) {
                             ? styles.labelWithDescription
                             : styles.labelWithNoDescription,
                         stylesProp?.label,
-                        hasError ? styles.labelWithError : undefined,
+                        hasError ? styles.error : undefined,
                         isDisabled && styles.disabledLabel,
                     ]}
                     tag="label"
@@ -257,7 +257,7 @@ export default function LabeledField(props: Props) {
                         <>
                             <PhosphorIcon
                                 icon={WarningCircle}
-                                style={[styles.errorIcon, styles.error]}
+                                style={[styles.errorIcon]}
                                 role="img"
                                 aria-label={labels.errorIconAriaLabel}
                             />
@@ -265,7 +265,6 @@ export default function LabeledField(props: Props) {
                                 style={[
                                     styles.textWordBreak,
                                     styles.helperTextMessage,
-                                    styles.errorMessage,
                                     styles.error,
                                 ]}
                             >
@@ -341,6 +340,7 @@ export default function LabeledField(props: Props) {
                             styles.helperTextSectionWithContent,
                             styles.helperTextMessage,
                             styles.textWordBreak,
+                            hasError && styles.error,
                             stylesProp?.elementAfterFieldEnd,
                         ]}
                         tag="div"
@@ -358,9 +358,6 @@ export default function LabeledField(props: Props) {
 const styles = StyleSheet.create({
     label: {
         color: semanticColor.core.foreground.neutral.strong,
-    },
-    labelWithError: {
-        color: theme.label.color.error.foreground,
     },
     disabledLabel: {
         color: theme.label.color.disabled.foreground,
@@ -397,12 +394,11 @@ const styles = StyleSheet.create({
     },
     error: {
         color: theme.error.color.foreground,
+        fontWeight: theme.error.font.weight,
     },
     errorIcon: {
         marginTop: sizing.size_010, // This vertically aligns the icon with the text
-    },
-    errorMessage: {
-        fontWeight: theme.error.font.weight,
+        color: theme.error.color.foreground,
     },
     required: {
         color: theme.requiredIndicator.color.foreground,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -126,6 +126,9 @@ type Props = {
 
     /**
      * The element to display before the field at the start of the row.
+     *
+     * This is commonly used for a description for the field. Prefer using this
+     * prop to provide more information about a field instead of tooltips.
      */
     elementBeforeFieldStart?: React.ReactNode;
     /**
@@ -134,6 +137,9 @@ type Props = {
     elementBeforeFieldEnd?: React.ReactNode;
     /**
      * The element to display after the field at the start of the row.
+     *
+     * For error messages or messages related to the read only state, use the
+     * `errorMessage` or `readOnlyMessage` props instead.
      */
     elementAfterFieldStart?: React.ReactNode;
     /**

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -86,6 +86,7 @@ type Props = {
      * - The field will have an id formatted as `${id}-field`
      * - The error will have an id formatted as `${id}-error`
      * - The read only message will have an id formatted as `${id}-read-only-message`
+     * - The `elementAfterFieldEnd` will have an id formatted as `${id}-element-after-field-end`
      *
      * If the `id` prop is not provided, a base unique id will be auto-generated.
      * This is important so that the different elements can be wired up together
@@ -103,6 +104,7 @@ type Props = {
      * - The field will have a testId formatted as `${testId}-field`
      * - The error will have a testId formatted as `${testId}-error`
      * - The read only message will have a testId formatted as `${testId}-read-only-message`
+     * - The `elementAfterFieldEnd` will have a testId formatted as `${testId}-element-after-field-end`
      */
     testId?: string;
     /**
@@ -156,6 +158,7 @@ export default function LabeledField(props: Props) {
     const fieldId = `${uniqueId}-field`;
     const errorId = `${uniqueId}-error`;
     const readOnlyMessageId = `${uniqueId}-read-only-message`;
+    const elementAfterFieldEndId = `${uniqueId}-element-after-field-end`;
 
     const isRequired = !!required || !!field.props.required;
     const hasError = !!errorMessage || !!field.props.error;
@@ -281,6 +284,7 @@ export default function LabeledField(props: Props) {
                 description && descriptionId,
                 errorMessage && errorId,
                 readOnlyMessage && readOnlyMessageId,
+                elementAfterFieldEnd && elementAfterFieldEndId,
             ]
                 .filter(Boolean)
                 .join(" "),
@@ -338,6 +342,8 @@ export default function LabeledField(props: Props) {
                             styles.textWordBreak,
                         ]}
                         tag="div"
+                        id={elementAfterFieldEndId}
+                        testId={testId && `${testId}-element-after-field-end`}
                     >
                         {elementAfterFieldEnd}
                     </BodyText>

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -77,6 +77,7 @@ type Props = {
         description?: StyleType;
         error?: StyleType;
         readOnlyMessage?: StyleType;
+        elementBeforeFieldStart?: StyleType;
         elementAfterFieldStart?: StyleType;
         elementAfterFieldEnd?: StyleType;
     };
@@ -88,6 +89,7 @@ type Props = {
      * - The field will have an id formatted as `${id}-field`
      * - The error will have an id formatted as `${id}-error`
      * - The read only message will have an id formatted as `${id}-read-only-message`
+     * - The `elementBeforeFieldStart` will have an id formatted as `${id}-element-before-field-start`
      * - The `elementAfterFieldStart` will have an id formatted as `${id}-element-after-field-start`
      * - The `elementAfterFieldEnd` will have an id formatted as `${id}-element-after-field-end`
      *
@@ -107,6 +109,7 @@ type Props = {
      * - The field will have a testId formatted as `${testId}-field`
      * - The error will have a testId formatted as `${testId}-error`
      * - The read only message will have a testId formatted as `${testId}-read-only-message`
+     * - The `elementBeforeFieldStart` will have a testId formatted as `${testId}-element-before-field-start`
      * - The `elementAfterFieldStart` will have a testId formatted as `${testId}-element-after-field-start`
      * - The `elementAfterFieldEnd` will have a testId formatted as `${testId}-element-after-field-end`
      */
@@ -118,6 +121,10 @@ type Props = {
      */
     labels?: LabeledFieldLabels;
 
+    /**
+     * The element to display before the field at the start of the row.
+     */
+    elementBeforeFieldStart?: React.ReactNode;
     /**
      * The element to display after the field at the start of the row.
      */
@@ -156,6 +163,7 @@ export default function LabeledField(props: Props) {
         errorMessage,
         readOnlyMessage,
         labels = defaultLabeledFieldLabels,
+        elementBeforeFieldStart,
         elementAfterFieldStart,
         elementAfterFieldEnd,
     } = props;
@@ -167,6 +175,7 @@ export default function LabeledField(props: Props) {
     const fieldId = `${uniqueId}-field`;
     const errorId = `${uniqueId}-error`;
     const readOnlyMessageId = `${uniqueId}-read-only-message`;
+    const elementBeforeFieldStartId = `${uniqueId}-element-before-field-start`;
     const elementAfterFieldStartId = `${uniqueId}-element-after-field-start`;
     const elementAfterFieldEndId = `${uniqueId}-element-after-field-end`;
 
@@ -293,6 +302,7 @@ export default function LabeledField(props: Props) {
                 description && descriptionId,
                 errorMessage && errorId,
                 readOnlyMessage && readOnlyMessageId,
+                elementBeforeFieldStart && elementBeforeFieldStartId,
                 elementAfterFieldStart && elementAfterFieldStartId,
                 elementAfterFieldEnd && elementAfterFieldEndId,
             ]
@@ -331,6 +341,27 @@ export default function LabeledField(props: Props) {
                     {readOnlyMessage}
                 </BodyText>
             </View>
+        );
+    }
+
+    function maybeRenderElementBeforeFieldStart() {
+        if (!elementBeforeFieldStart) {
+            return null;
+        }
+        return (
+            <BodyText
+                style={[
+                    styles.description,
+                    styles.helperTextMessage,
+                    styles.textWordBreak,
+                    stylesProp?.elementBeforeFieldStart,
+                ]}
+                tag="div"
+                id={elementBeforeFieldStartId}
+                testId={testId && `${testId}-element-before-field-start`}
+            >
+                {elementBeforeFieldStart}
+            </BodyText>
         );
     }
 
@@ -380,9 +411,14 @@ export default function LabeledField(props: Props) {
     return (
         <View style={stylesProp?.root}>
             {renderLabel()}
-            {maybeRenderDescription()}
+            <View style={styles.helperTextContainer}>
+                <View>
+                    {maybeRenderDescription()}
+                    {maybeRenderElementBeforeFieldStart()}
+                </View>
+            </View>
             {renderField()}
-            <View style={styles.afterField}>
+            <View style={styles.helperTextContainer}>
                 <View>
                     {maybeRenderReadOnlyMessage()}
                     {maybeRenderError()}
@@ -445,7 +481,7 @@ const styles = StyleSheet.create({
     textWordBreak: {
         overflowWrap: "break-word",
     },
-    afterField: {
+    helperTextContainer: {
         flexDirection: "row",
         justifyContent: "space-between",
         gap: sizing.size_040,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -77,6 +77,7 @@ type Props = {
         description?: StyleType;
         error?: StyleType;
         readOnlyMessage?: StyleType;
+        elementAfterFieldEnd?: StyleType;
     };
     /**
      * A unique id to use as the base of the ids for the elements within the component.
@@ -340,6 +341,7 @@ export default function LabeledField(props: Props) {
                             styles.helperTextSectionWithContent,
                             styles.helperTextMessage,
                             styles.textWordBreak,
+                            stylesProp?.elementAfterFieldEnd,
                         ]}
                         tag="div"
                         id={elementAfterFieldEndId}

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -243,7 +243,7 @@ export default function LabeledField(props: Props) {
             <React.Fragment>
                 <BodyText
                     style={[
-                        styles.beforeHelperText,
+                        styles.spacingUnderHelperText,
                         styles.helperTextMessage,
                         stylesProp?.description,
                         isDisabled && styles.disabledStyling,
@@ -263,7 +263,9 @@ export default function LabeledField(props: Props) {
                 <View
                     style={[
                         styles.helperTextSection,
-                        errorMessage ? styles.afterHelperText : undefined,
+                        errorMessage
+                            ? styles.spacingAboveHelperText
+                            : undefined,
                         stylesProp?.error,
                     ]}
                     id={errorId}
@@ -332,7 +334,7 @@ export default function LabeledField(props: Props) {
             <View
                 style={[
                     styles.helperTextSection,
-                    styles.afterHelperText,
+                    styles.spacingAboveHelperText,
                     stylesProp?.readOnlyMessage,
                 ]}
                 id={readOnlyMessageId}
@@ -357,7 +359,7 @@ export default function LabeledField(props: Props) {
         return (
             <BodyText
                 style={[
-                    styles.beforeHelperText,
+                    styles.spacingUnderHelperText,
                     styles.helperTextMessage,
                     isDisabled && styles.disabledStyling,
                     stylesProp?.elementBeforeFieldStart,
@@ -378,7 +380,7 @@ export default function LabeledField(props: Props) {
         return (
             <BodyText
                 style={[
-                    styles.beforeHelperText,
+                    styles.spacingUnderHelperText,
                     styles.helperTextMessage,
                     isDisabled && styles.disabledStyling,
                     stylesProp?.elementBeforeFieldEnd,
@@ -399,7 +401,7 @@ export default function LabeledField(props: Props) {
         return (
             <BodyText
                 style={[
-                    styles.afterHelperText,
+                    styles.spacingAboveHelperText,
                     styles.helperTextMessage,
                     isDisabled && styles.disabledStyling,
                     stylesProp?.elementAfterFieldStart,
@@ -420,7 +422,7 @@ export default function LabeledField(props: Props) {
         return (
             <BodyText
                 style={[
-                    styles.afterHelperText,
+                    styles.spacingAboveHelperText,
                     styles.helperTextMessage,
                     hasError && styles.errorStyling,
                     isDisabled && styles.disabledStyling,
@@ -509,11 +511,10 @@ const styles = StyleSheet.create({
     beforeHelperTextContainer: {
         alignItems: "flex-end",
     },
-    beforeHelperText: {
-        paddingBlockEnd: theme.root.layout.paddingBlockEnd.description,
+    spacingUnderHelperText: {
+        paddingBlockEnd: theme.root.layout.spacingBetweenHelperText,
     },
-    afterHelperText: {
-        paddingBlockStart:
-            theme.root.layout.paddingBlockEnd.helperTextSectionWithContent,
+    spacingAboveHelperText: {
+        paddingBlockStart: theme.root.layout.spacingBetweenHelperText,
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -262,7 +262,7 @@ export default function LabeledField(props: Props) {
             <React.Fragment>
                 <View
                     style={[
-                        styles.helperTextSection,
+                        styles.helperTextWithIcon,
                         errorMessage
                             ? styles.spacingAboveHelperText
                             : undefined,
@@ -333,7 +333,7 @@ export default function LabeledField(props: Props) {
         return (
             <View
                 style={[
-                    styles.helperTextSection,
+                    styles.helperTextWithIcon,
                     styles.spacingAboveHelperText,
                     stylesProp?.readOnlyMessage,
                 ]}
@@ -480,7 +480,7 @@ const styles = StyleSheet.create({
     disabledStyling: {
         color: semanticColor.core.foreground.disabled.strong,
     },
-    helperTextSection: {
+    helperTextWithIcon: {
         flexDirection: "row",
         gap: theme.helperText.layout.gap,
     },

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -201,11 +201,7 @@ export default function LabeledField(props: Props) {
     function renderLabel(): React.ReactNode {
         const requiredIcon = (
             <StyledSpan
-                style={[
-                    styles.textWordBreak,
-                    styles.required,
-                    isDisabled && styles.disabledStyling,
-                ]}
+                style={[styles.required, isDisabled && styles.disabledStyling]}
                 aria-hidden={true}
             >
                 {" "}
@@ -217,7 +213,6 @@ export default function LabeledField(props: Props) {
             <React.Fragment>
                 <BodyText
                     style={[
-                        styles.textWordBreak,
                         styles.label,
                         description
                             ? styles.labelWithDescription
@@ -248,7 +243,6 @@ export default function LabeledField(props: Props) {
             <React.Fragment>
                 <BodyText
                     style={[
-                        styles.textWordBreak,
                         styles.beforeHelperText,
                         styles.helperTextMessage,
                         stylesProp?.description,
@@ -269,9 +263,7 @@ export default function LabeledField(props: Props) {
                 <View
                     style={[
                         styles.helperTextSection,
-                        errorMessage
-                            ? styles.helperTextSectionWithContent
-                            : undefined,
+                        errorMessage ? styles.afterHelperText : undefined,
                         stylesProp?.error,
                     ]}
                     id={errorId}
@@ -297,7 +289,6 @@ export default function LabeledField(props: Props) {
                             />
                             <BodyText
                                 style={[
-                                    styles.textWordBreak,
                                     styles.helperTextMessage,
                                     styles.errorStyling,
                                 ]}
@@ -341,7 +332,7 @@ export default function LabeledField(props: Props) {
             <View
                 style={[
                     styles.helperTextSection,
-                    styles.helperTextSectionWithContent,
+                    styles.afterHelperText,
                     stylesProp?.readOnlyMessage,
                 ]}
                 id={readOnlyMessageId}
@@ -352,9 +343,7 @@ export default function LabeledField(props: Props) {
                     aria-label={labels.readOnlyAriaLabel}
                     color={semanticColor.core.foreground.neutral.subtle}
                 />
-                <BodyText
-                    style={[styles.textWordBreak, styles.helperTextMessage]}
-                >
+                <BodyText style={styles.helperTextMessage}>
                     {readOnlyMessage}
                 </BodyText>
             </View>
@@ -370,7 +359,6 @@ export default function LabeledField(props: Props) {
                 style={[
                     styles.beforeHelperText,
                     styles.helperTextMessage,
-                    styles.textWordBreak,
                     isDisabled && styles.disabledStyling,
                     stylesProp?.elementBeforeFieldStart,
                 ]}
@@ -392,7 +380,6 @@ export default function LabeledField(props: Props) {
                 style={[
                     styles.beforeHelperText,
                     styles.helperTextMessage,
-                    styles.textWordBreak,
                     isDisabled && styles.disabledStyling,
                     stylesProp?.elementBeforeFieldEnd,
                 ]}
@@ -412,9 +399,8 @@ export default function LabeledField(props: Props) {
         return (
             <BodyText
                 style={[
-                    styles.helperTextSectionWithContent,
+                    styles.afterHelperText,
                     styles.helperTextMessage,
-                    styles.textWordBreak,
                     isDisabled && styles.disabledStyling,
                     stylesProp?.elementAfterFieldStart,
                 ]}
@@ -434,9 +420,8 @@ export default function LabeledField(props: Props) {
         return (
             <BodyText
                 style={[
-                    styles.helperTextSectionWithContent,
+                    styles.afterHelperText,
                     styles.helperTextMessage,
-                    styles.textWordBreak,
                     hasError && styles.errorStyling,
                     isDisabled && styles.disabledStyling,
                     stylesProp?.elementAfterFieldEnd,
@@ -481,6 +466,7 @@ export default function LabeledField(props: Props) {
 const styles = StyleSheet.create({
     label: {
         color: semanticColor.core.foreground.neutral.strong,
+        overflowWrap: "break-word",
     },
     labelWithDescription: {
         paddingBlockEnd: theme.root.layout.paddingBlockEnd.labelWithDescription,
@@ -496,11 +482,8 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         gap: theme.helperText.layout.gap,
     },
-    helperTextSectionWithContent: {
-        paddingBlockStart:
-            theme.root.layout.paddingBlockEnd.helperTextSectionWithContent,
-    },
     helperTextMessage: {
+        overflowWrap: "break-word",
         color: theme.helperText.color.foreground,
         fontSize: theme.helperText.font.size,
         lineHeight: theme.helperText.font.lineHeight,
@@ -518,9 +501,6 @@ const styles = StyleSheet.create({
     required: {
         color: theme.requiredIndicator.color.foreground,
     },
-    textWordBreak: {
-        overflowWrap: "break-word",
-    },
     helperTextContainer: {
         flexDirection: "row",
         justifyContent: "space-between",
@@ -531,5 +511,9 @@ const styles = StyleSheet.create({
     },
     beforeHelperText: {
         paddingBlockEnd: theme.root.layout.paddingBlockEnd.description,
+    },
+    afterHelperText: {
+        paddingBlockStart:
+            theme.root.layout.paddingBlockEnd.helperTextSectionWithContent,
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -78,6 +78,7 @@ type Props = {
         error?: StyleType;
         readOnlyMessage?: StyleType;
         elementBeforeFieldStart?: StyleType;
+        elementBeforeFieldEnd?: StyleType;
         elementAfterFieldStart?: StyleType;
         elementAfterFieldEnd?: StyleType;
     };
@@ -90,6 +91,7 @@ type Props = {
      * - The error will have an id formatted as `${id}-error`
      * - The read only message will have an id formatted as `${id}-read-only-message`
      * - The `elementBeforeFieldStart` will have an id formatted as `${id}-element-before-field-start`
+     * - The `elementBeforeFieldEnd` will have an id formatted as `${id}-element-before-field-end`
      * - The `elementAfterFieldStart` will have an id formatted as `${id}-element-after-field-start`
      * - The `elementAfterFieldEnd` will have an id formatted as `${id}-element-after-field-end`
      *
@@ -110,6 +112,7 @@ type Props = {
      * - The error will have a testId formatted as `${testId}-error`
      * - The read only message will have a testId formatted as `${testId}-read-only-message`
      * - The `elementBeforeFieldStart` will have a testId formatted as `${testId}-element-before-field-start`
+     * - The `elementBeforeFieldEnd` will have a testId formatted as `${testId}-element-before-field-end`
      * - The `elementAfterFieldStart` will have a testId formatted as `${testId}-element-after-field-start`
      * - The `elementAfterFieldEnd` will have a testId formatted as `${testId}-element-after-field-end`
      */
@@ -125,6 +128,10 @@ type Props = {
      * The element to display before the field at the start of the row.
      */
     elementBeforeFieldStart?: React.ReactNode;
+    /**
+     * The element to display before the field at the end of the row.
+     */
+    elementBeforeFieldEnd?: React.ReactNode;
     /**
      * The element to display after the field at the start of the row.
      */
@@ -164,6 +171,7 @@ export default function LabeledField(props: Props) {
         readOnlyMessage,
         labels = defaultLabeledFieldLabels,
         elementBeforeFieldStart,
+        elementBeforeFieldEnd,
         elementAfterFieldStart,
         elementAfterFieldEnd,
     } = props;
@@ -176,6 +184,7 @@ export default function LabeledField(props: Props) {
     const errorId = `${uniqueId}-error`;
     const readOnlyMessageId = `${uniqueId}-read-only-message`;
     const elementBeforeFieldStartId = `${uniqueId}-element-before-field-start`;
+    const elementBeforeFieldEndId = `${uniqueId}-element-before-field-end`;
     const elementAfterFieldStartId = `${uniqueId}-element-after-field-start`;
     const elementAfterFieldEndId = `${uniqueId}-element-after-field-end`;
 
@@ -303,6 +312,7 @@ export default function LabeledField(props: Props) {
                 errorMessage && errorId,
                 readOnlyMessage && readOnlyMessageId,
                 elementBeforeFieldStart && elementBeforeFieldStartId,
+                elementBeforeFieldEnd && elementBeforeFieldEndId,
                 elementAfterFieldStart && elementAfterFieldStartId,
                 elementAfterFieldEnd && elementAfterFieldEndId,
             ]
@@ -365,6 +375,27 @@ export default function LabeledField(props: Props) {
         );
     }
 
+    function maybeRenderElementBeforeFieldEnd() {
+        if (!elementBeforeFieldEnd) {
+            return null;
+        }
+        return (
+            <BodyText
+                style={[
+                    styles.description,
+                    styles.helperTextMessage,
+                    styles.textWordBreak,
+                    stylesProp?.elementBeforeFieldEnd,
+                ]}
+                tag="div"
+                id={elementBeforeFieldEndId}
+                testId={testId && `${testId}-element-before-field-end`}
+            >
+                {elementBeforeFieldEnd}
+            </BodyText>
+        );
+    }
+
     function maybeRenderElementAfterFieldStart() {
         if (!elementAfterFieldStart) {
             return null;
@@ -411,11 +442,17 @@ export default function LabeledField(props: Props) {
     return (
         <View style={stylesProp?.root}>
             {renderLabel()}
-            <View style={styles.helperTextContainer}>
+            <View
+                style={[
+                    styles.helperTextContainer,
+                    styles.beforeHelperTextContainer,
+                ]}
+            >
                 <View>
                     {maybeRenderDescription()}
                     {maybeRenderElementBeforeFieldStart()}
                 </View>
+                {maybeRenderElementBeforeFieldEnd()}
             </View>
             {renderField()}
             <View style={styles.helperTextContainer}>
@@ -485,5 +522,8 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         justifyContent: "space-between",
         gap: sizing.size_040,
+    },
+    beforeHelperTextContainer: {
+        alignItems: "flex-end",
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -436,7 +436,7 @@ const styles = StyleSheet.create({
         fontWeight: theme.error.font.weight,
     },
     errorIcon: {
-        marginTop: sizing.size_010, // This vertically aligns the icon with the text
+        marginBlockStart: sizing.size_010, // This vertically aligns the icon with the text
         color: theme.error.color.foreground,
     },
     required: {

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -111,6 +111,11 @@ type Props = {
      * This is useful for internationalization. Defaults to English.
      */
     labels?: LabeledFieldLabels;
+
+    /**
+     * The element to display after the field at the end of the row.
+     */
+    elementAfterFieldEnd?: React.ReactNode;
 };
 
 export type LabeledFieldLabels = {
@@ -141,6 +146,7 @@ export default function LabeledField(props: Props) {
         errorMessage,
         readOnlyMessage,
         labels = defaultLabeledFieldLabels,
+        elementAfterFieldEnd,
     } = props;
 
     const generatedUniqueId = React.useId();
@@ -319,8 +325,24 @@ export default function LabeledField(props: Props) {
             {renderLabel()}
             {maybeRenderDescription()}
             {renderField()}
-            {maybeRenderReadOnlyMessage()}
-            {maybeRenderError()}
+            <View style={styles.afterField}>
+                <View>
+                    {maybeRenderReadOnlyMessage()}
+                    {maybeRenderError()}
+                </View>
+                {elementAfterFieldEnd && (
+                    <BodyText
+                        style={[
+                            styles.helperTextSectionWithContent,
+                            styles.helperTextMessage,
+                            styles.textWordBreak,
+                        ]}
+                        tag="div"
+                    >
+                        {elementAfterFieldEnd}
+                    </BodyText>
+                )}
+            </View>
         </View>
     );
 }
@@ -379,5 +401,10 @@ const styles = StyleSheet.create({
     },
     textWordBreak: {
         overflowWrap: "break-word",
+    },
+    afterField: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        gap: sizing.size_040,
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -217,9 +217,9 @@ export default function LabeledField(props: Props) {
                         description
                             ? styles.labelWithDescription
                             : styles.labelWithNoDescription,
-                        stylesProp?.label,
-                        hasError ? styles.errorStyling : undefined,
+                        hasError ? styles.labelWithError : undefined,
                         isDisabled && styles.disabledStyling,
+                        stylesProp?.label,
                     ]}
                     tag="label"
                     htmlFor={fieldId}
@@ -476,6 +476,9 @@ const styles = StyleSheet.create({
     labelWithNoDescription: {
         paddingBlockEnd:
             theme.root.layout.paddingBlockEnd.labelWithNoDescription,
+    },
+    labelWithError: {
+        color: theme.label.color.error.foreground,
     },
     disabledStyling: {
         color: semanticColor.core.foreground.disabled.strong,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -324,6 +324,28 @@ export default function LabeledField(props: Props) {
         );
     }
 
+    function maybeRenderElementAfterFieldEnd() {
+        if (!elementAfterFieldEnd) {
+            return null;
+        }
+        return (
+            <BodyText
+                style={[
+                    styles.helperTextSectionWithContent,
+                    styles.helperTextMessage,
+                    styles.textWordBreak,
+                    hasError && styles.error,
+                    stylesProp?.elementAfterFieldEnd,
+                ]}
+                tag="div"
+                id={elementAfterFieldEndId}
+                testId={testId && `${testId}-element-after-field-end`}
+            >
+                {elementAfterFieldEnd}
+            </BodyText>
+        );
+    }
+
     return (
         <View style={stylesProp?.root}>
             {renderLabel()}
@@ -334,22 +356,7 @@ export default function LabeledField(props: Props) {
                     {maybeRenderReadOnlyMessage()}
                     {maybeRenderError()}
                 </View>
-                {elementAfterFieldEnd && (
-                    <BodyText
-                        style={[
-                            styles.helperTextSectionWithContent,
-                            styles.helperTextMessage,
-                            styles.textWordBreak,
-                            hasError && styles.error,
-                            stylesProp?.elementAfterFieldEnd,
-                        ]}
-                        tag="div"
-                        id={elementAfterFieldEndId}
-                        testId={testId && `${testId}-element-after-field-end`}
-                    >
-                        {elementAfterFieldEnd}
-                    </BodyText>
-                )}
+                {maybeRenderElementAfterFieldEnd()}
             </View>
         </View>
     );

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -77,6 +77,7 @@ type Props = {
         description?: StyleType;
         error?: StyleType;
         readOnlyMessage?: StyleType;
+        elementAfterFieldStart?: StyleType;
         elementAfterFieldEnd?: StyleType;
     };
     /**
@@ -87,6 +88,7 @@ type Props = {
      * - The field will have an id formatted as `${id}-field`
      * - The error will have an id formatted as `${id}-error`
      * - The read only message will have an id formatted as `${id}-read-only-message`
+     * - The `elementAfterFieldStart` will have an id formatted as `${id}-element-after-field-start`
      * - The `elementAfterFieldEnd` will have an id formatted as `${id}-element-after-field-end`
      *
      * If the `id` prop is not provided, a base unique id will be auto-generated.
@@ -105,6 +107,7 @@ type Props = {
      * - The field will have a testId formatted as `${testId}-field`
      * - The error will have a testId formatted as `${testId}-error`
      * - The read only message will have a testId formatted as `${testId}-read-only-message`
+     * - The `elementAfterFieldStart` will have a testId formatted as `${testId}-element-after-field-start`
      * - The `elementAfterFieldEnd` will have a testId formatted as `${testId}-element-after-field-end`
      */
     testId?: string;
@@ -115,6 +118,10 @@ type Props = {
      */
     labels?: LabeledFieldLabels;
 
+    /**
+     * The element to display after the field at the start of the row.
+     */
+    elementAfterFieldStart?: React.ReactNode;
     /**
      * The element to display after the field at the end of the row.
      */
@@ -149,6 +156,7 @@ export default function LabeledField(props: Props) {
         errorMessage,
         readOnlyMessage,
         labels = defaultLabeledFieldLabels,
+        elementAfterFieldStart,
         elementAfterFieldEnd,
     } = props;
 
@@ -159,6 +167,7 @@ export default function LabeledField(props: Props) {
     const fieldId = `${uniqueId}-field`;
     const errorId = `${uniqueId}-error`;
     const readOnlyMessageId = `${uniqueId}-read-only-message`;
+    const elementAfterFieldStartId = `${uniqueId}-element-after-field-start`;
     const elementAfterFieldEndId = `${uniqueId}-element-after-field-end`;
 
     const isRequired = !!required || !!field.props.required;
@@ -284,6 +293,7 @@ export default function LabeledField(props: Props) {
                 description && descriptionId,
                 errorMessage && errorId,
                 readOnlyMessage && readOnlyMessageId,
+                elementAfterFieldStart && elementAfterFieldStartId,
                 elementAfterFieldEnd && elementAfterFieldEndId,
             ]
                 .filter(Boolean)
@@ -324,6 +334,27 @@ export default function LabeledField(props: Props) {
         );
     }
 
+    function maybeRenderElementAfterFieldStart() {
+        if (!elementAfterFieldStart) {
+            return null;
+        }
+        return (
+            <BodyText
+                style={[
+                    styles.helperTextSectionWithContent,
+                    styles.helperTextMessage,
+                    styles.textWordBreak,
+                    stylesProp?.elementAfterFieldStart,
+                ]}
+                tag="div"
+                id={elementAfterFieldStartId}
+                testId={testId && `${testId}-element-after-field-start`}
+            >
+                {elementAfterFieldStart}
+            </BodyText>
+        );
+    }
+
     function maybeRenderElementAfterFieldEnd() {
         if (!elementAfterFieldEnd) {
             return null;
@@ -355,6 +386,7 @@ export default function LabeledField(props: Props) {
                 <View>
                     {maybeRenderReadOnlyMessage()}
                     {maybeRenderError()}
+                    {maybeRenderElementAfterFieldStart()}
                 </View>
                 {maybeRenderElementAfterFieldEnd()}
             </View>

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -223,7 +223,7 @@ export default function LabeledField(props: Props) {
                             ? styles.labelWithDescription
                             : styles.labelWithNoDescription,
                         stylesProp?.label,
-                        hasError ? styles.error : undefined,
+                        hasError ? styles.errorStyling : undefined,
                         isDisabled && styles.disabledStyling,
                     ]}
                     tag="label"
@@ -299,7 +299,7 @@ export default function LabeledField(props: Props) {
                                 style={[
                                     styles.textWordBreak,
                                     styles.helperTextMessage,
-                                    styles.error,
+                                    styles.errorStyling,
                                 ]}
                             >
                                 {errorMessage}
@@ -437,7 +437,7 @@ export default function LabeledField(props: Props) {
                     styles.helperTextSectionWithContent,
                     styles.helperTextMessage,
                     styles.textWordBreak,
-                    hasError && styles.error,
+                    hasError && styles.errorStyling,
                     isDisabled && styles.disabledStyling,
                     stylesProp?.elementAfterFieldEnd,
                 ]}
@@ -507,7 +507,7 @@ const styles = StyleSheet.create({
         marginBlockStart: theme.helperText.layout.marginBlockStart,
         minWidth: sizing.size_0, // This enables the wrapping behaviour on the helper message
     },
-    error: {
+    errorStyling: {
         color: theme.error.color.foreground,
         fontWeight: theme.error.font.weight,
     },

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -204,7 +204,7 @@ export default function LabeledField(props: Props) {
                 style={[
                     styles.textWordBreak,
                     styles.required,
-                    isDisabled && styles.disabledLabel,
+                    isDisabled && styles.disabledStyling,
                 ]}
                 aria-hidden={true}
             >
@@ -224,7 +224,7 @@ export default function LabeledField(props: Props) {
                             : styles.labelWithNoDescription,
                         stylesProp?.label,
                         hasError ? styles.error : undefined,
-                        isDisabled && styles.disabledLabel,
+                        isDisabled && styles.disabledStyling,
                     ]}
                     tag="label"
                     htmlFor={fieldId}
@@ -249,9 +249,10 @@ export default function LabeledField(props: Props) {
                 <BodyText
                     style={[
                         styles.textWordBreak,
-                        styles.description,
+                        styles.beforeHelperText,
+                        styles.helperTextMessage,
                         stylesProp?.description,
-                        isDisabled && styles.disabledDescription,
+                        isDisabled && styles.disabledStyling,
                     ]}
                     testId={testId && `${testId}-description`}
                     id={descriptionId}
@@ -367,9 +368,10 @@ export default function LabeledField(props: Props) {
         return (
             <BodyText
                 style={[
-                    styles.description,
+                    styles.beforeHelperText,
                     styles.helperTextMessage,
                     styles.textWordBreak,
+                    isDisabled && styles.disabledStyling,
                     stylesProp?.elementBeforeFieldStart,
                 ]}
                 tag="div"
@@ -388,9 +390,10 @@ export default function LabeledField(props: Props) {
         return (
             <BodyText
                 style={[
-                    styles.description,
+                    styles.beforeHelperText,
                     styles.helperTextMessage,
                     styles.textWordBreak,
+                    isDisabled && styles.disabledStyling,
                     stylesProp?.elementBeforeFieldEnd,
                 ]}
                 tag="div"
@@ -412,6 +415,7 @@ export default function LabeledField(props: Props) {
                     styles.helperTextSectionWithContent,
                     styles.helperTextMessage,
                     styles.textWordBreak,
+                    isDisabled && styles.disabledStyling,
                     stylesProp?.elementAfterFieldStart,
                 ]}
                 tag="div"
@@ -434,6 +438,7 @@ export default function LabeledField(props: Props) {
                     styles.helperTextMessage,
                     styles.textWordBreak,
                     hasError && styles.error,
+                    isDisabled && styles.disabledStyling,
                     stylesProp?.elementAfterFieldEnd,
                 ]}
                 tag="div"
@@ -477,9 +482,6 @@ const styles = StyleSheet.create({
     label: {
         color: semanticColor.core.foreground.neutral.strong,
     },
-    disabledLabel: {
-        color: theme.label.color.disabled.foreground,
-    },
     labelWithDescription: {
         paddingBlockEnd: theme.root.layout.paddingBlockEnd.labelWithDescription,
     },
@@ -487,14 +489,8 @@ const styles = StyleSheet.create({
         paddingBlockEnd:
             theme.root.layout.paddingBlockEnd.labelWithNoDescription,
     },
-    description: {
-        color: theme.description.color.foreground,
-        paddingBlockEnd: theme.root.layout.paddingBlockEnd.description,
-        fontSize: theme.description.font.size,
-        lineHeight: theme.description.font.lineHeight,
-    },
-    disabledDescription: {
-        color: theme.description.color.disabled.foreground,
+    disabledStyling: {
+        color: semanticColor.core.foreground.disabled.strong,
     },
     helperTextSection: {
         flexDirection: "row",
@@ -505,6 +501,7 @@ const styles = StyleSheet.create({
             theme.root.layout.paddingBlockEnd.helperTextSectionWithContent,
     },
     helperTextMessage: {
+        color: theme.helperText.color.foreground,
         fontSize: theme.helperText.font.size,
         lineHeight: theme.helperText.font.lineHeight,
         marginBlockStart: theme.helperText.layout.marginBlockStart,
@@ -531,5 +528,8 @@ const styles = StyleSheet.create({
     },
     beforeHelperTextContainer: {
         alignItems: "flex-end",
+    },
+    beforeHelperText: {
+        paddingBlockEnd: theme.root.layout.paddingBlockEnd.description,
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -218,7 +218,7 @@ export default function LabeledField(props: Props) {
                             ? styles.labelWithDescription
                             : styles.labelWithNoDescription,
                         hasError ? styles.labelWithError : undefined,
-                        isDisabled && styles.disabledStyling,
+                        isDisabled && styles.labelWithDisabled,
                         stylesProp?.label,
                     ]}
                     tag="label"
@@ -479,6 +479,9 @@ const styles = StyleSheet.create({
     },
     labelWithError: {
         color: theme.label.color.error.foreground,
+    },
+    labelWithDisabled: {
+        color: theme.label.color.disabled.foreground,
     },
     disabledStyling: {
         color: semanticColor.core.foreground.disabled.strong,

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -16,21 +16,6 @@ const theme = {
             error: {
                 foreground: semanticColor.core.foreground.neutral.strong,
             },
-            disabled: {
-                foreground: semanticColor.core.foreground.neutral.strong,
-            },
-        },
-    },
-    description: {
-        font: {
-            size: font.body.size.small,
-            lineHeight: font.body.lineHeight.small,
-        },
-        color: {
-            foreground: semanticColor.core.foreground.neutral.default,
-            disabled: {
-                foreground: semanticColor.core.foreground.neutral.default,
-            },
         },
     },
     error: {
@@ -54,6 +39,9 @@ const theme = {
         font: {
             size: font.body.size.small,
             lineHeight: font.body.lineHeight.small,
+        },
+        color: {
+            foreground: semanticColor.core.foreground.neutral.default,
         },
     },
 };

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -6,9 +6,8 @@ const theme = {
             paddingBlockEnd: {
                 labelWithDescription: sizing.size_040,
                 labelWithNoDescription: sizing.size_120,
-                description: sizing.size_120,
-                helperTextSectionWithContent: sizing.size_120,
             },
+            spacingBetweenHelperText: sizing.size_120,
         },
     },
     label: {

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -15,6 +15,9 @@ const theme = {
             error: {
                 foreground: semanticColor.core.foreground.neutral.strong,
             },
+            disabled: {
+                foreground: semanticColor.core.foreground.neutral.strong,
+            },
         },
     },
     error: {

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -18,21 +18,6 @@ export default mergeTheme(defaultTheme, {
             error: {
                 foreground: semanticColor.core.foreground.critical.default,
             },
-            disabled: {
-                foreground: semanticColor.core.foreground.disabled.strong,
-            },
-        },
-    },
-    description: {
-        font: {
-            size: font.body.size.xsmall,
-            lineHeight: font.body.lineHeight.xsmall,
-        },
-        color: {
-            foreground: semanticColor.core.foreground.neutral.strong,
-            disabled: {
-                foreground: semanticColor.core.foreground.disabled.strong,
-            },
         },
     },
     error: {
@@ -57,6 +42,9 @@ export default mergeTheme(defaultTheme, {
         font: {
             size: font.body.size.xsmall,
             lineHeight: font.body.lineHeight.xsmall,
+        },
+        color: {
+            foreground: semanticColor.core.foreground.neutral.strong,
         },
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -6,11 +6,10 @@ export default mergeTheme(defaultTheme, {
     root: {
         layout: {
             paddingBlockEnd: {
-                labelWithDescription: sizing.size_100,
-                labelWithNoDescription: sizing.size_100,
-                description: sizing.size_100,
-                helperTextSectionWithContent: sizing.size_080,
+                labelWithDescription: sizing.size_040,
+                labelWithNoDescription: sizing.size_080,
             },
+            spacingBetweenHelperText: sizing.size_080,
         },
     },
     label: {

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -9,7 +9,7 @@ export default mergeTheme(defaultTheme, {
                 labelWithDescription: sizing.size_100,
                 labelWithNoDescription: sizing.size_100,
                 description: sizing.size_100,
-                helperTextSectionWithContent: sizing.size_100,
+                helperTextSectionWithContent: sizing.size_080,
             },
         },
     },

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -17,6 +17,9 @@ export default mergeTheme(defaultTheme, {
             error: {
                 foreground: semanticColor.core.foreground.critical.default,
             },
+            disabled: {
+                foreground: semanticColor.core.foreground.disabled.strong,
+            },
         },
     },
     error: {


### PR DESCRIPTION
## Summary:

- Add `elementBeforeFieldStart`, `elementBeforeFieldEnd`, `elementAfterFieldStart`, and `elementAfterFieldEnd` props
  - They are provided with an id and a testId if the `testId` prop is provided
  - The id is used for setting `aria-describedby` on the field 
- Simplify and consolidate component styles and component tokens
- Update token values to align more with the design

Things to highlight:
- `elementBeforeFieldStart` is pretty much the same as the `description` prop. I will remove the `description` prop in the next PR in favour of the `elementBeforeFieldStart` prop
- If the helper text after the field is an error message or read only message, the `errorMessage` and `readOnlyMessage` props should be used instead. If `errorMessage`, `readOnlyMessage`, and `elementAfterFieldEnd` are all provided, they will be all shown (it is up to the consuming apps to manage what should be shown)

Issue: WB-2018
Design: https://www.figma.com/design/e9qdyiDUBZ3rDabP9S7ulO/%E2%9A%A1%EF%B8%8F-Handshake?node-id=4077-1650&m=dev

<img width="1151" alt="image" src="https://github.com/user-attachments/assets/dd704b4d-bc1b-4512-99b0-993ff04d937a" />

## Test plan:
- Confirm the styling and behaviour of the `elementBeforeFieldStart`, `elementBeforeFieldEnd`, `elementAfterFieldStart`, and `elementAfterFieldEnd` props
  - `?path=/story/packages-labeledfield--helper-text&globals=theme:default` 
  - `?path=/story/packages-labeledfield-testing-snapshots-labeledfield--scenarios&globals=theme:default` (shows the behaviour in terms of text wrapping, combination with other props, supporting custom styling and custom elements)
- Review the docs for the new props (`/?path=/docs/packages-labeledfield--docs`)
- Review the docs for using Helper Text (`?path=/docs/packages-labeledfield--docs#helper-text`)

## Implementation Plan
1. Add support for readOnlyMessage (https://github.com/Khan/wonder-blocks/pull/2709)
2. Add support for other start/end helper text above and below the field (this PR)
3. (new) Remove `description` prop in favour of `elementBeforeFieldStart` prop
4. Add support for a `context` prop for required or optional text. This will replace the required prop. This will involve migrating current usage away from the required prop