### PR TITLE
LabeledField: Add `additionalHelperMessage` prop

### DIFF
--- a/__docs__/components/text-for-testing.ts
+++ b/__docs__/components/text-for-testing.ts
@@ -5,3 +5,5 @@ export const longTextWithNoWordBreak =
     "Loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliqua";
 export const reallyLongText =
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+export const reallyLongTextWithNoWordBreak =
+    "LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequatDuisauteiruredolorinreprehenderitinvoluptatevelitessecillumdoloreeufugiatnullapariaturExcepteursintoccaecatcupidatatnonproidentsuntinculpaquiofficiadeseruntmollitanimidestlaborum";

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -120,29 +120,6 @@ const scenarios = [
         },
     },
     {
-        name: "All properties disabled",
-        props: {
-            field: <TextField value="" onChange={() => {}} disabled />,
-            label: "Name",
-            description: "Helpful description text.",
-            errorMessage: "Message about the error",
-            required: "Custom required message",
-            additionalHelperMessage: "Additional helper message",
-            readOnlyMessage: "Read only message",
-        },
-    },
-    {
-        name: "All properties disabled without error",
-        props: {
-            field: <TextField value="" onChange={() => {}} disabled />,
-            label: "Name",
-            description: "Helpful description text.",
-            required: "Custom required message",
-            additionalHelperMessage: "Additional helper message",
-            readOnlyMessage: "Read only message",
-        },
-    },
-    {
         name: "Custom ReactNode elements",
         props: {
             label: (
@@ -215,6 +192,29 @@ const scenarios = [
         },
     },
     {
+        name: "All properties disabled",
+        props: {
+            field: <TextField value="" onChange={() => {}} disabled />,
+            label: "Name",
+            description: "Helpful description text.",
+            errorMessage: "Message about the error",
+            required: "Custom required message",
+            additionalHelperMessage: "Additional helper message",
+            readOnlyMessage: "Read only message",
+        },
+    },
+    {
+        name: "All properties disabled without error",
+        props: {
+            field: <TextField value="" onChange={() => {}} disabled />,
+            label: "Name",
+            description: "Helpful description text.",
+            required: "Custom required message",
+            additionalHelperMessage: "Additional helper message",
+            readOnlyMessage: "Read only message",
+        },
+    },
+    {
         name: "With read only message",
         props: {
             field: <TextField value="" onChange={() => {}} />,
@@ -255,6 +255,30 @@ const scenarios = [
             readOnlyMessage: "Message about the read only state",
         },
     },
+    {
+        name: "Additional helper message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            additionalHelperMessage: "Additional helper message",
+        },
+    },
+    {
+        name: "Long additional helper message",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            additionalHelperMessage: longText,
+        },
+    },
+    {
+        name: "Long additional helper message and no word break",
+        props: {
+            field: <TextField value="" onChange={() => {}} />,
+            label: "Name",
+            additionalHelperMessage: longTextWithNoWordBreak,
+        },
+    },
 ];
 
 /**
@@ -264,10 +288,10 @@ const scenarios = [
 export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
     const [textFieldValue, setTextFieldValue] = React.useState("");
     return (
-        <View style={{gap: sizing.size_240}}>
+        <View style={{width: "300px"}}>
             <ScenariosLayout
                 scenarios={scenarios}
-                styles={{root: {alignItems: "stretch"}}}
+                styles={{root: {alignItems: "stretch", gap: sizing.size_400}}}
             >
                 {(props) => (
                     <LabeledField

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -288,10 +288,10 @@ const scenarios = [
 export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
     const [textFieldValue, setTextFieldValue] = React.useState("");
     return (
-        <View style={{width: "300px"}}>
+        <View>
             <ScenariosLayout
                 scenarios={scenarios}
-                styles={{root: {alignItems: "stretch", gap: sizing.size_400}}}
+                styles={{root: {alignItems: "stretch"}}}
             >
                 {(props) => (
                     <LabeledField

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -115,6 +115,31 @@ const scenarios = [
             description: "Helpful description text.",
             errorMessage: "Message about the error",
             required: "Custom required message",
+            additionalHelperMessage: "Additional helper message",
+            readOnlyMessage: "Read only message",
+        },
+    },
+    {
+        name: "All properties disabled",
+        props: {
+            field: <TextField value="" onChange={() => {}} disabled />,
+            label: "Name",
+            description: "Helpful description text.",
+            errorMessage: "Message about the error",
+            required: "Custom required message",
+            additionalHelperMessage: "Additional helper message",
+            readOnlyMessage: "Read only message",
+        },
+    },
+    {
+        name: "All properties disabled without error",
+        props: {
+            field: <TextField value="" onChange={() => {}} disabled />,
+            label: "Name",
+            description: "Helpful description text.",
+            required: "Custom required message",
+            additionalHelperMessage: "Additional helper message",
+            readOnlyMessage: "Read only message",
         },
     },
     {
@@ -141,6 +166,11 @@ const scenarios = [
                     <b>Read</b> <i>only </i> <u>message</u>
                 </span>
             ),
+            additionalHelperMessage: (
+                <span>
+                    <b>Additional</b> <i>helper</i> <u>message</u>
+                </span>
+            ),
         },
     },
     {
@@ -152,6 +182,7 @@ const scenarios = [
             errorMessage: "Message about the error",
             required: "Custom required message",
             readOnlyMessage: "Message about the read only state",
+            additionalHelperMessage: "Additional helper message",
             styles: {
                 root: {
                     padding: sizing.size_080,
@@ -166,6 +197,9 @@ const scenarios = [
                     paddingBlockStart: sizing.size_020,
                 },
                 readOnlyMessage: {
+                    paddingBlockStart: sizing.size_020,
+                },
+                additionalHelperMessage: {
                     paddingBlockStart: sizing.size_020,
                 },
             },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -28,6 +28,8 @@ import {Heading} from "@khanacademy/wonder-blocks-typography";
  * - If the `errorMessage` prop is set on `LabeledField`, the `error` prop on the
  * form field component will be auto-populated so it doesn't need to be set
  * explicitly on the field
+ * - Setting the `readOnlyMessage` prop will also auto-populate the `readOnly`
+ * prop on the form field component
  * - If the `required` prop is set on `LabeledField`, it will be passed onto the
  * `field` prop component so it doesn't need to be set explicitly. If the `required`
  * prop is set on the `field` component, it will also get set for `LabeledField`
@@ -64,19 +66,20 @@ export const Default: StoryComponentType = {
         field: <TextField value="" onChange={() => {}} />,
         label: "Name",
         description: "Helpful description text.",
-        errorMessage: "Message about the error",
         required: "Custom required message",
     },
 };
 
 /**
  * Consider the following when providing helper text:
+ * - Use the `description` prop for the main helper text for a field
  * - If providing an error message for the field, use the `errorMessage` prop
  * - If providing a message related to the read only state for the field, use
  *   the `readOnlyMessage` prop
  * - For any other helper text, use the `additionalHelperMessage` prop
  *
- * If all of these props are used, they will all be shown.
+ * If all of these props are used, they will all be shown. It us up to the
+ * consuming application to manage when the helper text is shown.
  *
  * When any of these props are used, the field's `aria-describedby` attribute
  * will include the id of the element for the corresponding prop.
@@ -86,12 +89,21 @@ export const HelperText: StoryComponentType = {
         return (
             <View style={{gap: sizing.size_240}}>
                 <Heading>A field with an error message</Heading>
-                <LabeledField {...args} errorMessage="Error message" />
+                <LabeledField
+                    {...args}
+                    description="Helpful description text"
+                    errorMessage="Error message"
+                />
                 <Heading>A field with a read only message</Heading>
-                <LabeledField {...args} readOnlyMessage="Read only message" />
+                <LabeledField
+                    {...args}
+                    description="Helpful description text"
+                    readOnlyMessage="Read only message"
+                />
                 <Heading>A field with an additional helper message</Heading>
                 <LabeledField
                     {...args}
+                    description="Helpful description text"
                     additionalHelperMessage="Additional helper message"
                 />
                 <Heading>
@@ -100,6 +112,7 @@ export const HelperText: StoryComponentType = {
                 </Heading>
                 <LabeledField
                     {...args}
+                    description="Helpful description text"
                     errorMessage="Error message"
                     readOnlyMessage="Read only message"
                     additionalHelperMessage="Additional helper message"

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -69,6 +69,50 @@ export const Default: StoryComponentType = {
     },
 };
 
+/**
+ * Consider the following when providing helper text:
+ * - If providing an error message for the field, use the `errorMessage` prop
+ * - If providing a message related to the read only state for the field, use
+ *   the `readOnlyMessage` prop
+ * - For any other helper text, use the `additionalHelperMessage` prop
+ *
+ * If all of these props are used, they will all be shown.
+ *
+ * When any of these props are used, the field's `aria-describedby` attribute
+ * will include the id of the element for the corresponding prop.
+ */
+export const HelperText: StoryComponentType = {
+    render: (args) => {
+        return (
+            <View style={{gap: sizing.size_240}}>
+                <Heading>A field with an error message</Heading>
+                <LabeledField {...args} errorMessage="Error message" />
+                <Heading>A field with a read only message</Heading>
+                <LabeledField {...args} readOnlyMessage="Read only message" />
+                <Heading>A field with an additional helper message</Heading>
+                <LabeledField
+                    {...args}
+                    additionalHelperMessage="Additional helper message"
+                />
+                <Heading>
+                    A field with an error, readonly, and additional helper
+                    message
+                </Heading>
+                <LabeledField
+                    {...args}
+                    errorMessage="Error message"
+                    readOnlyMessage="Read only message"
+                    additionalHelperMessage="Additional helper message"
+                />
+            </View>
+        );
+    },
+    args: {
+        field: <TextField value="" onChange={() => {}} />,
+        label: "Name",
+    },
+};
+
 const StyledForm = addStyle("form");
 
 const AllFields = (
@@ -527,6 +571,11 @@ export const Custom = {
                 <b>Read</b> <i>only</i> <u>message</u>
             </span>
         ),
+        additionalHelperMessage: (
+            <span>
+                <b>Additional</b> <i>helper</i> <u>message</u>
+            </span>
+        ),
     },
 };
 
@@ -544,6 +593,7 @@ export const CustomStyles = {
         label: "Name",
         description: "Helpful description text.",
         errorMessage: "Message about the error",
+        additionalHelperMessage: "Additional helper message",
         required: "Custom required message",
         styles: {
             root: {
@@ -556,6 +606,9 @@ export const CustomStyles = {
                 paddingBlockEnd: sizing.size_020,
             },
             error: {
+                paddingBlockStart: sizing.size_020,
+            },
+            additionalHelperMessage: {
                 paddingBlockStart: sizing.size_020,
             },
         },

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -17,6 +17,7 @@ describe("LabeledField", () => {
     const errorMessage = "Error message";
     const testId = "test-id";
     const readOnlyMessage = "Read only message";
+    const additionalHelperMessage = "Additional helper message";
 
     const getLabel = () => screen.getByText(label);
     const getDescription = () => screen.getByText(description);
@@ -24,6 +25,8 @@ describe("LabeledField", () => {
     const getError = () => screen.getByTestId("test-id-error");
     const getReadOnlyMessage = () =>
         screen.getByTestId("test-id-read-only-message");
+    const getAdditionalHelperMessage = () =>
+        screen.getByText(additionalHelperMessage);
 
     it("LabeledField renders the label text", () => {
         // Arrange
@@ -96,7 +99,7 @@ describe("LabeledField", () => {
         expect(screen.getByText(readOnlyMessage)).toBeInTheDocument();
     });
 
-    it("LabeledField renders the read only message text even if there is an error message", () => {
+    it("LabeledField renders the read only message text even if there is an error message and additional helper message", () => {
         // Arrange
         const readOnlyMessage = "Read only message";
         render(
@@ -105,6 +108,7 @@ describe("LabeledField", () => {
                 label="Label"
                 readOnlyMessage={readOnlyMessage}
                 errorMessage="Error message"
+                additionalHelperMessage="Additional helper message"
             />,
             defaultOptions,
         );
@@ -116,15 +120,16 @@ describe("LabeledField", () => {
         expect(readOnlyMessageEl).toBeInTheDocument();
     });
 
-    it("LabeledField renders the error message text if there is also a read only message", () => {
+    it("LabeledField renders the error message text if there is also a read only message and additional helper message", () => {
         // Arrange
-        const readOnlyMessage = "Read only message";
+        const errorMessage = "Error message";
         render(
             <LabeledField
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
                 label="Label"
-                readOnlyMessage={readOnlyMessage}
-                errorMessage="Error message"
+                readOnlyMessage="Read only message"
+                errorMessage={errorMessage}
+                additionalHelperMessage="Additional helper message"
             />,
             defaultOptions,
         );
@@ -136,85 +141,48 @@ describe("LabeledField", () => {
         expect(errorMessageEl).toBeInTheDocument();
     });
 
-    it("LabeledField adds testId to label", () => {
+    it("renders the additional helper message text", () => {
         // Arrange
-        const testId = "testid";
-
-        // Act
+        const additionalHelperMessage = "Additional helper message";
         render(
             <LabeledField
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
                 label="Label"
-                testId={testId}
+                additionalHelperMessage={additionalHelperMessage}
             />,
             defaultOptions,
         );
 
-        // Assert
-        const label = screen.getByTestId(`${testId}-label`);
-        expect(label).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to description", () => {
-        // Arrange
-        const testId = "testid";
-
         // Act
-        render(
-            <LabeledField
-                field={<TextField id="tf-1" value="" onChange={() => {}} />}
-                label="Label"
-                description="Description"
-                testId={testId}
-            />,
-            defaultOptions,
+        const additionalHelperMessageEl = screen.getByText(
+            additionalHelperMessage,
         );
 
         // Assert
-        const description = screen.getByTestId(`${testId}-description`);
-        expect(description).toBeInTheDocument();
+        expect(additionalHelperMessageEl).toBeInTheDocument();
     });
 
-    it("LabeledField adds testId to error", () => {
+    it("renders the additional helper message text even if there is an error message and read only message", () => {
         // Arrange
-        const testId = "testid";
-
-        // Act
+        const additionalHelperMessage = "Additional helper message";
         render(
             <LabeledField
                 field={<TextField id="tf-1" value="" onChange={() => {}} />}
                 label="Label"
-                errorMessage="Error"
-                testId={testId}
-            />,
-            defaultOptions,
-        );
-
-        // Assert
-        const error = screen.getByTestId(`${testId}-error`);
-        expect(error).toBeInTheDocument();
-    });
-
-    it("LabeledField adds testId to read only message", () => {
-        // Arrange
-        const testId = "testid";
-
-        // Act
-        render(
-            <LabeledField
-                field={<TextField id="tf-1" value="" onChange={() => {}} />}
-                label="Label"
+                additionalHelperMessage={additionalHelperMessage}
+                errorMessage="Error message"
                 readOnlyMessage="Read only message"
-                testId={testId}
             />,
             defaultOptions,
         );
 
-        // Assert
-        const readOnlyMessage = screen.getByTestId(
-            `${testId}-read-only-message`,
+        // Act
+        const additionalHelperMessageEl = screen.getByText(
+            additionalHelperMessage,
         );
-        expect(readOnlyMessage).toBeInTheDocument();
+
+        // Assert
+        expect(additionalHelperMessageEl).toBeInTheDocument();
     });
 
     describe("Labels prop", () => {
@@ -297,6 +265,11 @@ describe("LabeledField", () => {
                     `${id}-read-only-message`,
                     getReadOnlyMessage,
                 ],
+                [
+                    "additional helper message",
+                    `${id}-additional-helper-message`,
+                    getAdditionalHelperMessage,
+                ],
             ])(
                 "should have the id for the %s element set to %s",
                 (
@@ -314,6 +287,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
+                            additionalHelperMessage={additionalHelperMessage}
                         />,
                         defaultOptions,
                     );
@@ -332,6 +306,11 @@ describe("LabeledField", () => {
                 ["field", "-field", getField],
                 ["error", "-error", getError],
                 ["read only message", "-read-only-message", getReadOnlyMessage],
+                [
+                    "additional helper message",
+                    "-additional-helper-message",
+                    getAdditionalHelperMessage,
+                ],
             ])(
                 "should have an auto-generated id for the %s element that ends with %s",
                 (
@@ -348,6 +327,7 @@ describe("LabeledField", () => {
                             errorMessage={errorMessage}
                             testId={testId}
                             readOnlyMessage={readOnlyMessage}
+                            additionalHelperMessage={additionalHelperMessage}
                         />,
                         defaultOptions,
                     );
@@ -372,6 +352,11 @@ describe("LabeledField", () => {
                     `${testId}-read-only-message`,
                     getReadOnlyMessage,
                 ],
+                [
+                    "additional helper message",
+                    `${testId}-additional-helper-message`,
+                    getAdditionalHelperMessage,
+                ],
             ])(
                 "should use the testId prop to set the %s element's data-testid attribute to %s",
                 (
@@ -388,6 +373,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
+                            additionalHelperMessage={additionalHelperMessage}
                         />,
                         defaultOptions,
                     );
@@ -423,8 +409,8 @@ describe("LabeledField", () => {
                 [
                     "read only message",
                     () => {
-                        // In order to get the read error message section (icon + message)
-                        // without using testId, we get the parent of the read error
+                        // In order to get the read read only message section (icon + message)
+                        // without using testId, we get the parent of the read only
                         // text
                         const el =
                             // eslint-disable-next-line testing-library/no-node-access
@@ -437,6 +423,7 @@ describe("LabeledField", () => {
                         return el;
                     },
                 ],
+                ["additional helper message", getAdditionalHelperMessage],
             ])(
                 "should not set the data-testid attribute on the %s element if the testId prop is not set",
                 (
@@ -451,6 +438,7 @@ describe("LabeledField", () => {
                             description={description}
                             errorMessage={errorMessage}
                             readOnlyMessage={readOnlyMessage}
+                            additionalHelperMessage={additionalHelperMessage}
                         />,
                         defaultOptions,
                     );
@@ -507,18 +495,20 @@ describe("LabeledField", () => {
                 await expect(container).toHaveNoA11yViolations();
             });
 
-            it("should have no accessibility violations if the readOnlyMessage prop is set", async () => {
+            it("should have no accessibility violations if the helper text props are set", async () => {
                 // Arrange
+                // Act
                 const {container} = render(
                     <LabeledField
                         field={<TextField value="" onChange={() => {}} />}
                         label="Label"
+                        description="Description for the field"
                         readOnlyMessage="Read only message"
+                        additionalHelperMessage="Additional helper message"
+                        errorMessage="Error message"
                     />,
                     defaultOptions,
                 );
-
-                // Act
 
                 // Assert
                 await expect(container).toHaveNoA11yViolations();
@@ -666,6 +656,31 @@ describe("LabeledField", () => {
                 );
             });
 
+            it("Should set aria-describedby on the field to the id of the additional helper message", () => {
+                // Arrange
+                const additionalHelperMessage = "Additional helper message";
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                        additionalHelperMessage={additionalHelperMessage}
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const additionalHelperMessageEl = screen.getByText(
+                    additionalHelperMessage,
+                );
+                const inputEl = screen.getByRole("textbox");
+
+                // Assert
+                expect(inputEl).toHaveAttribute(
+                    "aria-describedby",
+                    additionalHelperMessageEl.id,
+                );
+            });
+
             it("Should support multiple aria-describedby attributes on the field", () => {
                 // Arrange
                 const readOnlyMessage = "Read only message";
@@ -679,6 +694,7 @@ describe("LabeledField", () => {
                         readOnlyMessage={readOnlyMessage}
                         errorMessage={errorMessage}
                         description={description}
+                        additionalHelperMessage="Additional helper message"
                         id={id}
                     />,
                     defaultOptions,
@@ -690,8 +706,30 @@ describe("LabeledField", () => {
                 // Assert
                 expect(field).toHaveAttribute(
                     "aria-describedby",
-                    `${id}-description ${id}-read-only-message ${id}-error`,
+                    [
+                        `${id}-description`,
+                        `${id}-additional-helper-message`,
+                        `${id}-read-only-message`,
+                        `${id}-error`,
+                    ].join(" "),
                 );
+            });
+
+            it("Should have no aria-describedby values on the field if there is no helper text for the field", () => {
+                // Arrange
+                render(
+                    <LabeledField
+                        field={<TextField value="" onChange={() => {}} />}
+                        label="Label"
+                    />,
+                    defaultOptions,
+                );
+
+                // Act
+                const field = screen.getByRole("textbox");
+
+                // Assert
+                expect(field).toHaveAttribute("aria-describedby", "");
             });
         });
     });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -333,6 +333,7 @@ export default function LabeledField(props: Props) {
                 style={[
                     styles.helperTextSection,
                     styles.helperTextSectionWithContent,
+                    isDisabled && styles.disabledHelperTextMessage,
                     stylesProp?.additionalHelperMessage,
                 ]}
                 id={additionalHelperMessageId}
@@ -398,6 +399,9 @@ const styles = StyleSheet.create({
         lineHeight: theme.helperText.font.lineHeight,
         marginBlockStart: theme.helperText.layout.marginBlockStart,
         minWidth: sizing.size_0, // This enables the wrapping behaviour on the helper message
+    },
+    disabledHelperTextMessage: {
+        color: theme.helperText.color.disabled.foreground,
     },
     error: {
         color: theme.error.color.foreground,

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -166,11 +166,7 @@ export default function LabeledField(props: Props) {
     function renderLabel(): React.ReactNode {
         const requiredIcon = (
             <StyledSpan
-                style={[
-                    styles.textWordBreak,
-                    styles.required,
-                    isDisabled && styles.disabledLabel,
-                ]}
+                style={[styles.required, isDisabled && styles.disabledLabel]}
                 aria-hidden={true}
             >
                 {" "}
@@ -182,7 +178,6 @@ export default function LabeledField(props: Props) {
             <React.Fragment>
                 <BodyText
                     style={[
-                        styles.textWordBreak,
                         styles.label,
                         description
                             ? styles.labelWithDescription
@@ -213,7 +208,7 @@ export default function LabeledField(props: Props) {
             <React.Fragment>
                 <BodyText
                     style={[
-                        styles.textWordBreak,
+                        styles.helperTextMessage,
                         styles.description,
                         stylesProp?.description,
                         isDisabled && styles.disabledDescription,
@@ -261,7 +256,6 @@ export default function LabeledField(props: Props) {
                             />
                             <BodyText
                                 style={[
-                                    styles.textWordBreak,
                                     styles.helperTextMessage,
                                     styles.errorMessage,
                                     styles.error,
@@ -315,9 +309,7 @@ export default function LabeledField(props: Props) {
                     color={semanticColor.core.foreground.neutral.subtle}
                     style={styles.helperTextIcon}
                 />
-                <BodyText
-                    style={[styles.textWordBreak, styles.helperTextMessage]}
-                >
+                <BodyText style={[styles.helperTextMessage]}>
                     {readOnlyMessage}
                 </BodyText>
             </View>
@@ -336,9 +328,8 @@ export default function LabeledField(props: Props) {
                 style={[
                     styles.spacingAboveHelperText,
                     isDisabled && styles.disabledHelperTextMessage,
-                    stylesProp?.additionalHelperMessage,
-                    styles.textWordBreak,
                     styles.helperTextMessage,
+                    stylesProp?.additionalHelperMessage,
                 ]}
                 tag="div"
             >
@@ -362,6 +353,7 @@ export default function LabeledField(props: Props) {
 const styles = StyleSheet.create({
     label: {
         color: semanticColor.core.foreground.neutral.strong,
+        overflowWrap: "break-word",
     },
     labelWithError: {
         color: theme.label.color.error.foreground,
@@ -378,9 +370,7 @@ const styles = StyleSheet.create({
     },
     description: {
         color: theme.description.color.foreground,
-        paddingBlockEnd: theme.root.layout.paddingBlockEnd.description,
-        fontSize: theme.description.font.size,
-        lineHeight: theme.description.font.lineHeight,
+        paddingBlockEnd: theme.root.layout.spacingBetweenHelperText,
     },
     disabledDescription: {
         color: theme.description.color.disabled.foreground,
@@ -390,14 +380,14 @@ const styles = StyleSheet.create({
         gap: theme.helperText.layout.gap,
     },
     spacingAboveHelperText: {
-        paddingBlockStart:
-            theme.root.layout.paddingBlockEnd.helperTextSectionWithContent,
+        paddingBlockStart: theme.root.layout.spacingBetweenHelperText,
     },
     helperTextMessage: {
         fontSize: theme.helperText.font.size,
         lineHeight: theme.helperText.font.lineHeight,
         marginBlockStart: theme.helperText.layout.marginBlockStart,
         minWidth: sizing.size_0, // This enables the wrapping behaviour on the helper message
+        overflowWrap: "break-word",
     },
     disabledHelperTextMessage: {
         color: theme.helperText.color.disabled.foreground,
@@ -413,8 +403,5 @@ const styles = StyleSheet.create({
     },
     required: {
         color: theme.requiredIndicator.color.foreground,
-    },
-    textWordBreak: {
-        overflowWrap: "break-word",
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -232,9 +232,9 @@ export default function LabeledField(props: Props) {
             <React.Fragment>
                 <View
                     style={[
-                        styles.helperTextSection,
+                        styles.helperTextWithIcon,
                         errorMessage
-                            ? styles.helperTextSectionWithContent
+                            ? styles.spacingAboveHelperText
                             : undefined,
                         stylesProp?.error,
                     ]}
@@ -302,8 +302,8 @@ export default function LabeledField(props: Props) {
         return (
             <View
                 style={[
-                    styles.helperTextSection,
-                    styles.helperTextSectionWithContent,
+                    styles.helperTextWithIcon,
+                    styles.spacingAboveHelperText,
                     stylesProp?.readOnlyMessage,
                 ]}
                 id={readOnlyMessageId}
@@ -329,22 +329,20 @@ export default function LabeledField(props: Props) {
         }
 
         return (
-            <View
-                style={[
-                    styles.helperTextSection,
-                    styles.helperTextSectionWithContent,
-                    isDisabled && styles.disabledHelperTextMessage,
-                    stylesProp?.additionalHelperMessage,
-                ]}
+            <BodyText
                 id={additionalHelperMessageId}
                 testId={testId && `${testId}-additional-helper-message`}
+                style={[
+                    styles.spacingAboveHelperText,
+                    isDisabled && styles.disabledHelperTextMessage,
+                    stylesProp?.additionalHelperMessage,
+                    styles.textWordBreak,
+                    styles.helperTextMessage,
+                ]}
+                tag="div"
             >
-                <BodyText
-                    style={[styles.textWordBreak, styles.helperTextMessage]}
-                >
-                    {additionalHelperMessage}
-                </BodyText>
-            </View>
+                {additionalHelperMessage}
+            </BodyText>
         );
     }
 
@@ -386,11 +384,11 @@ const styles = StyleSheet.create({
     disabledDescription: {
         color: theme.description.color.disabled.foreground,
     },
-    helperTextSection: {
+    helperTextWithIcon: {
         flexDirection: "row",
         gap: theme.helperText.layout.gap,
     },
-    helperTextSectionWithContent: {
+    spacingAboveHelperText: {
         paddingBlockStart:
             theme.root.layout.paddingBlockEnd.helperTextSectionWithContent,
     },

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -255,7 +255,7 @@ export default function LabeledField(props: Props) {
                         <>
                             <PhosphorIcon
                                 icon={WarningCircle}
-                                style={[styles.errorIcon, styles.error]}
+                                style={[styles.helperTextIcon, styles.error]}
                                 role="img"
                                 aria-label={labels.errorIconAriaLabel}
                             />
@@ -313,6 +313,7 @@ export default function LabeledField(props: Props) {
                     icon={LockIcon}
                     aria-label={labels.readOnlyIconAriaLabel}
                     color={semanticColor.core.foreground.neutral.subtle}
+                    style={styles.helperTextIcon}
                 />
                 <BodyText
                     style={[styles.textWordBreak, styles.helperTextMessage]}
@@ -404,7 +405,7 @@ const styles = StyleSheet.create({
     error: {
         color: theme.error.color.foreground,
     },
-    errorIcon: {
+    helperTextIcon: {
         marginTop: sizing.size_010, // This vertically aligns the icon with the text
     },
     errorMessage: {

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -68,6 +68,10 @@ type Props = {
      */
     readOnlyMessage?: React.ReactNode;
     /**
+     * Additional helper text placed under the field.
+     */
+    additionalHelperMessage?: React.ReactNode;
+    /**
      * Custom styles for the elements of LabeledField. Useful if there are
      * specific cases where spacing between elements needs to be customized.
      */
@@ -77,6 +81,7 @@ type Props = {
         description?: StyleType;
         error?: StyleType;
         readOnlyMessage?: StyleType;
+        additionalHelperMessage?: StyleType;
     };
     /**
      * A unique id to use as the base of the ids for the elements within the component.
@@ -86,6 +91,7 @@ type Props = {
      * - The field will have an id formatted as `${id}-field`
      * - The error will have an id formatted as `${id}-error`
      * - The read only message will have an id formatted as `${id}-read-only-message`
+     * - The additional helper message will have an id formatted as `${id}-additional-helper-message`
      *
      * If the `id` prop is not provided, a base unique id will be auto-generated.
      * This is important so that the different elements can be wired up together
@@ -103,6 +109,7 @@ type Props = {
      * - The field will have a testId formatted as `${testId}-field`
      * - The error will have a testId formatted as `${testId}-error`
      * - The read only message will have a testId formatted as `${testId}-read-only-message`
+     * - The additional helper message will have a testId formatted as `${testId}-additional-helper-message`
      */
     testId?: string;
     /**
@@ -140,6 +147,7 @@ export default function LabeledField(props: Props) {
         description,
         errorMessage,
         readOnlyMessage,
+        additionalHelperMessage,
         labels = defaultLabeledFieldLabels,
     } = props;
 
@@ -150,7 +158,7 @@ export default function LabeledField(props: Props) {
     const fieldId = `${uniqueId}-field`;
     const errorId = `${uniqueId}-error`;
     const readOnlyMessageId = `${uniqueId}-read-only-message`;
-
+    const additionalHelperMessageId = `${uniqueId}-additional-helper-message`;
     const isRequired = !!required || !!field.props.required;
     const hasError = !!errorMessage || !!field.props.error;
     const isDisabled = !!field.props.disabled;
@@ -273,6 +281,7 @@ export default function LabeledField(props: Props) {
             id: fieldId,
             "aria-describedby": [
                 description && descriptionId,
+                additionalHelperMessage && additionalHelperMessageId,
                 readOnlyMessage && readOnlyMessageId,
                 errorMessage && errorId,
             ]
@@ -314,11 +323,36 @@ export default function LabeledField(props: Props) {
         );
     }
 
+    function maybeRenderAdditionalHelperMessage() {
+        if (!additionalHelperMessage) {
+            return null;
+        }
+
+        return (
+            <View
+                style={[
+                    styles.helperTextSection,
+                    styles.helperTextSectionWithContent,
+                    stylesProp?.additionalHelperMessage,
+                ]}
+                id={additionalHelperMessageId}
+                testId={testId && `${testId}-additional-helper-message`}
+            >
+                <BodyText
+                    style={[styles.textWordBreak, styles.helperTextMessage]}
+                >
+                    {additionalHelperMessage}
+                </BodyText>
+            </View>
+        );
+    }
+
     return (
         <View style={stylesProp?.root}>
             {renderLabel()}
             {maybeRenderDescription()}
             {renderField()}
+            {maybeRenderAdditionalHelperMessage()}
             {maybeRenderReadOnlyMessage()}
             {maybeRenderError()}
         </View>

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -55,6 +55,11 @@ const theme = {
             size: font.body.size.small,
             lineHeight: font.body.lineHeight.small,
         },
+        color: {
+            disabled: {
+                foreground: semanticColor.core.foreground.neutral.strong,
+            },
+        },
     },
 };
 

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -6,9 +6,8 @@ const theme = {
             paddingBlockEnd: {
                 labelWithDescription: sizing.size_040,
                 labelWithNoDescription: sizing.size_120,
-                description: sizing.size_120,
-                helperTextSectionWithContent: sizing.size_120,
             },
+            spacingBetweenHelperText: sizing.size_120,
         },
     },
     label: {
@@ -22,10 +21,6 @@ const theme = {
         },
     },
     description: {
-        font: {
-            size: font.body.size.small,
-            lineHeight: font.body.lineHeight.small,
-        },
         color: {
             foreground: semanticColor.core.foreground.neutral.default,
             disabled: {

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -8,9 +8,8 @@ export default mergeTheme(defaultTheme, {
             paddingBlockEnd: {
                 labelWithDescription: sizing.size_100,
                 labelWithNoDescription: sizing.size_100,
-                description: sizing.size_100,
-                helperTextSectionWithContent: sizing.size_100,
             },
+            spacingBetweenHelperText: sizing.size_100,
         },
     },
     label: {
@@ -24,10 +23,6 @@ export default mergeTheme(defaultTheme, {
         },
     },
     description: {
-        font: {
-            size: font.body.size.xsmall,
-            lineHeight: font.body.lineHeight.xsmall,
-        },
         color: {
             foreground: semanticColor.core.foreground.neutral.strong,
             disabled: {

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -58,5 +58,10 @@ export default mergeTheme(defaultTheme, {
             size: font.body.size.xsmall,
             lineHeight: font.body.lineHeight.xsmall,
         },
+        color: {
+            disabled: {
+                foreground: semanticColor.core.foreground.disabled.strong,
+            },
+        },
     },
 });


### PR DESCRIPTION
## Summary:
[wb-2018-additional-helper-message] simplify styles
[wb-2018-additional-helper-message] share styles between error and readonly icon
[wb-2018-additional-helper-message] rename some styles withing labeledfield
[wb-2018-additional-helper-message] Add tests
[wb-2018-additional-helper-message] Add stories
[wb-2018-additional-helper-message] handle disabled styling for the helper text
[wb-2018-additional-helper-message] add stories
[wb-2018-additional-helper-message] add additionalHelperMessage prop to LabeledField

Issue: WB-2018

## Test plan: