### PR TITLE
LabeledField: Update spacing

### DIFF
--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -378,7 +378,6 @@ const styles = StyleSheet.create({
         color: theme.helperText.color.default.foreground,
         fontSize: theme.helperText.font.size,
         lineHeight: theme.helperText.font.lineHeight,
-        marginBlockStart: theme.helperText.layout.marginBlockStart,
         minWidth: sizing.size_0, // This enables the wrapping behaviour on the helper message
         overflowWrap: "break-word",
     },
@@ -393,5 +392,7 @@ const styles = StyleSheet.create({
     },
     errorMessage: {
         fontWeight: theme.error.font.weight,
+        // This aligns the helper text with the icon
+        marginBlockStart: theme.helperText.layout.marginBlockStart,
     },
 });


### PR DESCRIPTION
## Summary:

Previously, all helper text had a 1px top margin, which was causing the spacing between elements to be 1px larger than needed. We only apply it to the error message now to align the message with the error icon


Issue: WB-XXXX

## Test plan:
- Confirm spacing between elements in LabeledField matches the design specs
  - `?path=/docs/packages-labeledfield--docs&globals=theme:thunderblocks`
  - Design: https://www.figma.com/design/e9qdyiDUBZ3rDabP9S7ulO/%E2%9A%A1%EF%B8%8F-Handshake?node-id=4073-4021&m=dev