### PR TITLE
Add onPaste prop to TextArea and TextField

### DIFF
--- a/.changeset/stupid-months-impress.md
+++ b/.changeset/stupid-months-impress.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+Add onPaste prop to TextArea and TextField

--- a/.changeset/stupid-months-impress.md
+++ b/.changeset/stupid-months-impress.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-form": minor
 ---
 
 Add onPaste prop to TextArea and TextField

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -608,6 +608,27 @@ describe("TextArea", () => {
             // Assert
             expect(handleOnBlur).toHaveBeenCalledOnce();
         });
+
+        it("should call the onPaste prop when text is pasted into the textarea", async () => {
+            // Arrange
+            const handleOnPaste = jest.fn();
+            render(
+                <TextArea
+                    value=""
+                    onChange={() => {}}
+                    onPaste={handleOnPaste}
+                />,
+                defaultOptions,
+            );
+
+            // Act
+            const textArea = await screen.findByRole("textbox");
+            textArea.focus();
+            await userEvent.paste("test");
+
+            // Assert
+            expect(handleOnPaste).toHaveBeenCalledOnce();
+        });
     });
 
     describe("Accessibility", () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx
@@ -405,6 +405,22 @@ describe("TextField", () => {
         expect(handleOnKeyDown).toHaveReturnedWith("Enter");
     });
 
+    it("onPaste is called when text is pasted into the input", async () => {
+        // Arrange
+        const handleOnPaste = jest.fn();
+        render(
+            <TextField value="" onChange={() => {}} onPaste={handleOnPaste} />,
+        );
+
+        // Act
+        const textbox = await screen.findByRole("textbox");
+        textbox.focus();
+        await userEvent.paste("test");
+
+        // Assert
+        expect(handleOnPaste).toHaveBeenCalledOnce();
+    });
+
     it("placeholder prop is passed to the input element", async () => {
         // Arrange
         const placeholder = "Placeholder";

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -127,6 +127,11 @@ type TextAreaProps = AriaProps & {
      */
     onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
     /**
+     * Called when text is pasted into the element.
+     * @param event The paste event
+     */
+    onPaste?: React.ClipboardEventHandler<HTMLTextAreaElement>;
+    /**
      * Provide a validation for the textarea value.
      * Return a string error message or null | void for a valid input.
      *
@@ -223,6 +228,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             onKeyUp,
             onFocus,
             onBlur,
+            onPaste,
             validate,
             onValidate,
             required,
@@ -301,6 +307,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     onKeyUp={disabled ? undefined : onKeyUp}
                     onFocus={onFocus} // TextArea can be focused on if it is disabled
                     onBlur={handleBlur} // TextArea can be blurred if it is disabled
+                    onPaste={disabled ? undefined : onPaste}
                     required={!!required}
                     {...otherProps}
                     aria-invalid={hasError}

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -82,6 +82,10 @@ type CommonProps = AriaProps & {
      */
     onBlur?: (event: React.FocusEvent<HTMLInputElement>) => unknown;
     /**
+     * Called when text is pasted into the element.
+     */
+    onPaste?: React.ClipboardEventHandler<HTMLInputElement>;
+    /**
      * Provide hints or examples of what to enter.
      */
     placeholder?: string;
@@ -189,6 +193,7 @@ const TextField = (props: PropsWithForwardRef) => {
         onChange,
         onFocus,
         onBlur,
+        onPaste,
         // Should only include Aria related props
         ...otherProps
     } = props;
@@ -247,6 +252,7 @@ const TextField = (props: PropsWithForwardRef) => {
                     onKeyDown={disabled ? undefined : onKeyDown}
                     onFocus={handleFocus} // TextField can be focused if disabled
                     onBlur={handleBlur} // TextField can be blurred if disabled
+                    onPaste={disabled ? undefined : onPaste}
                     data-testid={testId}
                     readOnly={readOnly || disabled} // Set readOnly also if it is disabled, otherwise users can type in the field
                     autoFocus={autoFocus}


### PR DESCRIPTION
## Summary:
Add the `onPaste` prop to TextArea and TextField.

Adding this for a specific case in Perseus: In the Radio widget editor,
content authors can paste image URLs in markdown to display images. This
is hard to read, so I'm making a UI that automatically reads the pasted
text and converts it into an easily readable placeholder, and the actual
image can be edited in a separate UI.

Issue: none

## Test plan:
`pnpm jest packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx`
`pnpm jest packages/wonder-blocks-form/src/components/__tests__/text-field.test.tsx`