### PR TITLE
[WB-2042.2] Remove semanticColor.text category

### DIFF
--- a/.changeset/clever-humans-know.md
+++ b/.changeset/clever-humans-know.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Updates CSS variables for the form package

--- a/.changeset/fresh-snakes-smoke.md
+++ b/.changeset/fresh-snakes-smoke.md
@@ -1,0 +1,9 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-styles": patch
+"@khanacademy/wonder-blocks-badge": patch
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Replaces instances of `semanticColor.text` with `semanticColor.core.foreground`

--- a/.changeset/friendly-buses-fly.md
+++ b/.changeset/friendly-buses-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": major
+---
+
+Removes semanticColor.text category now that we use semanticColor.core.foreground.

--- a/.changeset/thick-coins-chew.md
+++ b/.changeset/thick-coins-chew.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update form component-level tokens

--- a/__docs__/components/color.tsx
+++ b/__docs__/components/color.tsx
@@ -260,7 +260,7 @@ const styles = StyleSheet.create({
     },
     code: {
         alignSelf: "flex-start",
-        color: semanticColor.text.primary,
+        color: semanticColor.core.foreground.neutral.strong,
         display: "inline-flex",
         backgroundColor: semanticColor.surface.secondary,
         border: `1px solid ${color.offBlack16}`,

--- a/__docs__/components/state-sheet.tsx
+++ b/__docs__/components/state-sheet.tsx
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
     },
     label: {
         paddingBlockEnd: sizing.size_080,
-        color: semanticColor.text.secondary,
+        color: semanticColor.core.foreground.neutral.default,
     },
     content: {
         maxWidth: "100%",

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -515,18 +515,6 @@ Default icon colors that change in context (like actions).
 
 <ColorGroup colors={semanticColor.icon} group="icon" />
 
-### Text (deprecated)
-
-For all type to ensure contrast for legibility. Inverse text applies for dark
-backgrounds in light mode.
-
-<Banner
-    kind="warning"
-    text="These text tokens are deprecated and will be removed in the future. Please use the semanticColor.core.foreground tokens for text instead."
-/>
-
-<ColorGroup colors={semanticColor.text} group="text" />
-
 ### Status (deprecated)
 
 <Banner

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -364,7 +364,8 @@ export const AllBadgesScenarios: StoryComponentType = {
                                         borderColor:
                                             semanticColor.core.border.inverse
                                                 .strong,
-                                        color: semanticColor.text.inverse,
+                                        color: semanticColor.core.foreground
+                                            .inverse.strong,
                                     },
                                     icon: {color: semanticColor.icon.inverse},
                                     label: {

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -202,7 +202,7 @@ export const CustomStyles: StoryComponentType = {
                     root: {
                         backgroundColor: semanticColor.surface.inverse,
                         borderColor: semanticColor.core.border.inverse.strong,
-                        color: semanticColor.text.inverse,
+                        color: semanticColor.core.foreground.inverse.strong,
                     },
                     icon: {color: semanticColor.icon.inverse},
                     label: {

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -337,7 +337,7 @@ const styles = StyleSheet.create({
     },
     dark: {
         backgroundColor: semanticColor.surface.inverse,
-        color: semanticColor.text.inverse,
+        color: semanticColor.core.foreground.inverse.strong,
         padding: spacing.xSmall_8,
     },
     row: {
@@ -353,7 +353,7 @@ const styles = StyleSheet.create({
         padding: spacing.large_24,
     },
     disabled: {
-        color: semanticColor.text.inverse,
+        color: semanticColor.core.foreground.inverse.strong,
         backgroundColor: semanticColor.surface.overlay,
     },
     button: {

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -151,7 +151,7 @@ const styles = StyleSheet.create({
         borderLeft: `${border.width.thick} solid ${semanticColor.status.warning.foreground}`,
         borderRadius: border.radius.radius_040,
         background: semanticColor.status.warning.background,
-        color: semanticColor.text.primary,
+        color: semanticColor.core.foreground.neutral.strong,
         padding: sizing.size_160,
     },
     focused: focusStyles.focus[":focus-visible"],

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -123,7 +123,7 @@ const styles = StyleSheet.create({
         borderLeft: `${border.width.thick} solid ${semanticColor.status.warning.foreground}`,
         borderRadius: border.radius.radius_040,
         background: semanticColor.status.warning.background,
-        color: semanticColor.text.primary,
+        color: semanticColor.core.foreground.neutral.strong,
         padding: sizing.size_160,
     },
     focused: focusStyles.focus[":focus-visible"],

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -125,7 +125,7 @@ const styles = StyleSheet.create({
         borderLeft: `${border.width.thick} solid ${semanticColor.status.warning.foreground}`,
         borderRadius: border.radius.radius_040,
         background: semanticColor.status.warning.background,
-        color: semanticColor.text.primary,
+        color: semanticColor.core.foreground.neutral.strong,
         padding: sizing.size_160,
     },
     focused: {

--- a/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
@@ -345,7 +345,7 @@ const styles = StyleSheet.create({
         justifyContent: "center",
     },
     description: {
-        color: semanticColor.text.secondary,
+        color: semanticColor.core.foreground.neutral.default,
     },
     last: {
         borderBottom: "solid 1px #CCC",

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
         border: "none",
         maxWidth: 250,
         "::placeholder": {
-            color: semanticColor.text.secondary,
+            color: semanticColor.core.foreground.neutral.default,
         },
     },
 });

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -880,7 +880,7 @@ const styles = StyleSheet.create({
         border: "none",
         maxWidth: 250,
         "::placeholder": {
-            color: semanticColor.text.secondary,
+            color: semanticColor.core.foreground.neutral.default,
         },
     },
     button: {

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -246,7 +246,11 @@ export const StartAndEndIcons: StoryComponentType = {
                 >
                     This is a multi-line link with start and end icons
                 </Link>
-                <Body style={{color: semanticColor.text.inverse}}>
+                <Body
+                    style={{
+                        color: semanticColor.core.foreground.inverse.strong,
+                    }}
+                >
                     This is an inline{" "}
                     <Link
                         href="#link"
@@ -319,7 +323,12 @@ export const Inline: StoryComponentType = {
  */
 export const InlineLight: StoryComponentType = {
     render: () => (
-        <Body style={{color: semanticColor.text.inverse, width: 530}}>
+        <Body
+            style={{
+                color: semanticColor.core.foreground.inverse.strong,
+                width: 530,
+            }}
+        >
             This is an inline{" "}
             <Link href="#link" inline={true} light={true}>
                 regular link

--- a/__docs__/wonder-blocks-pill/pill.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill.stories.tsx
@@ -235,7 +235,7 @@ WithTypography.parameters = {
 export const WithStyle: StoryComponentType = () => {
     const customStyle = {
         backgroundColor: tokens.semanticColor.surface.inverse,
-        color: tokens.semanticColor.text.inverse,
+        color: tokens.semanticColor.core.foreground.inverse.strong,
         paddingLeft: tokens.spacing.xxLarge_48,
         paddingRight: tokens.spacing.xxLarge_48,
 

--- a/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
     action: {
         backgroundColor: "transparent",
         border: "none",
-        color: semanticColor.text.inverse,
+        color: semanticColor.core.foreground.inverse.strong,
         cursor: "pointer",
         margin: spacing.small_12,
         padding: spacing.xxSmall_6,

--- a/__docs__/wonder-blocks-styles/focus-styles.stories.tsx
+++ b/__docs__/wonder-blocks-styles/focus-styles.stories.tsx
@@ -85,7 +85,10 @@ export const Focus: Story = {
                         icon={info}
                         style={[
                             focusStyles.focus,
-                            {color: semanticColor.text.inverse},
+                            {
+                                color: semanticColor.core.foreground.inverse
+                                    .strong,
+                            },
                         ]}
                     />
                 </View>
@@ -125,7 +128,10 @@ export const Scenarios: Story = {
                             icon={info}
                             style={[
                                 focusStyles.focus,
-                                {color: semanticColor.text.inverse},
+                                {
+                                    color: semanticColor.core.foreground.inverse
+                                        .strong,
+                                },
                             ]}
                         />
                     ),

--- a/__docs__/wonder-blocks-tokens/tokens-semantic-color.mdx
+++ b/__docs__/wonder-blocks-tokens/tokens-semantic-color.mdx
@@ -53,7 +53,7 @@ import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 const styles = {
     background: semanticColor.surface.secondary,
     border: semanticColor.core.border.neutral.default,
-    color: semanticColor.text.primary,
+    color: semanticColor.core.foreground.neutral.strong,
 };
 ```
 

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -314,7 +314,7 @@ export const WithStyle: StoryComponentType = () => {
         <View style={[styles.centered, styles.row]}>
             <Tooltip
                 contentStyle={{
-                    color: semanticColor.text.inverse,
+                    color: semanticColor.core.foreground.inverse.strong,
                     padding: spacing.xLarge_32,
                 }}
                 content={`This is a styled tooltip.`}

--- a/packages/wonder-blocks-badge/src/components/badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/badge.tsx
@@ -90,7 +90,7 @@ const badgeTokens = {
         },
         color: {
             background: semanticColor.surface.secondary,
-            foreground: semanticColor.text.primary,
+            foreground: semanticColor.core.foreground.neutral.strong,
             border: semanticColor.core.border.neutral.subtle,
         },
     },

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -203,7 +203,7 @@ const styles = StyleSheet.create({
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "space-between",
-        color: semanticColor.text.primary,
+        color: semanticColor.core.foreground.neutral.strong,
         height: DROPDOWN_ITEM_HEIGHT,
         // This asymmetry arises from the Icon on the right side, which has
         // extra padding built in. To have the component look more balanced,

--- a/packages/wonder-blocks-form/src/components/choice-internal.tsx
+++ b/packages/wonder-blocks-form/src/components/choice-internal.tsx
@@ -12,6 +12,7 @@ import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import CheckboxCore from "./checkbox-core";
 import RadioCore from "./radio-core";
+import theme from "../theme";
 
 type Props = AriaProps & {
     /** Whether this choice is checked. */
@@ -189,7 +190,7 @@ const styles = StyleSheet.create({
         // 16 for icon + 8 for spacing strut
         marginLeft: spacing.medium_16 + spacing.xSmall_8,
         marginTop: spacing.xxxSmall_4,
-        color: semanticColor.text.secondary,
+        color: theme.description.color.foreground,
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -139,7 +139,7 @@ const styles = StyleSheet.create({
         color: semanticColor.core.foreground.neutral.strong,
     },
     description: {
-        color: semanticColor.text.secondary,
+        color: semanticColor.core.foreground.neutral.default,
     },
     error: {
         color: semanticColor.status.critical.foreground,

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -136,7 +136,7 @@ export default class FieldHeading extends React.Component<Props> {
 
 const styles = StyleSheet.create({
     label: {
-        color: semanticColor.text.primary,
+        color: semanticColor.core.foreground.neutral.strong,
     },
     description: {
         color: semanticColor.text.secondary,

--- a/packages/wonder-blocks-form/src/components/field-heading.tsx
+++ b/packages/wonder-blocks-form/src/components/field-heading.tsx
@@ -5,6 +5,7 @@ import {View, addStyle, StyleType} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium, LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import theme from "../theme";
 
 type Props = {
     /**
@@ -139,7 +140,7 @@ const styles = StyleSheet.create({
         color: semanticColor.core.foreground.neutral.strong,
     },
     description: {
-        color: semanticColor.core.foreground.neutral.default,
+        color: theme.description.color.foreground,
     },
     error: {
         color: semanticColor.status.critical.foreground,

--- a/packages/wonder-blocks-form/src/components/group-styles.ts
+++ b/packages/wonder-blocks-form/src/components/group-styles.ts
@@ -3,6 +3,7 @@ import {StyleSheet} from "aphrodite";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 
 import type {StyleDeclaration} from "aphrodite";
+import theme from "../theme";
 
 const styles: StyleDeclaration = StyleSheet.create({
     fieldset: {
@@ -22,7 +23,7 @@ const styles: StyleDeclaration = StyleSheet.create({
 
     description: {
         marginTop: spacing.xxxSmall_4,
-        color: semanticColor.text.secondary,
+        color: theme.description.color.foreground,
     },
 
     error: {

--- a/packages/wonder-blocks-form/src/theme/default.ts
+++ b/packages/wonder-blocks-form/src/theme/default.ts
@@ -1,4 +1,4 @@
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
     choice: {
@@ -7,6 +7,11 @@ export default {
                 padding: sizing.size_0,
                 margin: sizing.size_0,
             },
+        },
+    },
+    description: {
+        color: {
+            foreground: semanticColor.core.foreground.neutral.default,
         },
     },
     field: {

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -14,7 +14,7 @@ export default mergeTheme(defaultTheme, {
     },
     description: {
         color: {
-            foreground: semanticColor.core.foreground.neutral.strong,
+            foreground: semanticColor.core.foreground.neutral.subtle,
         },
     },
     field: {

--- a/packages/wonder-blocks-form/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-form/src/theme/thunderblocks.ts
@@ -1,6 +1,6 @@
 import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
 
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import defaultTheme from "./default";
 
 export default mergeTheme(defaultTheme, {
@@ -10,6 +10,11 @@ export default mergeTheme(defaultTheme, {
                 padding: sizing.size_040,
                 margin: `calc(${sizing.size_040} * -1)`,
             },
+        },
+    },
+    description: {
+        color: {
+            foreground: semanticColor.core.foreground.neutral.strong,
         },
     },
     field: {

--- a/packages/wonder-blocks-styles/src/styles/action-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/action-styles.ts
@@ -16,11 +16,11 @@ export const inverse = {
     // already includes a border.
     ":not([aria-disabled=true])": {
         borderColor: semanticColor.core.border.inverse.strong,
-        color: semanticColor.text.inverse,
+        color: semanticColor.core.foreground.inverse.strong,
     },
 
     ":hover:not([aria-disabled=true])": {
-        color: semanticColor.text.inverse,
+        color: semanticColor.core.foreground.inverse.strong,
         // Overriding borderColor only to preserve the visual integrity of the
         // button, as there might be some cases where the interactive element
         // already includes a border.

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -144,13 +144,6 @@ const surface = {
     overlay: color.black_50,
 };
 
-const text = {
-    primary: core.foreground.neutral.strong,
-    secondary: core.foreground.neutral.subtle,
-    disabled: core.foreground.inverse.subtle,
-    inverse: core.foreground.inverse.strong,
-};
-
 const sharedFeedbackStrongTokens = {
     background: core.background.neutral.strong,
     border: core.border.neutral.strong,
@@ -164,51 +157,51 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 default: {
                     border: core.border.instructive.default,
                     background: core.background.instructive.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 hover: {
                     border: core.border.instructive.strong,
                     background: core.background.instructive.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 press: {
                     border: core.border.instructive.strong,
                     background: core.background.instructive.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
             },
             destructive: {
                 default: {
                     border: core.border.critical.default,
                     background: core.background.critical.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 hover: {
                     border: core.border.critical.strong,
                     background: core.background.critical.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 press: {
                     border: core.border.critical.strong,
                     background: core.background.critical.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
             },
             neutral: {
                 default: {
                     border: core.border.neutral.default,
                     background: core.background.neutral.default,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 hover: {
                     border: core.border.neutral.strong,
                     background: core.background.neutral.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
                 press: {
                     border: core.border.neutral.strong,
                     background: core.background.neutral.strong,
-                    foreground: text.inverse,
+                    foreground: core.foreground.inverse.strong,
                 },
             },
 
@@ -556,7 +549,6 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
     },
 
     surface,
-    text,
 
     focus: {
         outer: color.blue_30,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -150,19 +150,6 @@ const sharedFeedbackStrongTokens = {
     text: core.foreground.inverse.strong,
 };
 
-/**
- * TODO(WB-1941): Remove text once we have migrated to the new core.foreground
- * tokens.
- *
- * @deprecated Use `core.foreground` tokens instead.
- */
-const text = {
-    primary: core.foreground.neutral.strong,
-    secondary: core.foreground.neutral.default,
-    disabled: core.foreground.inverse.subtle,
-    inverse: core.foreground.inverse.strong,
-};
-
 export const semanticColor = {
     /**
      * Our core colors are used for the most common elements in our UI. They
@@ -728,11 +715,6 @@ export const semanticColor = {
      * areas of the UI.
      */
     surface,
-    /**
-     * For all type to ensure contrast for legibility. Inverse text applies for
-     * dark backgrounds in light mode.
-     */
-    text,
 
     focus: {
         outer: color.blue,

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -160,7 +160,7 @@ const sharedStyles = StyleSheet.create({
         flexGrow: 1,
     },
     subtitle: {
-        color: semanticColor.text.secondary,
+        color: semanticColor.core.foreground.neutral.default,
     },
     titles: {
         padding: spacing.small_12,

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -146,7 +146,7 @@ const sharedStyles = StyleSheet.create({
     dark: {
         background: semanticColor.surface.inverse,
         boxShadow: `0 1px 0 0 ${color.white64}`,
-        color: semanticColor.text.inverse,
+        color: semanticColor.core.foreground.inverse.strong,
     },
     leftColumn: {
         alignItems: "center",


### PR DESCRIPTION
## Summary:

- Removes the `semanticColor.text` category
- Replaces instances of `semanticColor.text` with `semanticColor.core.foreground`
- Replaces `text.secondary` with `core.foreground.neutral.default`
- Replaces `text.primary` with `core.foreground.neutral.strong`
- Replaces `text.inverse` with `core.foreground.inverse.strong`

### Implementation plan:

1. #2721
2. Remove `semanticColor.text`.
3. Remove `semanticColor.icon`.

Issue: WB-2042

## Test plan:

Verify that the snapshots look as expected.

Note that all the snapshots that use `StateSheet` will report changes as the
component has slightly changed in TB for labels.