### PR TITLE
LabeledField POC: Composable helper text and generic slot props

### DIFF
--- a/__docs__/wonder-blocks-labeled-field/flexible-labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/flexible-labeled-field.stories.tsx
@@ -31,7 +31,7 @@ export default {
 export const Props = {
     args: {
         label: "Label",
-        field: <TextField value="Value" onChange={() => {}} />,
+        field: <TextField value="Field" onChange={() => {}} />,
         helperTextAbove: <HelperText message="Helper text above" />,
         helperTextBelow: <HelperText message="Helper text below" />,
     },
@@ -42,48 +42,50 @@ export const Props = {
 export const ErrorMessage = {
     args: {
         label: "Label",
-        field: <TextField value="Value" onChange={() => {}} error={true} />, // <-- NOTE: need to explicitly pass in error={true}
-        helperTextAbove: <HelperText message="Helper text" />,
-        helperTextBelow: <ErrorHelperText message="Helper text" show={true} />, // <-- NOTE: ErrorHelperText has a mandatory show prop so that even when it is not visible, the aria-live region can still be there. This is needed for it work more nicely with SRs
+        field: <TextField value="Field" onChange={() => {}} error={true} />, // <-- NOTE: need to explicitly pass in error={true}
+        helperTextAbove: <HelperText message="Helper text above" />,
+        helperTextBelow: (
+            <ErrorHelperText message="Error helper text below" show={true} />
+        ), // <-- NOTE: ErrorHelperText has a mandatory show prop so that even when it is not visible, the aria-live region can still be there. This is needed for it work more nicely with SRs
     },
 };
 
 export const ReadOnlyMessage = {
     args: {
         label: "Label",
-        field: <TextField value="Value" onChange={() => {}} readOnly={true} />, // <-- NOTE:need to explicitly pass in readOnly={true}
-        helperTextAbove: <HelperText message="Helper text" />,
-        helperTextBelow: <ReadOnlyHelperText message="Helper text" />,
+        field: <TextField value="Field" onChange={() => {}} readOnly={true} />, // <-- NOTE:need to explicitly pass in readOnly={true}
+        helperTextAbove: <HelperText message="Helper text above" />,
+        helperTextBelow: <ReadOnlyHelperText message="Helper text below" />,
     },
 };
 
 export const AnyMessageBelow = {
     args: {
         label: "Label",
-        field: <TextField value="Value" onChange={() => {}} />,
-        helperTextAbove: <HelperText message="Helper text" />,
-        helperTextBelow: <HelperText message="Helper text under field" />,
+        field: <TextField value="Field" onChange={() => {}} />,
+        helperTextAbove: <HelperText message="Helper text above" />,
+        helperTextBelow: <HelperText message="Helper text below" />,
     },
 };
 
 export const HelperTextInCorners = {
     args: {
         label: "Label",
-        field: <TextField value="Value" onChange={() => {}} />,
+        field: <TextField value="Field" onChange={() => {}} />,
         helperTextAbove: (
             <View
                 style={{flexDirection: "row", justifyContent: "space-between"}}
             >
-                <HelperText message="Above start helper text" />
-                <HelperText message="Above end helper text" />
+                <HelperText message="Helper text above - start" />
+                <HelperText message="Helper text above - end" />
             </View>
         ),
         helperTextBelow: (
             <View
                 style={{flexDirection: "row", justifyContent: "space-between"}}
             >
-                <HelperText message="Below start helper text" />
-                <HelperText message="Below end helper text" />
+                <HelperText message="Helper text below - start" />
+                <HelperText message="Helper text below - end" />
             </View>
         ),
     },
@@ -93,11 +95,14 @@ export const ErrorAndBelowDescription = {
     args: {
         label: "Label",
         field: <TextField value="Value" onChange={() => {}} error={true} />,
-        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextAbove: <HelperText message="Helper text above" />,
         helperTextBelow: (
             <View style={{gap: sizing.size_040}}>
-                <HelperText message="Helper text under field" />
-                <ErrorHelperText message="Error helper text" show={true} />
+                <HelperText message="Helper text below" />
+                <ErrorHelperText
+                    message="Error helper text below"
+                    show={true}
+                />
             </View>
         ),
     },
@@ -107,14 +112,17 @@ export const ErrorAndBelowDescriptionWithCount = {
     args: {
         label: "Label",
         field: <TextField value="Value" onChange={() => {}} error={true} />,
-        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextAbove: <HelperText message="Helper text above" />,
         helperTextBelow: (
             <View
                 style={{flexDirection: "row", justifyContent: "space-between"}}
             >
                 <View style={{gap: sizing.size_040}}>
-                    <HelperText message="Helper text under field" />
-                    <ErrorHelperText message="Error helper text" show={true} />
+                    <HelperText message="Helper text below" />
+                    <ErrorHelperText
+                        message="Error helper text below"
+                        show={true}
+                    />
                 </View>
                 {/* NOTE:If we want this to be red when there is an error, consumers will have to do this manually. Unless we make all helper text red if there's an error */}
                 <HelperText message="1/3" />
@@ -127,14 +135,17 @@ export const DisabledStyling = {
     args: {
         label: "Label",
         field: <TextField value="Value" onChange={() => {}} disabled={true} />,
-        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextAbove: <HelperText message="Helper text above" />,
         helperTextBelow: (
             <View
                 style={{flexDirection: "row", justifyContent: "space-between"}}
             >
                 <View style={{gap: sizing.size_040}}>
-                    <HelperText message="Helper text under field" />
-                    <ErrorHelperText message="Error helper text" show={true} />
+                    <HelperText message="Helper text below" />
+                    <ErrorHelperText
+                        message="Error helper text below"
+                        show={true}
+                    />
                 </View>
                 <HelperText message="1/3" />
             </View>

--- a/__docs__/wonder-blocks-labeled-field/flexible-labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/flexible-labeled-field.stories.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import {Meta} from "@storybook/react";
+import {HelperText} from "../../packages/wonder-blocks-labeled-field/src/components/helper-text";
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-labeled-field/package.json";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {ErrorHelperText} from "../../packages/wonder-blocks-labeled-field/src/components/error-helper-text";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {ReadOnlyHelperText} from "../../packages/wonder-blocks-labeled-field/src/components/read-only-helper-text";
+import {FlexibleLabeledField} from "../../packages/wonder-blocks-labeled-field/src/components/flexible-labeled-field";
+import TextField from "../../packages/wonder-blocks-form/src/components/text-field";
+
+export default {
+    title: "Packages / LabeledField / FlexibleLabeledFieldTesting",
+    component: FlexibleLabeledField,
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+        chromatic: {
+            // Disabling snapshots for all stories by default because the testing
+            // snapshots cover the different scenarios
+            disableSnapshot: true,
+        },
+    },
+} as Meta<typeof FlexibleLabeledField>;
+
+export const Props = {
+    args: {
+        label: "Label",
+        field: <TextField value="Value" onChange={() => {}} />,
+        helperTextAbove: <HelperText message="Helper text above" />,
+        helperTextBelow: <HelperText message="Helper text below" />,
+    },
+};
+/**
+ * If the field has error=true, we change the label styling to red
+ */
+export const ErrorMessage = {
+    args: {
+        label: "Label",
+        field: <TextField value="Value" onChange={() => {}} error={true} />, // <-- NOTE: need to explicitly pass in error={true}
+        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextBelow: <ErrorHelperText message="Helper text" show={true} />, // <-- NOTE: ErrorHelperText has a mandatory show prop so that even when it is not visible, the aria-live region can still be there. This is needed for it work more nicely with SRs
+    },
+};
+
+export const ReadOnlyMessage = {
+    args: {
+        label: "Label",
+        field: <TextField value="Value" onChange={() => {}} readOnly={true} />, // <-- NOTE:need to explicitly pass in readOnly={true}
+        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextBelow: <ReadOnlyHelperText message="Helper text" />,
+    },
+};
+
+export const AnyMessageBelow = {
+    args: {
+        label: "Label",
+        field: <TextField value="Value" onChange={() => {}} />,
+        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextBelow: <HelperText message="Helper text under field" />,
+    },
+};
+
+export const HelperTextInCorners = {
+    args: {
+        label: "Label",
+        field: <TextField value="Value" onChange={() => {}} />,
+        helperTextAbove: (
+            <View
+                style={{flexDirection: "row", justifyContent: "space-between"}}
+            >
+                <HelperText message="Above start helper text" />
+                <HelperText message="Above end helper text" />
+            </View>
+        ),
+        helperTextBelow: (
+            <View
+                style={{flexDirection: "row", justifyContent: "space-between"}}
+            >
+                <HelperText message="Below start helper text" />
+                <HelperText message="Below end helper text" />
+            </View>
+        ),
+    },
+};
+
+export const ErrorAndBelowDescription = {
+    args: {
+        label: "Label",
+        field: <TextField value="Value" onChange={() => {}} error={true} />,
+        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextBelow: (
+            <View style={{gap: sizing.size_040}}>
+                <HelperText message="Helper text under field" />
+                <ErrorHelperText message="Error helper text" show={true} />
+            </View>
+        ),
+    },
+};
+
+export const ErrorAndBelowDescriptionWithCount = {
+    args: {
+        label: "Label",
+        field: <TextField value="Value" onChange={() => {}} error={true} />,
+        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextBelow: (
+            <View
+                style={{flexDirection: "row", justifyContent: "space-between"}}
+            >
+                <View style={{gap: sizing.size_040}}>
+                    <HelperText message="Helper text under field" />
+                    <ErrorHelperText message="Error helper text" show={true} />
+                </View>
+                {/* NOTE:If we want this to be red when there is an error, consumers will have to do this manually. Unless we make all helper text red if there's an error */}
+                <HelperText message="1/3" />
+            </View>
+        ),
+    },
+};
+
+export const DisabledStyling = {
+    args: {
+        label: "Label",
+        field: <TextField value="Value" onChange={() => {}} disabled={true} />,
+        helperTextAbove: <HelperText message="Helper text" />,
+        helperTextBelow: (
+            <View
+                style={{flexDirection: "row", justifyContent: "space-between"}}
+            >
+                <View style={{gap: sizing.size_040}}>
+                    <HelperText message="Helper text under field" />
+                    <ErrorHelperText message="Error helper text" show={true} />
+                </View>
+                <HelperText message="1/3" />
+            </View>
+        ),
+    },
+};

--- a/__docs__/wonder-blocks-labeled-field/helper-text.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/helper-text.stories.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import {Meta} from "@storybook/react";
+import CookieIcon from "@phosphor-icons/core/regular/cookie.svg";
+import {HelperText} from "../../packages/wonder-blocks-labeled-field/src/components/helper-text";
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-labeled-field/package.json";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
+import {ErrorHelperText} from "../../packages/wonder-blocks-labeled-field/src/components/error-helper-text";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {ReadOnlyHelperText} from "../../packages/wonder-blocks-labeled-field/src/components/read-only-helper-text";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+
+export default {
+    title: "Packages / LabeledField / HelperText",
+    component: HelperText,
+    parameters: {
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+        chromatic: {
+            // Disabling snapshots for all stories by default because the testing
+            // snapshots cover the different scenarios
+            disableSnapshot: true,
+        },
+    },
+} as Meta<typeof HelperText>;
+
+export const Default = {
+    render: (args: PropsFor<typeof HelperText>) => {
+        return (
+            <View style={{gap: sizing.size_160}}>
+                <HelperText message="Custom Helper text" />
+                <HelperText
+                    message="Custom helper text with icon"
+                    icon={<PhosphorIcon icon={CookieIcon} />}
+                />
+                <ErrorHelperText message="Error helper text" show={true} />
+                <ReadOnlyHelperText message="Read only helper text" />
+            </View>
+        );
+    },
+};

--- a/packages/wonder-blocks-labeled-field/src/components/error-helper-text.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/error-helper-text.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import WarningCircle from "@phosphor-icons/core/bold/warning-circle-bold.svg";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {HelperText} from "./helper-text";
+import theme from "../theme";
+
+type Props = {
+    message?: React.ReactNode;
+    id?: string;
+    testId?: string;
+    show: boolean;
+    iconAriaLabel?: string;
+};
+
+export const ErrorHelperText = (props: Props) => {
+    const {message, id, testId, show, iconAriaLabel = "Error: "} = props;
+
+    return (
+        <HelperText
+            id={id}
+            testId={testId}
+            styles={{root: {color: theme.error.color.foreground}}}
+            message={show && message}
+            icon={
+                show && (
+                    <PhosphorIcon
+                        icon={WarningCircle}
+                        aria-label={iconAriaLabel}
+                    />
+                )
+            }
+            // We use aria-live="assertive" for the error so that it is
+            // immediately announced and the user can address the issue
+            // before submitting the form. We use aria-live=assertive
+            // instead of role=alert because Safari + VoiceOver would
+            // not read out the error when focused on if the element
+            // referenced by the aria-describedby had role="alert".
+            aria-live="assertive"
+            // We add aria-atomic=true so that any updates to the error
+            // is announced
+            aria-atomic="true"
+        />
+    );
+};

--- a/packages/wonder-blocks-labeled-field/src/components/flexible-labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/flexible-labeled-field.tsx
@@ -1,0 +1,67 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+type Props = {
+    id?: string;
+    testId?: string;
+    label: React.ReactNode;
+    field: React.ReactElement;
+    helperTextAbove?: React.ReactNode;
+    helperTextBelow?: React.ReactNode;
+};
+export const FlexibleLabeledField = (props: Props) => {
+    const {label, field, helperTextAbove, helperTextBelow} = props;
+
+    const fieldId = React.useId();
+    const helperTextAboveId = React.useId();
+    const helperTextBelowId = React.useId();
+    const hasError = field.props.error;
+    const isDisabled = field.props.disabled;
+
+    function renderField() {
+        return React.cloneElement(field, {
+            id: fieldId,
+            "aria-describedby": [helperTextAboveId, helperTextBelowId]
+                .filter(Boolean)
+                .join(" "),
+        });
+    }
+
+    return (
+        <View
+            style={[
+                {gap: sizing.size_080},
+                isDisabled && styles.disabledStyling,
+            ]}
+        >
+            <BodyText
+                tag="label"
+                size="small"
+                weight="bold"
+                htmlFor={fieldId}
+                style={hasError ? styles.errorLabel : undefined}
+            >
+                {label}
+            </BodyText>
+            {helperTextAbove && (
+                <View id={helperTextAboveId}>{helperTextAbove}</View>
+            )}
+            {renderField()}
+            {helperTextBelow && (
+                <View id={helperTextBelowId}>{helperTextBelow}</View>
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    errorLabel: {
+        color: semanticColor.core.foreground.critical.default,
+    },
+    disabledStyling: {
+        color: semanticColor.core.foreground.disabled.strong,
+    },
+});

--- a/packages/wonder-blocks-labeled-field/src/components/helper-text.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/helper-text.tsx
@@ -1,0 +1,47 @@
+import {AriaProps, StyleType, View} from "@khanacademy/wonder-blocks-core";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+type Props = {
+    id?: string;
+    testId?: string;
+    icon?: React.ReactNode;
+    message: React.ReactNode;
+    styles?: {
+        root?: StyleType;
+    };
+} & AriaProps;
+
+export const HelperText = (props: Props) => {
+    const {
+        icon,
+        message,
+        styles: stylesProp,
+        id,
+        testId,
+        ...otherProps
+    } = props;
+
+    return (
+        <BodyText
+            id={id}
+            testId={testId}
+            size="xsmall"
+            style={[styles.root, stylesProp?.root]}
+            tag="div"
+            {...otherProps}
+        >
+            {icon && <View>{icon}</View>}
+            <View>{message}</View>
+        </BodyText>
+    );
+};
+
+const styles = StyleSheet.create({
+    root: {
+        display: "flex",
+        gap: sizing.size_040,
+    },
+});

--- a/packages/wonder-blocks-labeled-field/src/components/read-only-helper-text.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/read-only-helper-text.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import LockIcon from "@phosphor-icons/core/bold/lock-bold.svg";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {HelperText} from "./helper-text";
+
+type Props = {
+    message: React.ReactNode;
+    iconAriaLabel?: string;
+};
+
+export const ReadOnlyHelperText = (props: Props) => {
+    const {message, iconAriaLabel} = props;
+
+    return (
+        <HelperText
+            message={message}
+            icon={
+                <PhosphorIcon
+                    icon={LockIcon}
+                    aria-label={iconAriaLabel}
+                    color={semanticColor.core.foreground.neutral.subtle}
+                />
+            }
+        />
+    );
+};


### PR DESCRIPTION
## Summary:

Creating a proof of concept for generic slot props for above and below the field based on https://github.com/Khan/wonder-blocks/pull/2709#discussion_r2198106793

This PR includes the following components:
- FlexibleLabelField : For prototyping purposes, this is the LabeledField component (if we like this approach, these changes would be made to the existing component)
- Helper text components to be used with the LabeledField component
  - HelperText
  - ErrorHelperText
  - ReadOnlyHelperText 

I think this approach is more composable and flexible, though it is less opinionated 

Related stories:
- LabeledField usage `?path=/docs/packages-labeledfield-flexiblelabeledfieldtesting--docs&globals=theme:thunderblocks`
- Types of Helper Text `?path=/docs/packages-labeledfield-helpertext--docs&globals=theme:thunderblocks`

Note: This PR is a POC for the LabeledField api. It doesn't completely follow the design details right now and doesn't handle different text wrapping cases. It does wire up the `label` `htmlFor` attribute and the field's `aria-describedby` attribute


Issue: WB-2011

## Test plan: