### PR TITLE
Ensure styles are generated before rendering in `ActivityIconButton`

### DIFF
--- a/__docs__/wonder-blocks-icon-button/activity-icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button.stories.tsx
@@ -62,29 +62,6 @@ export const Default: StoryComponentType = {
     },
 };
 
-function TogglingActivityIconButton() {
-    const [isOn, setIsOn] = React.useState(false);
-
-    return (
-        <>
-            <ActivityIconButton
-                icon={IconMappings.arrowUp}
-                kind="secondary"
-                aria-label="toggle"
-                onClick={() => {
-                    setIsOn(!isOn);
-                }}
-                actionType={isOn ? "progressive" : "neutral"}
-            />
-            {isOn && <button autoFocus>focus grabber</button>}
-        </>
-    );
-}
-
-export const Toggling: StoryComponentType = {
-    render: TogglingActivityIconButton,
-};
-
 /**
  * In this example, we have `primary`, `secondary`, `tertiary` and `disabled`
  * `ActivityIconButton`s from left to right.

--- a/__docs__/wonder-blocks-icon-button/activity-icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button.stories.tsx
@@ -62,6 +62,29 @@ export const Default: StoryComponentType = {
     },
 };
 
+function TogglingActivityIconButton() {
+    const [isOn, setIsOn] = React.useState(false);
+
+    return (
+        <>
+            <ActivityIconButton
+                icon={IconMappings.arrowUp}
+                kind="secondary"
+                aria-label="toggle"
+                onClick={() => {
+                    setIsOn(!isOn);
+                }}
+                actionType={isOn ? "progressive" : "neutral"}
+            />
+            {isOn && <button autoFocus>focus grabber</button>}
+        </>
+    );
+}
+
+export const Toggling: StoryComponentType = {
+    render: TogglingActivityIconButton,
+};
+
 /**
  * In this example, we have `primary`, `secondary`, `tertiary` and `disabled`
  * `ActivityIconButton`s from left to right.

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -87,7 +87,7 @@ export const ActivityIconButton: React.ForwardRefExoticComponent<
 
     const [pressed, setPressed] = React.useState(false);
 
-    const latestButtonStyles = _generateStyles(actionType, !!disabled, kind);
+    const latestButtonStyles = _generateStyles(actionType, kind);
     // we only want to update the button styles the render cycle after they
     // are generated, so that they have time to be applied to the DOM.
     // if we render with the latest button styles before they're applied to
@@ -208,10 +208,9 @@ const styles: Record<string, StyleDeclaration> = {};
 
 const _generateStyles = (
     actionType: ActivityIconButtonActionType = "progressive",
-    disabled: boolean,
     kind: IconButtonKind,
 ) => {
-    const buttonType = `${actionType}-d_${disabled}-${kind}`;
+    const buttonType = `${actionType}-${kind}`;
     if (styles[buttonType]) {
         return styles[buttonType];
     }

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {CSSProperties, StyleSheet} from "aphrodite";
+import {CSSProperties, StyleSheet, type StyleDeclaration} from "aphrodite";
 import {Link} from "react-router-dom-v5-compat";
 
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -87,7 +87,17 @@ export const ActivityIconButton: React.ForwardRefExoticComponent<
 
     const [pressed, setPressed] = React.useState(false);
 
-    const buttonStyles = _generateStyles(actionType, !!disabled, kind);
+    const latestButtonStyles = _generateStyles(actionType, !!disabled, kind);
+    // we only want to update the button styles the render cycle after they
+    // are generated, so that they have time to be applied to the DOM.
+    // if we render with the latest button styles before they're applied to
+    // the DOM, if the transition property is set, the button will animate
+    // from a browser default state to the correct styles, which leads to a
+    // very confusing visual effect.
+    const [buttonStyles, setButtonStyles] = React.useState(latestButtonStyles);
+    React.useLayoutEffect(() => {
+        setButtonStyles(latestButtonStyles);
+    }, [latestButtonStyles]);
 
     const styles = [
         buttonStyles.button,
@@ -194,7 +204,7 @@ const theme = {
     },
 };
 
-const styles: Record<string, any> = {};
+const styles: Record<string, StyleDeclaration> = {};
 
 const _generateStyles = (
     actionType: ActivityIconButtonActionType = "progressive",


### PR DESCRIPTION
## Summary:
This fixes an unusual bug. If all of these events happened at the same time:

- the button is pressed
- the button's action type switches to one that has not been rendered before
- the button loses focus

The button would render briefly without any styling, then awkwardly transition to its normal state.

This fix feels pretty clunky, but I'm struggling to think of something better. I tried using `flushToStyleTag` from aphrodite after generating the styles, but it did not work. I also considered pre-computing the styles for all combinations of kind and action type, but that would add a lot of noise to our stylesheets on initial render (but maybe that's okay!).

## Test plan:
Check out the commit in this PR with the story added for manual testing, click the button, and verify that it doesn't exhibit the behavior from [this video](https://khanacademy.slack.com/archives/C0917FL3B47/p1753291369069999)