### PR TITLE
[WB-2042.1] Remove semanticColor.border category

### DIFF
--- a/.changeset/silver-icons-itch.md
+++ b/.changeset/silver-icons-itch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": major
+---
+
+Removes semanticColor.border category as it is deprecated (core.border is the replacement)

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -362,7 +362,8 @@ export const AllBadgesScenarios: StoryComponentType = {
                                         backgroundColor:
                                             semanticColor.surface.inverse,
                                         borderColor:
-                                            semanticColor.border.inverse,
+                                            semanticColor.core.border.inverse
+                                                .strong,
                                         color: semanticColor.text.inverse,
                                     },
                                     icon: {color: semanticColor.icon.inverse},

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -201,7 +201,7 @@ export const CustomStyles: StoryComponentType = {
                 styles={{
                     root: {
                         backgroundColor: semanticColor.surface.inverse,
-                        borderColor: semanticColor.border.inverse,
+                        borderColor: semanticColor.core.border.inverse.strong,
                         color: semanticColor.text.inverse,
                     },
                     icon: {color: semanticColor.icon.inverse},

--- a/__docs__/wonder-blocks-icon/custom-icon-components.stories.tsx
+++ b/__docs__/wonder-blocks-icon/custom-icon-components.stories.tsx
@@ -110,7 +110,7 @@ export const CustomIconsWithCustomStyle: StoryComponentType = {
             backgroundColor: semanticColor.surface.secondary,
             padding: sizing.size_040,
             borderRadius: border.radius.radius_040,
-            border: `${border.width.thin} solid ${semanticColor.border.subtle}`,
+            border: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
         },
     },
 };

--- a/packages/wonder-blocks-badge/src/components/badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/badge.tsx
@@ -91,7 +91,7 @@ const badgeTokens = {
         color: {
             background: semanticColor.surface.secondary,
             foreground: semanticColor.text.primary,
-            border: semanticColor.border.subtle,
+            border: semanticColor.core.border.neutral.subtle,
         },
     },
     icon: {

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -136,22 +136,6 @@ const core = {
     },
 };
 
-/**
- * TODO(WB-1941): Remove border once we have migrated to the new core.border
- * tokens.
- */
-const border = {
-    subtle: color.gray_60,
-    // TODO(WB-1941): Change to the new core.border structure and use
-    // neutral.default instead of primary.
-    // primary: color.fadedOffBlack16,
-    primary: color.gray_30,
-    strong: color.gray_20,
-    inverse: color.white_100,
-    progressive: color.blue_30,
-    destructive: color.red_30,
-};
-
 const surface = {
     primary: color.white_100,
     secondary: color.blue_90,
@@ -573,7 +557,6 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
 
     surface,
     text,
-    border,
 
     focus: {
         outer: color.blue_30,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -136,19 +136,6 @@ const core = {
     },
 };
 
-/**
- * TODO(WB-1941): Remove border once we have migrated to the new core.border
- * tokens.
- */
-const border = {
-    primary: color.fadedOffBlack16,
-    subtle: color.fadedOffBlack8,
-    strong: color.fadedOffBlack50,
-    inverse: color.white,
-    progressive: color.blue,
-    destructive: color.red,
-};
-
 const surface = {
     primary: color.white,
     secondary: color.offWhite,
@@ -746,14 +733,6 @@ export const semanticColor = {
      * dark backgrounds in light mode.
      */
     text,
-    /**
-     * Borders define structure for elements. Generally borders for component
-     * elements would use -Primary, rows and layout elements use -Subtle and
-     * -Strong for when 3:1 contrast is a priority (ex. form elements)
-     *
-     * @deprecated Use `core.border` tokens instead.
-     */
-    border: border,
 
     focus: {
         outer: color.blue,


### PR DESCRIPTION
## Summary:

Removes the `semanticColor.border` category as it is deprecated, as we have
created the `semanticColor.core.border` category instead.

Next PR will remove `semanticColor.text`.

Issue: https://khanacademy.atlassian.net/browse/WB-2042

## Test plan:

Verify that the stories in `wonder-blocks-badge` look as expected. There might be a slight change with the Base Badge component, but that should be ok.