### PR TITLE
Use new background tokens in WB components

### DIFF
--- a/.changeset/flat-pumpkins-provide.md
+++ b/.changeset/flat-pumpkins-provide.md
@@ -1,0 +1,14 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-styles": patch
+"@khanacademy/wonder-blocks-tokens": patch
+"@khanacademy/wonder-blocks-badge": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+Replace use of `surface` tokens in components in favour of `background` tokens

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -82,7 +82,7 @@ const parameters = {
         values: [
             {
                 name: "light",
-                value: semanticColor.surface.primary,
+                value: semanticColor.core.background.base.default,
             },
             {
                 name: "darkBlue",

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -85,8 +85,8 @@ const parameters = {
                 value: semanticColor.core.background.base.default,
             },
             {
-                name: "darkBlue",
-                value: semanticColor.surface.inverse,
+                name: "darkBlue", // TODO(WB-2050): rename to dark
+                value: semanticColor.core.background.neutral.strong,
             },
             {
                 name: "offWhite", // TODO(WB-2050): rename to subtle

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -89,8 +89,8 @@ const parameters = {
                 value: semanticColor.surface.inverse,
             },
             {
-                name: "offWhite",
-                value: semanticColor.surface.secondary,
+                name: "offWhite", // TODO(WB-2050): rename to subtle
+                value: semanticColor.core.background.base.subtle,
             },
         ],
     },

--- a/__docs__/components/code.tsx
+++ b/__docs__/components/code.tsx
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
         gap: sizing.size_040,
     },
     code: {
-        backgroundColor: semanticColor.surface.secondary,
+        backgroundColor: semanticColor.core.background.base.subtle,
         padding: sizing.size_040,
         fontSize: font.body.size.xsmall,
     },

--- a/__docs__/components/color.tsx
+++ b/__docs__/components/color.tsx
@@ -243,7 +243,7 @@ const styles = StyleSheet.create({
         maxWidth: "100%",
         width: "100%",
 
-        backgroundColor: semanticColor.surface.secondary,
+        backgroundColor: semanticColor.core.background.base.subtle,
         border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
         borderRadius: border.radius.radius_040,
     },
@@ -275,7 +275,7 @@ const styles = StyleSheet.create({
         alignSelf: "flex-start",
         color: semanticColor.core.foreground.neutral.strong,
         display: "inline-flex",
-        backgroundColor: semanticColor.surface.secondary,
+        backgroundColor: semanticColor.core.background.base.subtle,
         border: `1px solid ${color.offBlack16}`,
         padding: spacing.xxxxSmall_2,
         borderRadius: border.radius.radius_040,

--- a/__docs__/components/placeholder.tsx
+++ b/__docs__/components/placeholder.tsx
@@ -15,7 +15,7 @@ export const Placeholder = (props: Props) => {
     return (
         <View
             style={{
-                backgroundColor: semanticColor.surface.secondary,
+                backgroundColor: semanticColor.core.background.base.subtle,
                 padding: sizing.size_120,
                 margin: sizing.size_010,
                 border: `${border.width.thin}px dashed ${semanticColor.core.border.neutral.subtle}`,

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -357,7 +357,8 @@ export const AllBadgesScenarios: StoryComponentType = {
                                 styles: {
                                     root: {
                                         backgroundColor:
-                                            semanticColor.surface.inverse,
+                                            semanticColor.core.background
+                                                .neutral.strong,
                                         borderColor:
                                             semanticColor.core.border.knockout
                                                 .default,

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -197,7 +197,8 @@ export const CustomStyles: StoryComponentType = {
                 }
                 styles={{
                     root: {
-                        backgroundColor: semanticColor.surface.inverse,
+                        backgroundColor:
+                            semanticColor.core.background.neutral.strong,
                         borderColor: semanticColor.core.border.knockout.default,
                         color: semanticColor.core.foreground.knockout.default,
                     },

--- a/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
@@ -410,7 +410,7 @@ export const CompactCellsAsListItems: StoryComponentType = {
 
 const styles = StyleSheet.create({
     example: {
-        backgroundColor: semanticColor.surface.secondary,
+        backgroundColor: semanticColor.core.background.base.subtle,
         padding: spacing.large_24,
         width: 320 + spacing.xxLarge_48,
     },

--- a/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
@@ -227,7 +227,7 @@ export const CompactCellHorizontalRules: StoryComponentType = {
 export const CompactCellWithCustomStyles: StoryComponentType = {
     render: () => (
         <CompactCell
-            title="CompactCell with a darkBlue background"
+            title="CompactCell with a dark background"
             leftAccessory={
                 <PhosphorIcon icon={IconMappings.article} size="medium" />
             }

--- a/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
@@ -238,7 +238,7 @@ export const CompactCellWithCustomStyles: StoryComponentType = {
                 />
             }
             style={{
-                background: semanticColor.surface.inverse,
+                background: semanticColor.core.background.neutral.strong,
                 color: semanticColor.core.foreground.knockout.default,
             }}
             onClick={() => {}}

--- a/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
@@ -451,7 +451,7 @@ export const CustomStyles = {
 
 const styles = StyleSheet.create({
     example: {
-        backgroundColor: semanticColor.surface.secondary,
+        backgroundColor: semanticColor.core.background.base.subtle,
         padding: spacing.large_24,
         width: 376,
     },

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -336,7 +336,7 @@ const styles = StyleSheet.create({
         textAlign: "center",
     },
     dark: {
-        backgroundColor: semanticColor.surface.inverse,
+        backgroundColor: semanticColor.core.background.neutral.strong,
         color: semanticColor.core.foreground.knockout.default,
         padding: spacing.xSmall_8,
     },

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -353,8 +353,8 @@ const styles = StyleSheet.create({
         padding: spacing.large_24,
     },
     disabled: {
-        color: semanticColor.core.foreground.knockout.default,
-        backgroundColor: semanticColor.surface.overlay,
+        color: semanticColor.action.primary.disabled.foreground,
+        backgroundColor: semanticColor.action.primary.disabled.background,
     },
     button: {
         maxWidth: 150,

--- a/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
@@ -27,7 +27,7 @@ const defaultArgs = {
 
 const styles = StyleSheet.create({
     example: {
-        background: semanticColor.surface.secondary,
+        background: semanticColor.core.background.base.subtle,
         padding: sizing.size_160,
         width: 300,
     },

--- a/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-item.stories.tsx
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
         width: 300,
     },
     items: {
-        background: semanticColor.surface.primary,
+        background: semanticColor.core.background.base.default,
     },
 });
 

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -126,7 +126,7 @@ export default {
 
 const styles = StyleSheet.create({
     example: {
-        background: semanticColor.surface.secondary,
+        background: semanticColor.core.background.base.subtle,
         padding: sizing.size_160,
     },
     exampleExtended: {

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -493,7 +493,8 @@ export const CustomActionItems: StoryComponentType = {
                 onClick={action("user profile clicked!")}
                 style={{
                     [":hover [data-testid=new-pill]" as any]: {
-                        backgroundColor: semanticColor.surface.primary,
+                        backgroundColor:
+                            semanticColor.core.background.base.default,
                         color: semanticColor.status.notice.foreground,
                     },
                 }}

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -49,7 +49,7 @@ const customItems = allProfilesWithPictures.map((user, index) => (
 
 const styles = StyleSheet.create({
     example: {
-        background: semanticColor.surface.secondary,
+        background: semanticColor.core.background.base.subtle,
         padding: sizing.size_160,
         width: 300,
     },

--- a/__docs__/wonder-blocks-dropdown/listbox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/listbox.stories.tsx
@@ -27,7 +27,7 @@ const items = [
 
 const styles = StyleSheet.create({
     example: {
-        background: semanticColor.surface.secondary,
+        background: semanticColor.core.background.base.subtle,
         padding: sizing.size_160,
         width: 360,
     },

--- a/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
         width: 300,
     },
     items: {
-        background: semanticColor.surface.primary,
+        background: semanticColor.core.background.base.default,
     },
 });
 

--- a/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/option-item.stories.tsx
@@ -23,7 +23,7 @@ const defaultArgs = {
 
 const styles = StyleSheet.create({
     example: {
-        background: semanticColor.surface.secondary,
+        background: semanticColor.core.background.base.subtle,
         padding: sizing.size_160,
         width: 300,
     },

--- a/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
@@ -153,7 +153,8 @@ export const Scenarios: Story = {
                         <View
                             style={{
                                 flexDirection: "row",
-                                background: semanticColor.surface.secondary,
+                                background:
+                                    semanticColor.core.background.base.subtle,
                                 gap: sizing.size_160,
                                 padding: sizing.size_160,
                             }}

--- a/__docs__/wonder-blocks-icon/custom-icon-components.stories.tsx
+++ b/__docs__/wonder-blocks-icon/custom-icon-components.stories.tsx
@@ -104,7 +104,7 @@ export const CustomIconsWithCustomStyle: StoryComponentType = {
     ...AllCustomIcons,
     args: {
         style: {
-            backgroundColor: semanticColor.surface.secondary,
+            backgroundColor: semanticColor.core.background.base.subtle,
             padding: sizing.size_040,
             borderRadius: border.radius.radius_040,
             border: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,

--- a/__docs__/wonder-blocks-link/link-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-link/link-testing-snapshots.stories.tsx
@@ -79,7 +79,8 @@ export const StateSheetStory: Story = {
     render: (args, {globals}) => {
         const isRTL = globals.direction === "rtl";
         const isDark =
-            globals.backgrounds?.value === semanticColor.surface.inverse;
+            globals.backgrounds?.value ===
+            semanticColor.core.background.neutral.strong;
         const columnsPerMode = isRTL ? rtlColumns : columns;
 
         return (

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -186,7 +186,8 @@ export const StartAndEndIcons: StoryComponentType = {
             {/* Light */}
             <View
                 style={{
-                    backgroundColor: semanticColor.surface.inverse,
+                    backgroundColor:
+                        semanticColor.core.background.neutral.strong,
                     padding: spacing.large_24,
                 }}
             >

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -710,7 +710,7 @@ const styles = StyleSheet.create({
         maxWidth: "15%",
     },
     card: {
-        background: semanticColor.surface.secondary,
+        background: semanticColor.core.background.base.subtle,
         border: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
         borderRadius: border.radius.radius_040,
         width: "100%",

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -290,7 +290,7 @@ const styles = StyleSheet.create({
     squareDialog: {
         maxHeight: 500,
         maxWidth: 500,
-        backgroundColor: semanticColor.surface.inverse,
+        backgroundColor: semanticColor.core.background.neutral.strong,
     },
     smallSquarePanel: {
         maxHeight: 400,

--- a/__docs__/wonder-blocks-pill/pill.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill.stories.tsx
@@ -245,7 +245,8 @@ export const WithStyle: StoryComponentType = () => {
 
         ":active": {
             outlineColor: tokens.semanticColor.core.border.neutral.subtle,
-            backgroundColor: tokens.semanticColor.surface.overlay,
+            backgroundColor:
+                tokens.semanticColor.core.background.neutral.default,
         },
     };
 

--- a/__docs__/wonder-blocks-pill/pill.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill.stories.tsx
@@ -234,7 +234,7 @@ WithTypography.parameters = {
 
 export const WithStyle: StoryComponentType = () => {
     const customStyle = {
-        backgroundColor: tokens.semanticColor.surface.inverse,
+        backgroundColor: tokens.semanticColor.core.background.neutral.strong,
         color: tokens.semanticColor.core.foreground.knockout.default,
         paddingLeft: tokens.spacing.xxLarge_48,
         paddingRight: tokens.spacing.xxLarge_48,

--- a/__docs__/wonder-blocks-styles/action-styles-variants.stories.tsx
+++ b/__docs__/wonder-blocks-styles/action-styles-variants.stories.tsx
@@ -190,7 +190,8 @@ export default {
                     <View
                         {...props}
                         style={{
-                            background: semanticColor.surface.inverse,
+                            background:
+                                semanticColor.core.background.neutral.strong,
                             padding: spacing.medium_16,
                             gap: spacing.medium_16,
                         }}

--- a/__docs__/wonder-blocks-styles/focus-styles.stories.tsx
+++ b/__docs__/wonder-blocks-styles/focus-styles.stories.tsx
@@ -75,7 +75,8 @@ export const Focus: Story = {
                 </View>
                 <View
                     style={{
-                        background: semanticColor.surface.inverse,
+                        background:
+                            semanticColor.core.background.neutral.strong,
                         padding: spacing.medium_16,
                         gap: spacing.medium_16,
                     }}
@@ -208,7 +209,7 @@ export const Scenarios: Story = {
                         {...props}
                         style={{
                             background: inverse
-                                ? semanticColor.surface.inverse
+                                ? semanticColor.core.background.neutral.strong
                                 : semanticColor.status.success.background,
                             padding: spacing.medium_16,
                             gap: spacing.medium_16,

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -161,7 +161,7 @@ export const HeaderWithNavigationTabsExample: StoryComponentType = {
                 width: "100vw",
             },
             headerStyle: {
-                backgroundColor: semanticColor.surface.primary,
+                backgroundColor: semanticColor.core.background.base.default,
                 display: "flex",
                 alignItems: "center",
                 flexWrap: "wrap",

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -156,7 +156,7 @@ export const HeaderWithNavigationTabsExample: StoryComponentType = {
         const headerVerticalSpacing = sizing.size_120;
         const styles = StyleSheet.create({
             pageStyle: {
-                backgroundColor: semanticColor.surface.secondary,
+                backgroundColor: semanticColor.core.background.base.subtle,
                 height: "100vh",
                 width: "100vw",
             },

--- a/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
@@ -87,8 +87,6 @@ export const SemanticColors = () => (
                 cell: (row) => (
                     <View
                         style={{
-                            background:
-                                semanticColor.core.background.neutral.subtle,
                             padding: sizing.size_060,
                         }}
                     >

--- a/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
@@ -29,7 +29,7 @@ import {Code} from "../components/code";
  * import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
  *
  * const styles = {
- *     background: semanticColor.surface.secondary,
+ *     background: semanticColor.core.background.base.subtle,
  *     border: semanticColor.core.border.neutral.default,
  *     color: semanticColor.core.foreground.neutral.strong,
  * };

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -315,7 +315,7 @@ const styles = StyleSheet.create({
         // vertically stacked.
         position: "static",
         boxSizing: "border-box",
-        backgroundColor: semanticColor.surface.primary,
+        backgroundColor: semanticColor.core.background.base.default,
     },
     wrapperWithAnimation: {
         transition: "grid-template-rows 300ms",

--- a/packages/wonder-blocks-badge/src/components/badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/badge.tsx
@@ -89,7 +89,7 @@ const badgeTokens = {
             radius: border.radius.radius_080,
         },
         color: {
-            background: semanticColor.surface.secondary,
+            background: semanticColor.core.background.neutral.subtle,
             foreground: semanticColor.core.foreground.neutral.strong,
             border: semanticColor.core.border.neutral.subtle,
         },

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -222,7 +222,7 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
 
 const styles = StyleSheet.create({
     wrapper: {
-        background: semanticColor.surface.primary,
+        background: semanticColor.core.background.base.default,
         borderRadius: theme.root.border.radius.default,
         color: semanticColor.core.foreground.neutral.strong,
         minHeight: theme.root.sizing.minHeight,
@@ -340,15 +340,15 @@ const styles = StyleSheet.create({
     },
 
     disabled: {
-        background: semanticColor.surface.primary,
+        background: semanticColor.core.background.base.default,
         borderRadius: theme.root.border.radius.default,
         color: theme.root.color.disabled.foreground,
         ":hover": {
-            background: semanticColor.surface.primary,
+            background: semanticColor.core.background.base.default,
             cursor: "not-allowed",
         },
         ":active": {
-            background: semanticColor.surface.primary,
+            background: semanticColor.core.background.base.default,
             borderRadius: theme.root.border.radius.default,
         },
         [":focus-visible:active" as any]: {

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -702,7 +702,7 @@ const styles = StyleSheet.create({
         maxWidth: "100%",
         flexWrap: "wrap",
         // The following styles are to emulate the input styles
-        background: semanticColor.surface.primary,
+        background: semanticColor.core.background.base.default,
         borderRadius: theme.opener.border.radius.rest,
         border: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
         paddingInline: theme.opener.layout.padding.inline,
@@ -742,7 +742,7 @@ const styles = StyleSheet.create({
      * Listbox custom styles
      */
     listbox: {
-        backgroundColor: semanticColor.surface.primary,
+        backgroundColor: semanticColor.core.background.base.default,
         borderRadius: theme.listbox.border.radius,
         border: `solid ${border.width.thin} ${semanticColor.core.border.neutral.subtle}`,
         // TODO(WB-1878): Move to elevation tokens.

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -1073,7 +1073,7 @@ const styles = StyleSheet.create({
     },
 
     dropdown: {
-        backgroundColor: semanticColor.surface.primary,
+        backgroundColor: semanticColor.core.background.base.default,
         borderRadius: theme.listbox.border.radius,
         paddingBlock: theme.listbox.layout.padding.block,
         paddingInline: theme.listbox.layout.padding.inline,

--- a/packages/wonder-blocks-dropdown/src/components/listbox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/listbox.tsx
@@ -210,7 +210,7 @@ export default function Listbox(props: Props) {
 
 const styles = StyleSheet.create({
     listbox: {
-        backgroundColor: semanticColor.surface.primary,
+        backgroundColor: semanticColor.core.background.base.default,
         outline: "none",
         // layout
         paddingBlock: theme.listbox.layout.padding.block,

--- a/packages/wonder-blocks-form/src/util/styles.ts
+++ b/packages/wonder-blocks-form/src/util/styles.ts
@@ -176,7 +176,7 @@ export const colorStates: StyleMap = {
             default: {
                 rest: {
                     border: semanticColor.input.checked.background,
-                    background: semanticColor.core.border.knockout.default, // TODO(WB-2050): use white background
+                    background: semanticColor.core.background.base.default,
                 },
                 hover: baseStyles.choice.checked,
                 press: {
@@ -197,15 +197,15 @@ export const colorStates: StyleMap = {
             disabled: {
                 rest: {
                     border: semanticColor.core.border.disabled.default,
-                    background: semanticColor.core.border.knockout.default, // TODO(WB-2050): use white background
+                    background: semanticColor.core.background.base.default,
                 },
                 hover: {
                     border: semanticColor.core.border.disabled.strong,
-                    background: semanticColor.core.border.knockout.default, // TODO(WB-2050): use white background
+                    background: semanticColor.core.background.base.default,
                 },
                 press: {
                     border: semanticColor.core.border.disabled.strong,
-                    background: semanticColor.core.border.knockout.default, // TODO(WB-2050): use white background
+                    background: semanticColor.core.background.base.default,
                 },
             },
         },

--- a/packages/wonder-blocks-modal/src/components/drawer-backdrop.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-backdrop.tsx
@@ -202,7 +202,7 @@ const styles = StyleSheet.create({
         height: "100%",
         display: "flex",
         overflow: "hidden",
-        background: semanticColor.surface.overlay,
+        background: semanticColor.core.background.overlay.default,
     },
     inlineStart: {
         alignItems: "flex-start",

--- a/packages/wonder-blocks-modal/src/components/flexible-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/flexible-panel.tsx
@@ -109,7 +109,7 @@ export default function FlexiblePanel({
     const mainContent = renderMainContent();
 
     const defaultBackgroundStyle = {
-        backgroundColor: semanticColor.surface.primary,
+        backgroundColor: semanticColor.core.background.base.default,
     };
 
     const combinedBackgroundStyles = {

--- a/packages/wonder-blocks-modal/src/components/modal-backdrop.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-backdrop.tsx
@@ -170,6 +170,6 @@ const styles = StyleSheet.create({
         //     now!
         overflow: "auto",
 
-        background: semanticColor.surface.overlay,
+        background: semanticColor.core.background.overlay.default,
     },
 });

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -143,7 +143,7 @@ const styles = StyleSheet.create({
     wrapper: {
         flex: "1 1 auto",
         flexDirection: "column",
-        background: semanticColor.surface.primary,
+        background: semanticColor.core.background.base.default,
         boxSizing: "border-box",
         overflow: "hidden",
         height: "100%",

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -104,7 +104,7 @@ const styles = StyleSheet.create({
     content: {
         borderRadius: border.radius.radius_040,
         border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
-        backgroundColor: semanticColor.surface.primary,
+        backgroundColor: semanticColor.core.background.base.default,
         // TODO(WB-1878): Use `elevation` token.
         boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,
         margin: 0,

--- a/packages/wonder-blocks-styles/src/styles/action-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/action-styles.ts
@@ -34,6 +34,6 @@ export const inverse = {
         borderRadius: border.radius.radius_080,
         // This is a slightly darker color than the inverse color.
         borderColor: pressColor,
-        background: `color-mix(in srgb, ${semanticColor.surface.primary} 5%, transparent)`,
+        background: `color-mix(in srgb, ${semanticColor.core.background.base.default} 5%, transparent)`,
     },
 };

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -264,17 +264,17 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             neutral: {
                 default: {
                     border: core.border.neutral.subtle,
-                    background: core.background.neutral.subtle,
+                    background: core.background.base.default,
                     foreground: core.foreground.neutral.default,
                 },
                 hover: {
                     border: core.border.neutral.strong,
-                    background: core.background.neutral.subtle,
+                    background: core.background.base.default,
                     foreground: core.foreground.neutral.strong,
                 },
                 press: {
                     border: core.border.neutral.strong,
-                    background: core.background.neutral.subtle,
+                    background: core.background.base.default,
                     foreground: core.foreground.neutral.strong,
                 },
             },
@@ -443,10 +443,10 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                     selected: core.background.neutral.default,
                 },
                 secondary: {
-                    rest: core.background.neutral.subtle,
-                    hover: core.background.neutral.subtle,
-                    press: core.background.neutral.subtle,
-                    selected: core.background.neutral.subtle,
+                    rest: core.background.base.default,
+                    hover: core.background.base.default,
+                    press: core.background.base.default,
+                    selected: core.background.base.default,
                 },
                 tertiary: {
                     rest: core.transparent,
@@ -746,13 +746,13 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
         },
         disabled: {
             border: core.border.disabled.default,
-            background: core.background.neutral.subtle,
+            background: core.background.base.default,
             foreground: core.foreground.disabled.default,
             placeholder: core.foreground.disabled.subtle,
         },
         error: {
             border: core.border.critical.default,
-            background: core.background.neutral.subtle,
+            background: core.background.base.default,
             foreground: core.foreground.neutral.strong,
         },
         readOnly: {

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -735,7 +735,7 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
     input: {
         default: {
             border: core.border.neutral.default,
-            background: surface.primary,
+            background: core.background.base.default,
             foreground: core.foreground.neutral.strong,
             placeholder: core.foreground.neutral.subtle,
         },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -672,7 +672,7 @@ export const semanticColor = {
     input: {
         default: {
             border: core.border.neutral.default,
-            background: surface.primary,
+            background: core.background.base.default,
             foreground: core.foreground.neutral.strong,
             placeholder: core.foreground.neutral.default,
         },
@@ -693,7 +693,7 @@ export const semanticColor = {
             foreground: core.foreground.neutral.strong,
         },
         readOnly: {
-            background: surface.primary,
+            background: core.background.base.default,
             text: core.foreground.neutral.strong,
             icon: core.transparent,
         },

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -144,7 +144,7 @@ const sharedStyles = StyleSheet.create({
     },
     // TODO(WB-1852): Remove light variant.
     dark: {
-        background: semanticColor.surface.inverse,
+        background: color.darkBlue,
         boxShadow: `0 1px 0 0 ${color.white64}`,
         color: semanticColor.core.foreground.knockout.default,
     },

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -120,7 +120,7 @@ export default function Toolbar({
 
 const sharedStyles = StyleSheet.create({
     container: {
-        background: semanticColor.surface.primary,
+        background: semanticColor.core.background.base.default,
         border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
         flex: 1,
         display: "grid",

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -130,7 +130,7 @@ const styles = StyleSheet.create({
         maxWidth: 472,
         borderRadius: border.radius.radius_040,
         border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
-        backgroundColor: semanticColor.surface.primary,
+        backgroundColor: semanticColor.core.background.base.default,
         // TODO(WB-1878): Use `elevation` token.
         boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,
         justifyContent: "center",


### PR DESCRIPTION
## Summary:

- Moves away from the `semanticColor.surface.*` tokens in favour of the new `semanticColor.core.background.base/overlay` tokens
- Also moves away from `semanticColor.core.background.neutral.subtle` usage in TB that expects the value to be `white`  (the remaining usage of `background.neutral.subtle` is fine to change to light gray later on for the TB theme) 

Token mapping: 

| Previous token | New token [1] | 
| --- | --- |
| `semanticColor.surface.primary` | `semanticColor.core.background.base.default` |
| `semanticColor.surface.secondary` | `semanticColor.core.background.base.subtle` |
| `semanticColor.surface.emphasis` | `semanticColor.core.background.base.strong` |
| `semanticColor.surface.inverse` [2] | `semanticColor.core.background.neutral.strong` |
| `semanticColor.surface.overlay` | `semanticColor.core.overlay.default` |
| `semanticColor.core.background.neutral.subtle`[3] | `semanticColore.core.background.base.default` |

[1] For places where this direct mapping isn't used, there was probably a more appropriate token to use. I've annotated the PR with these use cases. Let me know if you have any questions! 

[2] In the Classic theme, `surface.inverse` is `darkBlue`. We don't have a semantic token for `darkBlue` since this is a pattern we want to start moving away from so we map existing usage to `background.neutral.strong` where it makes sense (see related https://khanacademy.slack.com/archives/C07CA2YR0BZ/p1755209242348059?thread_ts=1755201560.160039&cid=C07CA2YR0BZ). Annotated the PR with any exceptions to this mapping

[3] If `semanticColor.core.background.neutral.subtle` is expected to be `white` in the ThunderBlocks theme, it was updated to `semanticColore.core.background.base.default`. This is because the background neutral subtle value will change in a following PR

Issue: WB-2050

Design: [Colors](https://www.figma.com/design/e9qdyiDUBZ3rDabP9S7ulO/%E2%9A%A1%EF%B8%8F-Handshake?node-id=3040-15158&m=dev)

## Test plan:

1. Confirm there are no unexpected changes to components (I've commented on the expected changes in Chromatic as well)
2. Confirm `surface.` tokens are no longer used in WB
3. Confirm remaining use of `background.neutral.subtle` is okay to change to light gray in the TB themes
4. Confirm new token usage makes sense

## Implementation Plan

1. Add knockout tokens (https://github.com/Khan/wonder-blocks/pull/2758)
2. Add background base and overlay tokens (https://github.com/Khan/wonder-blocks/pull/2759)
5. Update usage (in WB and other repos) (WB (this PR): https://github.com/Khan/wonder-blocks/pull/2766) 
- Replace foreground and border inverse tokens usage in other repos
- Replace surface tokens with background base tokens
- Use background.base.default token for white instead of background.neutral.subtle
6. Remove surface and inverse tokens  
7. Update background.neutral.subtle to light gray