### PR TITLE
ButtonCore: Fix passing in invalid attributes

### DIFF
--- a/.changeset/healthy-crabs-refuse.md
+++ b/.changeset/healthy-crabs-refuse.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-button": patch
+---
+
+ButtonCore: Prevent `focused` and `hovered` props from being applied to the underlying button element

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -33,6 +33,10 @@ const ButtonCore: React.ForwardRefExoticComponent<
         skipClientNav,
         actionType,
         disabled: disabledProp,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- make sure it is not included in restProps
+        focused,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars -- make sure it is not included in restProps
+        hovered,
         href = undefined,
         kind = "primary",
         labelStyle,


### PR DESCRIPTION
## Summary:

The recent button changes in https://github.com/Khan/wonder-blocks/pull/2734/files#diff-ede6855e27a1ecfe88d6f2e68ba1979e36ea896776f7e023078b353df3b84b94L36-L37 would cause tests to fail in `frontend` due to unexpected `console.error` calls.

This was because `hovered` and `focused` props were being included with `restProps`, which is applied to the underlying button element. These aren't valid html attributes so an error was logged.

To fix this, we go back to pulling out the `focused` and `hovered` props from `restProps`. Since they are unused, we disable the unused variable lint rules for these lines

Note: We continue to have `focused` and `hovered` props because `Button` still uses `ClickableBehaviour` and it passes in state information. Long term we want to move away from using `ClickableBehaviour`, but rely on it in some places to handle browsers inconsistencies ([more details about ClickableBehaviour](https://github.com/Khan/wonder-blocks/pull/2244#discussion_r1628440285))


Issue: WB-2051

## Test plan:

Test that using the npm snapshot for this PR in frontend results in no unit test failures