### PR TITLE
LabeledField: Remove `required` prop

### DIFF
--- a/.changeset/fifty-bananas-explode.md
+++ b/.changeset/fifty-bananas-explode.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": major
+---
+
+LabeledField: Remove `required` prop. The upcoming `contextLabel` prop should be used instead for visual labels indicating if a field is required or optional. Field components will need to have their `required` prop set explicitly

--- a/.changeset/strange-squids-try.md
+++ b/.changeset/strange-squids-try.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update LabeledField component theme css variables (required tokens are no longer needed)

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -204,12 +204,12 @@ export const WithLabeledField: StoryComponentType = {
                         selectedValues={value}
                         onChange={setValue}
                         onValidate={setErrorMessage}
+                        required={true}
                     >
                         {optionItems}
                     </MultiSelect>
                 }
                 description="Description"
-                required={true}
                 errorMessage={errorMessage}
             />
         );

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -225,12 +225,12 @@ export const WithLabeledField: StoryComponentType = {
                         selectedValue={value}
                         onChange={setValue}
                         onValidate={setErrorMessage}
+                        required={true}
                     >
                         {optionItems}
                     </SingleSelect>
                 }
                 description="Description"
-                required={true}
                 errorMessage={errorMessage}
             />
         );

--- a/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/labeled-text-field.stories.tsx
@@ -108,11 +108,11 @@ export const MigrationToLabeledField: StoryComponentType = {
                 <LabeledField
                     label="Using LabeledField with TextField (recommended)"
                     description={description}
-                    required={required}
                     errorMessage={textFieldErrorMessage}
                     field={
                         <TextField
                             {...args}
+                            required={required}
                             value={textFieldValue}
                             onChange={setTextFieldValue}
                             placeholder={placeholder}

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -124,10 +124,10 @@ export const WithLabeledField: StoryComponentType = {
                         value={value}
                         onChange={setValue}
                         onValidate={setErrorMessage}
+                        required={true}
                     />
                 }
                 description="Description"
-                required={true}
                 errorMessage={errorMessage}
             />
         );

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -86,10 +86,10 @@ export const WithLabeledField: StoryComponentType = {
                         value={value}
                         onChange={setValue}
                         onValidate={setErrorMessage}
+                        required={true}
                     />
                 }
                 description="Description"
-                required={true}
                 errorMessage={errorMessage}
             />
         );

--- a/__docs__/wonder-blocks-labeled-field/accessibility.mdx
+++ b/__docs__/wonder-blocks-labeled-field/accessibility.mdx
@@ -30,8 +30,8 @@ prop is not provided, a unique id will be auto-generated!
 
 Since the label, description, and error message are associated with the field,
 they are read out with the field when it is interacted with. If the field component
-handles the `error` and `required` props and sets the `aria-invalid` and `aria-required`
-attributes, then this information is also announced.
+handles the `error` prop and sets the `aria-invalid` attribute, then this
+information is also announced.
 
 ### Error messages
 

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -78,7 +78,6 @@ const scenarios = [
     {
         name: "With long text",
         props: {
-            required: true,
             label: longText,
             errorMessage: longText,
             description: longText,
@@ -94,7 +93,6 @@ const scenarios = [
     {
         name: "With long text and no word break",
         props: {
-            required: true,
             label: longTextWithNoWordBreak,
             errorMessage: longTextWithNoWordBreak,
             description: longTextWithNoWordBreak,
@@ -114,7 +112,6 @@ const scenarios = [
             label: "Name",
             description: "Helpful description text.",
             errorMessage: "Message about the error",
-            required: "Custom required message",
             additionalHelperMessage: "Additional helper message",
             readOnlyMessage: "Read only message",
         },
@@ -157,7 +154,6 @@ const scenarios = [
             label: "Name",
             description: "Helpful description text.",
             errorMessage: "Message about the error",
-            required: "Custom required message",
             readOnlyMessage: "Message about the read only state",
             additionalHelperMessage: "Additional helper message",
             styles: {
@@ -189,7 +185,6 @@ const scenarios = [
             label: "Name",
             description: "Helpful description text.",
             additionalHelperMessage: "Additional helper message",
-            required: true,
         },
     },
     {
@@ -199,7 +194,6 @@ const scenarios = [
             label: "Name",
             description: "Helpful description text.",
             errorMessage: "Message about the error",
-            required: "Custom required message",
             additionalHelperMessage: "Additional helper message",
             readOnlyMessage: "Read only message",
         },
@@ -210,7 +204,6 @@ const scenarios = [
             field: <TextField value="Value" onChange={() => {}} disabled />,
             label: "Name",
             description: "Helpful description text.",
-            required: "Custom required message",
             additionalHelperMessage: "Additional helper message",
             readOnlyMessage: "Read only message",
         },
@@ -221,7 +214,6 @@ const scenarios = [
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
             description: "Helpful description text.",
-            required: true,
             readOnlyMessage: "Message about why it is read only",
         },
     },
@@ -231,7 +223,6 @@ const scenarios = [
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
             description: "Helpful description text.",
-            required: true,
             readOnlyMessage: longText,
         },
     },
@@ -241,7 +232,6 @@ const scenarios = [
             field: <TextField value="" onChange={() => {}} />,
             label: "Name",
             description: "Helpful description text.",
-            required: true,
             readOnlyMessage: longTextWithNoWordBreak,
         },
     },
@@ -252,7 +242,6 @@ const scenarios = [
             label: "Name",
             description: "Helpful description text.",
             errorMessage: "Message about the error",
-            required: "Custom required message",
             readOnlyMessage: "Message about the read only state",
         },
     },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.argtypes.ts
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.argtypes.ts
@@ -20,10 +20,17 @@ export default {
             },
         },
     },
-    required: {
+    readOnlyMessage: {
         table: {
             type: {
-                summary: "string | boolean",
+                summary: "string | ReactNode",
+            },
+        },
+    },
+    additionalHelperMessage: {
+        table: {
+            type: {
+                summary: "string | ReactNode",
             },
         },
     },

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -131,7 +131,7 @@ const AllFields = (
         showSubmitButtonInStory?: boolean;
         disabled?: boolean;
         textValue?: string;
-        required?: boolean;
+        required?: boolean | string; // Used for the field component's required prop
     },
 ) => {
     const {
@@ -298,6 +298,7 @@ const AllFields = (
                         }
                         instantValidation={false}
                         disabled={disabled}
+                        required={args.required}
                     />
                 }
             />
@@ -317,6 +318,7 @@ const AllFields = (
                         }
                         instantValidation={false}
                         disabled={disabled}
+                        required={args.required}
                     />
                 }
             />
@@ -335,6 +337,7 @@ const AllFields = (
                         onValidate={setSingleSelectErrorMessage}
                         validate={singleSelectValidate}
                         disabled={disabled}
+                        required={args.required}
                     >
                         <OptionItem label="Mango" value="mango" />
                         <OptionItem label="Strawberry" value="strawberry" />
@@ -360,6 +363,7 @@ const AllFields = (
                                 : undefined
                         }
                         disabled={disabled}
+                        required={args.required}
                     >
                         <OptionItem label="Mango" value="mango" />
                         <OptionItem label="Strawberry" value="strawberry" />
@@ -466,7 +470,9 @@ export const Required: AllFieldsStoryComponentType = {
         description: "Helpful description text.",
         showSubmitButtonInStory: true,
     },
-    render: AllFields,
+    render: (args) => (
+        <AllFields {...args} required="Custom required error message" />
+    ),
 };
 
 /**

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -18,8 +18,10 @@ import {allModes} from "../../.storybook/modes";
 import {Heading} from "@khanacademy/wonder-blocks-typography";
 
 /**
- * The `LabeledField` component provides common elements for a form field such
- * as the label, required indicator, description, and error message.
+ * A LabeledField is an element that provides a label, context label, and
+ * helper text to present more information about any type of form field
+ * component. Helper text includes a description, error message, read only
+ * message, and any additional helper message.
  *
  * It is highly recommended that all form fields should be used with the
  * `LabeledField` component so that our form fields are consistent and accessible.
@@ -30,10 +32,6 @@ import {Heading} from "@khanacademy/wonder-blocks-typography";
  * explicitly on the field
  * - Setting the `readOnlyMessage` prop will also auto-populate the `readOnly`
  * prop on the form field component
- * - If the `required` prop is set on `LabeledField`, it will be passed onto the
- * `field` prop component so it doesn't need to be set explicitly. If the `required`
- * prop is set on the `field` component, it will also get set for `LabeledField`
- * so that the required indicator is shown
  * - For TextField and TextArea, it is highly recommended that they are
  * configured with `instantValidation=false` so that validation happens on blur.
  * See Validation docs for those components for more details!
@@ -66,7 +64,6 @@ export const Default: StoryComponentType = {
         field: <TextField value="" onChange={() => {}} />,
         label: "Name",
         description: "Helpful description text.",
-        required: "Custom required message",
     },
 };
 
@@ -134,6 +131,7 @@ const AllFields = (
         showSubmitButtonInStory?: boolean;
         disabled?: boolean;
         textValue?: string;
+        required?: boolean;
     },
 ) => {
     const {
@@ -409,7 +407,7 @@ const AllFields = (
  * is an error message.
  *
  * Because of this, LabeledField works best with field components that accept
- * `error` and `required` props since these props will get auto-populated by
+ * `error` and `readOnly` props since these props will get auto-populated by
  * LabeledField.
  */
 export const Fields: StoryComponentType = {
@@ -449,13 +447,12 @@ export const Fields: StoryComponentType = {
 
 /**
  * If it is mandatory for a user to fill out a field, it can be marked as
- * required.
+ * required by:
+ * - using the `contextLabel` prop for a "required" label on the `LabeledField`
+ * component for the field
+ * - providing a `required` prop on the `field` component
  *
- * LabeledField will auto-populate the `required` prop for the field
- * component and validation is handled by the specific field components. See
- * docs for each component for more details on validation logic.
- *
- * If LabeledField's `required` prop is used and the field's `onValidate` prop
+ * If field's `required` prop is used and the field's `onValidate` prop
  * sets LabeledField's `errorMessage` prop, the error message for the required
  * field will be shown.
  *
@@ -467,7 +464,6 @@ export const Fields: StoryComponentType = {
 export const Required: AllFieldsStoryComponentType = {
     args: {
         description: "Helpful description text.",
-        required: "Custom required error message",
         showSubmitButtonInStory: true,
     },
     render: AllFields,
@@ -540,7 +536,7 @@ export const ChangingErrors: StoryComponentType = {
  * - MultiSelect
  *
  * This is recommended because LabeledField will inject WB specific props:
- * `required`, `error`, and `testId`. The `field` component should handle these
+ * `readOnly`, `error`, and `testId`. The `field` component should handle these
  * props accordingly. This is helpful because for example, if LabeledField has
  * an error message, the field should also be in an error state. If the `field`
  * component doesn't support these props, there will be console warnings.
@@ -550,7 +546,6 @@ export const WithNonWb = {
         label: "Label",
         description: "Description",
         errorMessage: "Error message",
-        required: true,
         field: <input type="text" />,
     },
 };
@@ -607,7 +602,6 @@ export const CustomStyles = {
         description: "Helpful description text.",
         errorMessage: "Message about the error",
         additionalHelperMessage: "Additional helper message",
-        required: "Custom required message",
         styles: {
             root: {
                 padding: sizing.size_080,

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -139,7 +139,6 @@ export const WithLabeledField: StoryComponentType = {
                     />
                 }
                 description="Description"
-                required={true}
                 errorMessage={errorMessage}
             />
         );

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -3,7 +3,6 @@ import {render, screen, within} from "@testing-library/react";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {userEvent} from "@testing-library/user-event";
 import LabeledField from "../labeled-field";
 
 const defaultOptions = {

--- a/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/__tests__/labeled-field.test.tsx
@@ -735,45 +735,6 @@ describe("LabeledField", () => {
     });
 
     describe("Field", () => {
-        it.each([
-            {
-                required: true,
-                ariaRequired: "true",
-            },
-            {
-                required: false,
-                ariaRequired: "false",
-            },
-            {
-                required: undefined,
-                ariaRequired: "false",
-            },
-            {
-                required: "Custom required message",
-                ariaRequired: "true",
-            },
-        ])(
-            "should set aria-required to $ariaRequired on the field if LabeledField has the required set to $required",
-            ({required, ariaRequired}) => {
-                // Arrange
-                // Act
-                render(
-                    <LabeledField
-                        field={<TextField value="" onChange={() => {}} />}
-                        required={required}
-                        label="Label"
-                    />,
-                    defaultOptions,
-                );
-
-                // Assert
-                expect(screen.getByRole("textbox")).toHaveAttribute(
-                    "aria-required",
-                    ariaRequired,
-                );
-            },
-        );
-
         it("should set aria-invalid on the field if LabeledField has the errorMessage prop", () => {
             // Arrange
             // Act
@@ -794,51 +755,6 @@ describe("LabeledField", () => {
         });
 
         describe("Using props set on field", () => {
-            it("should set the required indicator if the field has the required prop set", async () => {
-                // Arrange
-                // Act
-                render(
-                    <LabeledField
-                        field={
-                            <TextField
-                                value=""
-                                onChange={() => {}}
-                                required="Required msg"
-                            />
-                        }
-                        label="Label"
-                    />,
-                    defaultOptions,
-                );
-
-                // Assert
-                await screen.findByLabelText("Label *");
-            });
-
-            it("should still set the field as required if it is set on the field and not LabeledField", () => {
-                // Arrange
-                // Act
-                render(
-                    <LabeledField
-                        field={
-                            <TextField
-                                value=""
-                                onChange={() => {}}
-                                required="Required msg"
-                            />
-                        }
-                        label="Label"
-                    />,
-                    defaultOptions,
-                );
-
-                // Assert
-                expect(screen.getByRole("textbox")).toHaveAttribute(
-                    "aria-required",
-                    "true",
-                );
-            });
-
             it("should still use the field's error prop if it is not set on LabeledField", () => {
                 // Arrange
                 // Act
@@ -862,76 +778,6 @@ describe("LabeledField", () => {
                     "true",
                 );
             });
-        });
-    });
-
-    describe("Custom required message", () => {
-        it("should show the custom required message if it is set on the field", async () => {
-            // Arrange
-            const requiredMessage = "Custom required message";
-
-            const ControlledLabeledFieldWithTextField = () => {
-                const [value, setValue] = React.useState("T");
-                const [errorMessage, setErrorMessage] = React.useState<
-                    string | null
-                >();
-                return (
-                    <LabeledField
-                        field={
-                            <TextField
-                                value={value}
-                                onChange={setValue}
-                                onValidate={setErrorMessage}
-                                required={requiredMessage}
-                            />
-                        }
-                        label="Label"
-                        errorMessage={errorMessage}
-                    />
-                );
-            };
-            render(<ControlledLabeledFieldWithTextField />, defaultOptions);
-            const field = await screen.findByRole("textbox");
-
-            // Act
-            await userEvent.type(field, "{backspace}");
-
-            // Assert
-            await screen.findByText(requiredMessage);
-        });
-
-        it("should show the custom required message if it is set on LabeledField", async () => {
-            // Arrange
-            const requiredMessage = "Custom required message";
-
-            const ControlledLabeledFieldWithTextField = () => {
-                const [value, setValue] = React.useState("T");
-                const [errorMessage, setErrorMessage] = React.useState<
-                    string | null
-                >();
-                return (
-                    <LabeledField
-                        field={
-                            <TextField
-                                value={value}
-                                onChange={setValue}
-                                onValidate={setErrorMessage}
-                            />
-                        }
-                        required={requiredMessage}
-                        label="Label"
-                        errorMessage={errorMessage}
-                    />
-                );
-            };
-            render(<ControlledLabeledFieldWithTextField />, defaultOptions);
-            const field = await screen.findByRole("textbox");
-
-            // Act
-            await userEvent.type(field, "{backspace}");
-
-            // Assert
-            await screen.findByText(requiredMessage);
         });
     });
 

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -22,30 +22,6 @@ type Props = {
      */
     description?: React.ReactNode;
     /**
-     * Whether this field is required to to continue, or the error message to
-     * render if this field is left blank. This is passed into the field
-     * component.
-     *
-     * This can be a boolean or a string.
-     *
-     * String:
-     * Please pass in a translated string to use as the error message that will
-     * render if the user leaves this field blank. If this field is required,
-     * and a string is not passed in, a default untranslated string will render
-     * upon error.
-     * Note: The string will not be used if a `validate` prop is passed in.
-     *
-     * Example message: i18n._("A password is required to log in.")
-     *
-     * Boolean:
-     * True/false indicating whether this field is required. Please do not pass
-     * in `true` if possible - pass in the error string instead.
-     * If `true` is passed, and a `validate` prop is not passed, that means
-     * there is no corresponding message and the default untranlsated message
-     * will be used.
-     */
-    required?: boolean | string;
-    /**
      * The message for the error element. If there is a message, it will also
      * set the `error` prop on the `field` component.
      *
@@ -129,12 +105,11 @@ const defaultLabeledFieldLabels: LabeledFieldLabels = {
     errorIconAriaLabel: "Error:",
 };
 
-const StyledSpan = addStyle("span");
-
 /**
- * A LabeledField is an element that provides a label, required indicator,
- * description, and error to present better context and hints to any type of
- * form field component.
+ * A LabeledField is an element that provides a label, context label, and
+ * helper text to present more information about any type of form field
+ * component. Helper text includes a description, error message, read only
+ * message, and any additional helper message.
  */
 export default function LabeledField(props: Props) {
     const {
@@ -142,7 +117,6 @@ export default function LabeledField(props: Props) {
         styles: stylesProp,
         label,
         id,
-        required,
         testId,
         description,
         errorMessage,
@@ -159,21 +133,10 @@ export default function LabeledField(props: Props) {
     const errorId = `${uniqueId}-error`;
     const readOnlyMessageId = `${uniqueId}-read-only-message`;
     const additionalHelperMessageId = `${uniqueId}-additional-helper-message`;
-    const isRequired = !!required || !!field.props.required;
     const hasError = !!errorMessage || !!field.props.error;
     const isDisabled = !!field.props.disabled;
 
     function renderLabel(): React.ReactNode {
-        const requiredIcon = (
-            <StyledSpan
-                style={[styles.required, isDisabled && styles.disabledLabel]}
-                aria-hidden={true}
-            >
-                {" "}
-                *
-            </StyledSpan>
-        );
-
         return (
             <React.Fragment>
                 <BodyText
@@ -193,7 +156,6 @@ export default function LabeledField(props: Props) {
                     weight="semi"
                 >
                     {label}
-                    {isRequired && requiredIcon}
                 </BodyText>
             </React.Fragment>
         );
@@ -281,7 +243,6 @@ export default function LabeledField(props: Props) {
             ]
                 .filter(Boolean)
                 .join(" "),
-            required: required || field.props.required,
             error: hasError,
             testId: testId ? `${testId}-field` : undefined,
             readOnly: readOnlyMessage || field.props.readOnly,
@@ -394,8 +355,5 @@ const styles = StyleSheet.create({
     },
     errorMessage: {
         fontWeight: theme.error.font.weight,
-    },
-    required: {
-        color: theme.requiredIndicator.color.foreground,
     },
 });

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import WarningCircle from "@phosphor-icons/core/bold/warning-circle-bold.svg";
 import LockIcon from "@phosphor-icons/core/bold/lock-bold.svg";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import {View, addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
+import {View, StyleType} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import theme from "../theme";

--- a/packages/wonder-blocks-labeled-field/src/theme/default.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/default.ts
@@ -28,11 +28,6 @@ const theme = {
             weight: font.weight.regular,
         },
     },
-    requiredIndicator: {
-        color: {
-            foreground: semanticColor.core.foreground.critical.subtle,
-        },
-    },
     helperText: {
         layout: {
             gap: sizing.size_080,

--- a/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-labeled-field/src/theme/thunderblocks.ts
@@ -30,11 +30,6 @@ export default mergeTheme(defaultTheme, {
             weight: font.weight.bold,
         },
     },
-    requiredIndicator: {
-        color: {
-            foreground: semanticColor.core.foreground.critical.default,
-        },
-    },
     helperText: {
         layout: {
             gap: sizing.size_040,


### PR DESCRIPTION
## Summary:

Removing the `required` prop from `LabeledField` in favour of the new upcoming `contextLabel` prop. The asterisk that marks a field as required will be replaced with a context label (either "required" or "optional"). Consumers can pass in the `required` prop to the underlying field component used with the LabeledField

Issue: WB-2017

## Test plan:
- Confirm there is no `required` prop on the `LabeledField` anymore
- Confirm the LabeledField docs don't include references to the `required` prop for `LabeledField` (Note: The form field components will still support a `required` prop)
- Confirm the LabeledField Required story continues to work as expected (pressing "Submit" while all the fields are empty shows the custom error message provided to the field) `?path=/story/packages-labeledfield--required`


## Implementation plan for LabeledField updates:
- Support `readOnlyMessage` (released and deployed!) https://github.com/Khan/wonder-blocks/pull/2709
- Support `additionalHelperMessage` https://github.com/Khan/wonder-blocks/pull/2714
- Remove `required` prop (this PR) https://github.com/Khan/wonder-blocks/pull/2715
- Add `contextLabel` prop (next)