### PR TITLE
Adds a `locale` prop to `BirthdayPicker` to better support i18n

### DIFF
--- a/.changeset/wicked-singers-dream.md
+++ b/.changeset/wicked-singers-dream.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-birthday-picker": minor
+---
+
+Adds a `locale` prop to `BirthdayPicker` to better support i18n. Defaults to `navigator.language` if not provided

--- a/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
+++ b/__docs__/wonder-blocks-birthday-picker/birthday-picker.stories.tsx
@@ -194,3 +194,18 @@ export const BirthdayPickerMobile: StoryComponentType = {
         },
     },
 };
+
+/**
+ * A BirthdayPicker can be configured to render the month names in a different
+ * locale. This can be useful when we want to display the component in a
+ * different language.
+ *
+ * If no locale is provided, the browser's `navigator.language` value will be
+ * used.
+ */
+export const Locale: StoryComponentType = {
+    args: {
+        locale: "es",
+        defaultValue: "2021-01-19",
+    },
+};

--- a/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/__tests__/birthday-picker.test.tsx
@@ -651,4 +651,20 @@ describe("BirthdayPicker", () => {
             expect(onChange).toHaveBeenCalledWith(`${lastYear}-07-05`);
         });
     });
+
+    describe("locale", () => {
+        it("renders the month names in the correct locale", async () => {
+            // Arrange
+            render(
+                <BirthdayPicker
+                    locale="es"
+                    onChange={() => {}}
+                    defaultValue="2021-01-19"
+                />,
+            );
+
+            // Assert (January in Spanish is "ene")
+            await screen.findByText("ene");
+        });
+    });
 });

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -65,6 +65,11 @@ type Props = {
      * Additional styles applied to the dropdowns.
      */
     dropdownStyle?: StyleType;
+    /**
+     * The locale to use for the month names. If not provided, the browser's
+     * `navigator.language` value will be used.
+     */
+    locale?: string;
 };
 
 type State = {
@@ -355,9 +360,12 @@ export default class BirthdayPicker extends React.Component<Props, State> {
     }
 
     monthsShort(): string[] {
-        const format = new Intl.DateTimeFormat(navigator.language, {
-            month: "short",
-        }).format;
+        const format = new Intl.DateTimeFormat(
+            this.props.locale || navigator.language,
+            {
+                month: "short",
+            },
+        ).format;
         return [...Array(12).keys()].map((m) =>
             // TODO: use Temporal.PlainDate.from() once the linter lets
             // format() accept a Temporal object


### PR DESCRIPTION
## Summary:

Previously, we were getting the list of months in short form from `moment`. When `moment` was removed from WB in favour of the Temporal API in https://github.com/Khan/wonder-blocks/pull/2549, we started using the Intl.DateTimeFormat api with `navigator.language` from the browser

Unfortunately, `navigator.language` isn't always the same as the user's language setting. To address this, we introduce a `locale` prop so that consuming applications can set the locale to use. If this isn't provided, it will default to using `navigator.language` to get the month names

Issue: WB-1939

## Test plan:

1. Confirm the BirthdayPicker Locale story shows localized labels for the month names and selected month value (?path=/story/packages-birthdaypicker--locale)
2. Using the npm snapshot in frontend, confirm that using the `locale` prop fixes the localization issue