### PR TITLE
Do not try to focus hidden elements in `FocusTrap`

### DIFF
--- a/.changeset/flat-rivers-reflect.md
+++ b/.changeset/flat-rivers-reflect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Do not try to focus hidden elements in FocusTrap

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -427,6 +427,42 @@ WithInitialFocusId.parameters = {
     },
 };
 
+export const WithLastButtonHidden: StoryComponentType = () => {
+    const modalLastButtonHidden = () => (
+        <OnePaneDialog
+            title="Single-line title"
+            content={
+                <View style={{gap: sizing.size_240}}>
+                    <Button>Button 1</Button>
+                    <Button style={{display: "none"}}>Button 2</Button>
+                </View>
+            }
+        />
+    );
+
+    return (
+        <ModalLauncher modal={modalLastButtonHidden}>
+            {({openModal}) => (
+                <Button onClick={openModal}>
+                    Open modal with last button hidden
+                </Button>
+            )}
+        </ModalLauncher>
+    );
+};
+
+WithLastButtonHidden.parameters = {
+    chromatic: {
+        // All the examples for ModalLauncher are behavior based, not visual.
+        disableSnapshot: true,
+    },
+    docs: {
+        description: {
+            story: `Verifying that the focus trap works when the last button is hidden.`,
+        },
+    },
+};
+
 /**
  * Focus trap navigation
  */

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -427,42 +427,6 @@ WithInitialFocusId.parameters = {
     },
 };
 
-export const WithLastButtonHidden: StoryComponentType = () => {
-    const modalLastButtonHidden = () => (
-        <OnePaneDialog
-            title="Single-line title"
-            content={
-                <View style={{gap: sizing.size_240}}>
-                    <Button>Button 1</Button>
-                    <Button style={{display: "none"}}>Button 2</Button>
-                </View>
-            }
-        />
-    );
-
-    return (
-        <ModalLauncher modal={modalLastButtonHidden}>
-            {({openModal}) => (
-                <Button onClick={openModal}>
-                    Open modal with last button hidden
-                </Button>
-            )}
-        </ModalLauncher>
-    );
-};
-
-WithLastButtonHidden.parameters = {
-    chromatic: {
-        // All the examples for ModalLauncher are behavior based, not visual.
-        disableSnapshot: true,
-    },
-    docs: {
-        description: {
-            story: `Verifying that the focus trap works when the last button is hidden.`,
-        },
-    },
-};
-
 /**
  * Focus trap navigation
  */

--- a/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.tsx
@@ -111,8 +111,7 @@ describe("FocusTrap", () => {
         );
 
         // Initial focused element
-        const firstButton = screen.getByRole("button", {name: /button 1/i});
-        firstButton.focus();
+        screen.getByRole("button", {name: /button 1/i}).focus();
 
         // Act
         await userEvent.tab({shift: true});
@@ -134,8 +133,7 @@ describe("FocusTrap", () => {
         );
 
         // Initial focused element
-        const firstButton = screen.getByRole("button", {name: /button 1/i});
-        firstButton.focus();
+        screen.getByRole("button", {name: /button 1/i}).focus();
 
         // Act
         await userEvent.tab({shift: true});

--- a/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.tsx
@@ -98,13 +98,36 @@ describe("FocusTrap", () => {
         ).toHaveFocus();
     });
 
-    it("does not move focus to hidden elements", async () => {
+    it("does not move focus to elements with display: none", async () => {
         // Arrange
         render(
             <FocusTrap>
                 <Button>button 1</Button>
                 <Button>button 2</Button>
                 <Button id="hidden-element" style={{display: "none"}}>
+                    button 3
+                </Button>
+            </FocusTrap>,
+        );
+
+        // Initial focused element
+        const firstButton = screen.getByRole("button", {name: /button 1/i});
+        firstButton.focus();
+
+        // Act
+        await userEvent.tab({shift: true});
+
+        // Assert
+        expect(screen.getByRole("button", {name: /button 2/i})).toHaveFocus();
+    });
+
+    it("does not move focus to elements with visibility: hidden", async () => {
+        // Arrange
+        render(
+            <FocusTrap>
+                <Button>button 1</Button>
+                <Button>button 2</Button>
+                <Button id="hidden-element" style={{visibility: "hidden"}}>
                     button 3
                 </Button>
             </FocusTrap>,

--- a/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/focus-trap.test.tsx
@@ -7,17 +7,9 @@ import {Choice, RadioGroup} from "@khanacademy/wonder-blocks-form";
 
 import FocusTrap from "../focus-trap";
 
-// jsdom's Element does not implement checkVisibility, so we assign a placeholder
-// to it here, then mock the implementation in the tests.
-Element.prototype.checkVisibility = () => true;
-
 describe("FocusTrap", () => {
     it("moves focus to the first focusable element", async () => {
         // Arrange
-        jest.spyOn(Element.prototype, "checkVisibility").mockImplementation(
-            () => true,
-        );
-
         render(
             <>
                 <FocusTrap>
@@ -63,10 +55,6 @@ describe("FocusTrap", () => {
 
     it("moves focus to the last focusable element", async () => {
         // Arrange
-        jest.spyOn(Element.prototype, "checkVisibility").mockImplementation(
-            () => true,
-        );
-
         render(
             <>
                 <FocusTrap>
@@ -112,20 +100,13 @@ describe("FocusTrap", () => {
 
     it("does not move focus to hidden elements", async () => {
         // Arrange
-        jest.spyOn(Element.prototype, "checkVisibility").mockImplementation(
-            function (this: Element) {
-                if (this.id === "hidden-element") {
-                    return false;
-                }
-                return true;
-            },
-        );
-
         render(
             <FocusTrap>
                 <Button>button 1</Button>
                 <Button>button 2</Button>
-                <Button id="hidden-element">button 3</Button>
+                <Button id="hidden-element" style={{display: "none"}}>
+                    button 3
+                </Button>
             </FocusTrap>,
         );
 

--- a/packages/wonder-blocks-modal/src/components/focus-trap.tsx
+++ b/packages/wonder-blocks-modal/src/components/focus-trap.tsx
@@ -87,13 +87,7 @@ export default class FocusTrap extends React.Component<Props> {
         // Get the list of available focusable elements within the modal.
         const focusableNodes = Array.from(
             modalRootAsHtmlEl.querySelectorAll(FOCUSABLE_ELEMENTS),
-        ).filter((element) =>
-            element.checkVisibility === undefined
-                ? // checkVisibility is not implemented in jsdom, so just assume
-                  // the element is visible
-                  true
-                : element.checkVisibility(),
-        );
+        ).filter((element) => element.checkVisibility());
 
         const nodeIndex = !isLast ? focusableNodes.length - 1 : 0;
 

--- a/packages/wonder-blocks-modal/src/components/focus-trap.tsx
+++ b/packages/wonder-blocks-modal/src/components/focus-trap.tsx
@@ -87,7 +87,10 @@ export default class FocusTrap extends React.Component<Props> {
         // Get the list of available focusable elements within the modal.
         const focusableNodes = Array.from(
             modalRootAsHtmlEl.querySelectorAll(FOCUSABLE_ELEMENTS),
-        ).filter((element) => element.checkVisibility());
+        ).filter((element) => {
+            const style = window.getComputedStyle(element);
+            return style.display !== "none" && style.visibility !== "hidden";
+        });
 
         const nodeIndex = !isLast ? focusableNodes.length - 1 : 0;
 

--- a/packages/wonder-blocks-modal/src/components/focus-trap.tsx
+++ b/packages/wonder-blocks-modal/src/components/focus-trap.tsx
@@ -87,6 +87,12 @@ export default class FocusTrap extends React.Component<Props> {
         // Get the list of available focusable elements within the modal.
         const focusableNodes = Array.from(
             modalRootAsHtmlEl.querySelectorAll(FOCUSABLE_ELEMENTS),
+        ).filter((element) =>
+            element.checkVisibility === undefined
+                ? // checkVisibility is not implemented in jsdom, so just assume
+                  // the element is visible
+                  true
+                : element.checkVisibility(),
         );
 
         const nodeIndex = !isLast ? focusableNodes.length - 1 : 0;


### PR DESCRIPTION
## Summary:
This prevents issues when the last element in a modal is hidden. Without this PR, we would try to focus it when shift+tabbing back from the close button, and focus would exit the trap.

Ideally, we'd use [`checkVisibility`](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility), but Safari 15.6 doesn't support it per [caniuse](https://caniuse.com/mdn-api_element_checkvisibility).

## Test plan:
- Run the new test
- Check out the reverted commit in this PR, which includes a story which can be used for manually testing (I don't think it's worth keeping this story around, but I wanted to see it working firsthand)