### PR TITLE
Button and ActivityButton: Support custom icons

### DIFF
--- a/.changeset/smart-ants-clap.md
+++ b/.changeset/smart-ants-clap.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-button": minor
+---
+
+Support custom icons in Button and ActivityButton components

--- a/__docs__/wonder-blocks-button/activity-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-button/activity-button-testing-snapshots.stories.tsx
@@ -10,6 +10,7 @@ import {ScenariosLayout} from "../components/scenarios-layout";
 import {longTextWithNoWordBreak} from "../components/text-for-testing";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -149,6 +150,28 @@ export const Scenarios: Story = {
                             }}
                         >
                             {longTextWithNoWordBreak}
+                        </ActivityButton>
+                    ),
+                },
+            },
+            {
+                name: "With custom icons",
+                props: {
+                    children: (
+                        <ActivityButton
+                            startIcon={
+                                <Icon>
+                                    <img alt="" src="logo.svg" />
+                                </Icon>
+                            }
+                            endIcon={
+                                <Icon>
+                                    <img alt="" src="logo.svg" />
+                                </Icon>
+                            }
+                            kind="secondary"
+                        >
+                            With custom icons
                         </ActivityButton>
                     ),
                 },

--- a/__docs__/wonder-blocks-button/activity-button.stories.tsx
+++ b/__docs__/wonder-blocks-button/activity-button.stories.tsx
@@ -16,6 +16,7 @@ import packageConfig from "../../packages/wonder-blocks-icon-button/package.json
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import activityButtonArgtypes from "./activity-button.argtypes";
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 
 export default {
     title: "Packages / Button / ActivityButton",
@@ -73,6 +74,40 @@ export const WithStartIcon: Story = {
         startIcon: magnifyingGlass,
         disabled: false,
         kind: "primary",
+    },
+};
+
+/**
+ * For non-Phosphor icons, you can use the Wonder Blocks Icon component for the
+ * `startIcon` and `endIcon` props.
+ *
+ * ```tsx
+ * import {Icon} from "@khanacademy/wonder-blocks-icon";
+ *
+ * <ActivityButton
+ *     startIcon={<Icon><img alt="" src="logo.svg" /></Icon>}
+ *     endIcon={<Icon><img alt="" src="logo.svg" /></Icon>}
+ * >
+ *   Action
+ * </ActivityButton>
+ * ```
+ *
+ * Note: The ActivityButton component will handle the sizing for the icons.
+ */
+export const WithCustomIcons: Story = {
+    args: {
+        children: "Action",
+        startIcon: (
+            <Icon>
+                <img alt="" src="logo.svg" />
+            </Icon>
+        ),
+        endIcon: (
+            <Icon>
+                <img alt="" src="logo.svg" />
+            </Icon>
+        ),
+        kind: "secondary",
     },
 };
 

--- a/__docs__/wonder-blocks-button/button-shared.argtypes.ts
+++ b/__docs__/wonder-blocks-button/button-shared.argtypes.ts
@@ -10,7 +10,9 @@ export default {
         mapping: IconMappings,
         table: {
             category: "Layout",
-            type: {summary: "PhosphorIconAsset"},
+            // NOTE: We use `Icon` instead of `ReactElement` because we want to
+            // encourage the use of `Icon` components for custom icons.
+            type: {summary: "PhosphorIconAsset | Icon"},
         },
     },
     endIcon: {
@@ -18,7 +20,9 @@ export default {
         mapping: IconMappings,
         table: {
             category: "Layout",
-            type: {summary: "PhosphorIconAsset"},
+            // NOTE: We use `Icon` instead of `ReactElement` because we want to
+            // encourage the use of `Icon` components for custom icons.
+            type: {summary: "PhosphorIconAsset | Icon"},
         },
     },
     className: {

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -27,6 +27,7 @@ import ComponentInfo from "../components/component-info";
 import ButtonArgTypes from "./button.argtypes";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {Icon} from "@khanacademy/wonder-blocks-icon";
+import {themeModes} from "../../.storybook/modes";
 
 export default {
     title: "Packages / Button / Button",
@@ -412,11 +413,16 @@ const IconExample = () => (
  * );
  * ```
  *
- * Note: The Buttoncomponent will handle the sizing for the icons
+ * Note: The Button component will handle the sizing for the icons
  */
 export const WithIcon: StoryComponentType = {
     name: "Icon",
     render: () => <IconExample />,
+    parameters: {
+        chromatic: {
+            modes: themeModes,
+        },
+    },
 };
 
 export const Size: StoryComponentType = () => (

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -26,6 +26,7 @@ import ComponentInfo from "../components/component-info";
 
 import ButtonArgTypes from "./button.argtypes";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 
 export default {
     title: "Packages / Button / Button",
@@ -329,6 +330,52 @@ const IconExample = () => (
                 </Button>
             ))}
         </View>
+        <BodyText weight="bold" style={styles.label}>
+            Using Icon component for custom icons
+        </BodyText>
+        <View style={styles.row}>
+            {kinds.map((kind, idx) => (
+                <Button
+                    kind={kind}
+                    startIcon={
+                        <Icon>
+                            <img src={"logo.svg"} alt="" />
+                        </Icon>
+                    }
+                    endIcon={
+                        <Icon>
+                            <img src={"logo.svg"} alt="" />
+                        </Icon>
+                    }
+                    style={styles.button}
+                    key={idx}
+                >
+                    {kind}
+                </Button>
+            ))}
+        </View>
+        <View style={styles.row}>
+            {kinds.map((kind, idx) => (
+                <Button
+                    kind={kind}
+                    startIcon={
+                        <Icon>
+                            <img src={"logo.svg"} alt="" />
+                        </Icon>
+                    }
+                    endIcon={
+                        <Icon>
+                            <img src={"logo.svg"} alt="" />
+                        </Icon>
+                    }
+                    style={styles.button}
+                    key={idx}
+                    size="small"
+                >
+                    {`${kind} small`}
+                </Button>
+            ))}
+        </View>
     </View>
 );
 
@@ -341,14 +388,34 @@ const IconExample = () => (
  * __NOTE:__ Icons are available from the [Phosphor
  * Icons](https://phosphoricons.com/) library.
  *
- * To import an icon, you can use the following syntax:
+ * To use a Phosphor icon, you can use the following syntax:
  *
- * e.g.
- * ```
+ * ```tsx
  * import pencilSimple from "@phosphor-icons/core/regular/pencil-simple.svg";
+ *
+ * export const ButtonExample = () => (
+ *     <Button startIcon={pencilSimple}>
+ *         Example button
+ *     </Button>
+ * );
  * ```
+ *
+ * For custom icons, you can use the Wonder Blocks Icon component:
+ *
+ * ```tsx
+ * import {Icon} from "@khanacademy/wonder-blocks-icon";
+ *
+ * export const ButtonExample = () => (
+ *     <Button startIcon={<Icon><img src="example.svg" alt="Example icon" /></Icon>}>
+ *         Example button
+ *     </Button>
+ * );
+ * ```
+ *
+ * Note: The Buttoncomponent will handle the sizing for the icons
  */
-export const Icon: StoryComponentType = {
+export const WithIcon: StoryComponentType = {
+    name: "Icon",
     render: () => <IconExample />,
 };
 

--- a/packages/wonder-blocks-button/src/components/__tests__/activity-button.test.tsx
+++ b/packages/wonder-blocks-button/src/components/__tests__/activity-button.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 import {ActivityButton} from "../activity-button";
 
 describe("ActivityButton", () => {
@@ -425,6 +426,50 @@ describe("ActivityButton", () => {
                 // Assert
                 expect(onMouseDown).toHaveBeenCalledTimes(1);
             });
+        });
+    });
+
+    describe("icons", () => {
+        test("icon is displayed with aria-hidden=true when the button contains a custom startIcon", async () => {
+            // Arrange
+            render(
+                <ActivityButton
+                    startIcon={
+                        <Icon testId="custom-icon">
+                            <img src="icon.svg" alt="" />
+                        </Icon>
+                    }
+                >
+                    Label
+                </ActivityButton>,
+            );
+
+            // Act
+            const icon = await screen.findByTestId("custom-icon");
+
+            // Assert
+            expect(icon).toHaveAttribute("aria-hidden", "true");
+        });
+
+        test("icon is displayed with aria-hidden=true when the button contains a custom endIcon", async () => {
+            // Arrange
+            render(
+                <ActivityButton
+                    endIcon={
+                        <Icon testId="custom-icon">
+                            <img src="icon.svg" alt="" />
+                        </Icon>
+                    }
+                >
+                    Label
+                </ActivityButton>,
+            );
+
+            // Act
+            const icon = await screen.findByTestId("custom-icon");
+
+            // Assert
+            expect(icon).toHaveAttribute("aria-hidden", "true");
         });
     });
 });

--- a/packages/wonder-blocks-button/src/components/__tests__/button-with-icon.test.tsx
+++ b/packages/wonder-blocks-button/src/components/__tests__/button-with-icon.test.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import plus from "@phosphor-icons/core/regular/plus.svg";
 
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 import Button from "../button";
 
 describe("button with icon", () => {
@@ -176,6 +177,94 @@ describe("button with icon", () => {
 
         // Assert
         expect(icon).toBeInTheDocument();
+        expect(icon).toHaveAttribute("aria-hidden", "true");
+    });
+
+    test("should use the test id prop for the start icon", async () => {
+        // Arrange
+        render(
+            <Button
+                testId={"button-test-id"}
+                startIcon={
+                    <Icon>
+                        <img src="icon.svg" alt="" />
+                    </Icon>
+                }
+            >
+                Label
+            </Button>,
+        );
+
+        // Act
+        const icon = await screen.findByTestId("button-test-id-start-icon");
+
+        // Assert
+        expect(icon).toBeInTheDocument();
+    });
+
+    test("should use the test id prop for the end icon", async () => {
+        // Arrange
+        render(
+            <Button
+                testId={"button-test-id"}
+                endIcon={
+                    <Icon>
+                        <img src="icon.svg" alt="" />
+                    </Icon>
+                }
+            >
+                Label
+            </Button>,
+        );
+
+        // Act
+        const icon = await screen.findByTestId("button-test-id-end-icon");
+
+        // Assert
+        expect(icon).toBeInTheDocument();
+    });
+
+    test("icon is displayed with aria-hidden=true when the button contains a custom startIcon", async () => {
+        // Arrange
+        render(
+            <Button
+                testId={"button-test-id"}
+                startIcon={
+                    <Icon>
+                        <img src="icon.svg" alt="" />
+                    </Icon>
+                }
+            >
+                Label
+            </Button>,
+        );
+
+        // Act
+        const icon = await screen.findByTestId("button-test-id-start-icon");
+
+        // Assert
+        expect(icon).toHaveAttribute("aria-hidden", "true");
+    });
+
+    test("icon is displayed with aria-hidden=true when the button contains a custom endIcon", async () => {
+        // Arrange
+        render(
+            <Button
+                testId={"button-test-id"}
+                endIcon={
+                    <Icon>
+                        <img src="icon.svg" alt="" />
+                    </Icon>
+                }
+            >
+                Label
+            </Button>,
+        );
+
+        // Act
+        const icon = await screen.findByTestId("button-test-id-end-icon");
+
+        // Assert
         expect(icon).toHaveAttribute("aria-hidden", "true");
     });
 });

--- a/packages/wonder-blocks-button/src/components/activity-button.tsx
+++ b/packages/wonder-blocks-button/src/components/activity-button.tsx
@@ -75,17 +75,24 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
             <>
                 {/* NOTE: Using a regular className to be able to use descendant selectors to account for the hover and press states */}
                 <View style={chonkyStyles} className="chonky">
-                    {startIcon && (
-                        // We use the `PhosphorIcon` component to render the icon.
-                        // It is a wrapper around the Phosphor icons library.
-                        <PhosphorIcon
-                            size="medium"
-                            color="currentColor"
-                            icon={startIcon}
-                            style={[styles.icon, stylesProp?.startIcon]}
-                            aria-hidden="true"
-                        />
-                    )}
+                    {/* If startIcon is a string, we use the `PhosphorIcon` component to render it. Otherwise, we render the element directly */}
+                    {startIcon &&
+                        (typeof startIcon === "string" ? (
+                            // We use the `PhosphorIcon` component to render the icon.
+                            // It is a wrapper around the Phosphor icons library.
+                            <PhosphorIcon
+                                size="medium"
+                                color="currentColor"
+                                icon={startIcon}
+                                style={[styles.icon, stylesProp?.startIcon]}
+                                aria-hidden="true"
+                            />
+                        ) : (
+                            React.cloneElement(startIcon, {
+                                "aria-hidden": true,
+                                style: [styles.icon, stylesProp?.startIcon],
+                            })
+                        ))}
 
                     <BodyText
                         tag="span"
@@ -95,18 +102,24 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
                     >
                         {children}
                     </BodyText>
-
-                    {endIcon && (
-                        // We use the `PhosphorIcon` component to render the icon.
-                        // It is a wrapper around the Phosphor icons library.
-                        <PhosphorIcon
-                            size="medium"
-                            color="currentColor"
-                            icon={endIcon}
-                            style={[styles.icon, stylesProp?.endIcon]}
-                            aria-hidden="true"
-                        />
-                    )}
+                    {/* If endIcon is a string, we use the `PhosphorIcon` component to render it. Otherwise, we render the element directly */}
+                    {endIcon &&
+                        (typeof endIcon === "string" ? (
+                            // We use the `PhosphorIcon` component to render the icon.
+                            // It is a wrapper around the Phosphor icons library.
+                            <PhosphorIcon
+                                size="medium"
+                                color="currentColor"
+                                icon={endIcon}
+                                style={[styles.icon, stylesProp?.endIcon]}
+                                aria-hidden="true"
+                            />
+                        ) : (
+                            React.cloneElement(endIcon, {
+                                "aria-hidden": true,
+                                style: [styles.icon, stylesProp?.endIcon],
+                            })
+                        ))}
                 </View>
             </>
         </ButtonUnstyled>

--- a/packages/wonder-blocks-button/src/components/button-icon.tsx
+++ b/packages/wonder-blocks-button/src/components/button-icon.tsx
@@ -14,7 +14,7 @@ export function ButtonIcon({
     style,
     testId,
 }: {
-    icon: PhosphorIconAsset;
+    icon: PhosphorIconAsset | React.ReactElement;
     size: "small" | "medium";
     style?: StyleType;
     testId?: string;
@@ -28,16 +28,26 @@ export function ButtonIcon({
 
     const commonProps = {
         "aria-hidden": true,
-        color: "currentColor",
         style: [style, iconStyle],
         testId,
     };
+
+    const phosphorIconProps = {
+        ...commonProps,
+        color: "currentColor",
+    };
+
+    if (typeof icon !== "string") {
+        // If the icon is not a string, it is a custom icon that can be rendered
+        // directly with the corresponding styles
+        return React.cloneElement(icon, commonProps);
+    }
 
     switch (size) {
         case "small":
             return (
                 <PhosphorIcon
-                    {...commonProps}
+                    {...phosphorIconProps}
                     size="small"
                     icon={icon as PhosphorBold | PhosphorFill}
                 />
@@ -47,7 +57,7 @@ export function ButtonIcon({
         default:
             return (
                 <PhosphorIcon
-                    {...commonProps}
+                    {...phosphorIconProps}
                     size="medium"
                     icon={icon as PhosphorRegular | PhosphorFill}
                 />

--- a/packages/wonder-blocks-button/src/util/button.types.ts
+++ b/packages/wonder-blocks-button/src/util/button.types.ts
@@ -25,13 +25,19 @@ export type BaseButtonProps =
         /**
          * A Phosphor icon asset (imported as a static SVG file) that
          * will appear at the start of the button (left for LTR, right for RTL).
+         *
+         * For non-Phosphor icons, pass in a WB Icon component that wraps
+         * the custom icon.
          */
-        startIcon?: PhosphorIconAsset;
+        startIcon?: PhosphorIconAsset | React.ReactElement;
         /**
          * A Phosphor icon asset (imported as a static SVG file) that
          * will appear at the end of the button (right for LTR, left for RTL).
+         *
+         * For non-Phosphor icons, pass in a WB Icon component that wraps
+         * the custom icon.
          */
-        endIcon?: PhosphorIconAsset;
+        endIcon?: PhosphorIconAsset | React.ReactElement;
 
         /**
          * The kind of the button, either primary, secondary, or tertiary.


### PR DESCRIPTION
## Summary:

Adds support for custom non-Phosphor icons in Button and ActivityButton components. The `startIcon` and `endIcon` props can now accept either a `PhosphorIconAsset` or a `ReactElement`. In the docs, we recommend using the Wonder Blocks Icon component for custom icons.

For context, this implementation is similar to the one in PR: https://github.com/Khan/wonder-blocks/pull/2762 . Various teams have asked about custom icons like Khanmigo or gem icons in WB components. I've created other tickets for supporting custom icons in IconButton and Banner components as well!

Issue: WB-1954

## Test plan:

Confirm a custom icon can be used in Button and ActivityButton components:
- `?path=/story/packages-button-button--with-icon`
- `?path=/story/packages-button-activitybutton--with-custom-icons`