### PR TITLE
Icon button components: support custom icons

### DIFF
--- a/__docs__/wonder-blocks-icon-button/activity-icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button.stories.tsx
@@ -218,8 +218,10 @@ export const WithLabel: StoryComponentType = {
 };
 
 /**
- * `ActivityIconButton` accepts a custom icon element as the `icon` prop. The
- * custom icon element will be rendered as-is.
+ * For non-Phosphor icons, you can use the Wonder Blocks Icon component to wrap
+ * the custom icon.
+ *
+ * Note: The ActivityIconButton component will handle the sizing for the icon.
  */
 export const WithCustomIcon: StoryComponentType = {
     render: () => {

--- a/__docs__/wonder-blocks-icon-button/conversation-icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/conversation-icon-button-testing-snapshots.stories.tsx
@@ -6,6 +6,8 @@ import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg"
 import {ConversationIconButton} from "@khanacademy/wonder-blocks-icon-button";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {themeModes} from "../../.storybook/modes";
+import {ScenariosLayout} from "../components/scenarios-layout";
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -64,5 +66,30 @@ export const StateSheetStory: StoryComponentType = {
     },
     parameters: {
         pseudo: defaultPseudoStates,
+    },
+};
+
+export const Scenarios: StoryComponentType = {
+    render: () => {
+        const scenarios = [
+            {
+                name: "With custom icon",
+                props: {
+                    icon: (
+                        <Icon>
+                            <img src="logo.svg" alt="" />
+                        </Icon>
+                    ),
+                    "aria-label": "Wonder Blocks",
+                    kind: "secondary",
+                },
+            },
+        ];
+
+        return (
+            <ScenariosLayout scenarios={scenarios}>
+                {(props) => <ConversationIconButton {...props} />}
+            </ScenariosLayout>
+        );
     },
 };

--- a/__docs__/wonder-blocks-icon-button/conversation-icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/conversation-icon-button.stories.tsx
@@ -12,7 +12,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {ConversationIconButton} from "@khanacademy/wonder-blocks-icon-button";
 
 import {ActionItem, ActionMenu} from "@khanacademy/wonder-blocks-dropdown";
-import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import packageConfig from "../../packages/wonder-blocks-icon-button/package.json";
@@ -210,5 +210,23 @@ export const Expanded: Story = {
                 />
             </ActionMenu>
         );
+    },
+};
+
+/**
+ * For non-Phosphor icons, you can use the Wonder Blocks Icon component to wrap
+ * the custom icon.
+ *
+ * Note: The ConversationIconButton component will handle the sizing for the icon.
+ */
+export const WithCustomIcon: Story = {
+    args: {
+        "aria-label": "Wonder Blocks",
+        icon: (
+            <Icon>
+                <img src="logo.svg" alt="" />
+            </Icon>
+        ),
+        kind: "secondary",
     },
 };

--- a/__docs__/wonder-blocks-icon-button/icon-button-shared.argtypes.ts
+++ b/__docs__/wonder-blocks-icon-button/icon-button-shared.argtypes.ts
@@ -22,6 +22,14 @@ export default {
             type: "select",
         },
         options: IconMappings as any,
+        table: {
+            category: "Layout",
+            type: {
+                // NOTE: We document `Icon` instead of `ReactElement` because we want to
+                // encourage the use of `Icon` components for custom icons.
+                summary: "PhosphorIconAsset | Icon",
+            },
+        },
     },
     kind: {
         control: {

--- a/__docs__/wonder-blocks-icon-button/icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button-testing-snapshots.stories.tsx
@@ -9,6 +9,8 @@ import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {themeModes} from "../../.storybook/modes";
+import {ScenariosLayout} from "../components/scenarios-layout";
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -99,6 +101,31 @@ export const Sizes: StoryComponentType = {
                     </View>
                 )}
             </AllVariants>
+        );
+    },
+};
+
+export const Scenarios: StoryComponentType = {
+    render: () => {
+        const scenarios = [
+            {
+                name: "With custom icon",
+                props: {
+                    icon: (
+                        <Icon>
+                            <img src="logo.svg" alt="" />
+                        </Icon>
+                    ),
+                    "aria-label": "Wonder Blocks",
+                    kind: "secondary",
+                },
+            },
+        ];
+
+        return (
+            <ScenariosLayout scenarios={scenarios}>
+                {(props) => <IconButton {...props} />}
+            </ScenariosLayout>
         );
     },
 };

--- a/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button.stories.tsx
@@ -23,6 +23,7 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-icon-button/package.json";
 import IconButtonArgtypes from "./icon-button.argtypes";
 import TextField from "../../packages/wonder-blocks-form/src/components/text-field";
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 
 /**
  * An `IconButton` is a button whose contents are an SVG image.
@@ -374,6 +375,30 @@ export const SubmittingForms: StoryComponentType = {
             // We are testing the form submission, not UI changes.
             disableSnapshot: true,
         },
+    },
+};
+
+/**
+ * For non-Phosphor icons, you can use the Wonder Blocks Icon component to wrap
+ * the custom icon.
+ *
+ * Note: The IconButton component will handle the sizing for the icon.
+ */
+export const WithCustomIcon: StoryComponentType = {
+    render: (args) => (
+        <IconButton
+            {...args}
+            icon={
+                <Icon>
+                    <img src="logo.svg" alt="" />
+                </Icon>
+            }
+            aria-label="Wonder Blocks"
+            onClick={(e) => action("clicked")(e)}
+        />
+    ),
+    args: {
+        kind: "secondary",
     },
 };
 

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -36,7 +36,7 @@ type LabelOnly = {
     label: string;
 };
 
-type Props = Omit<BaseIconButtonProps, "icon"> &
+type Props = BaseIconButtonProps &
     (AriaLabelOnly | LabelOnly) & {
         /**
          * The action type of the button. This determines the visual style of the
@@ -46,11 +46,6 @@ type Props = Omit<BaseIconButtonProps, "icon"> &
          * - `neutral` is used for buttons that indicate a neutral action.
          */
         actionType?: ActivityIconButtonActionType;
-
-        /**
-         * A Phosphor icon asset (imported as a static SVG file), or an element.
-         */
-        icon: PhosphorIconAsset | React.ReactElement;
     };
 
 /**

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -3,7 +3,7 @@ import {CSSProperties, StyleSheet} from "aphrodite";
 import {Link} from "react-router-dom-v5-compat";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {PhosphorIcon, PhosphorIconAsset} from "@khanacademy/wonder-blocks-icon";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 

--- a/packages/wonder-blocks-icon-button/src/components/conversation-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/conversation-icon-button.tsx
@@ -87,9 +87,22 @@ export const ConversationIconButton: React.ForwardRefExoticComponent<
             style={styles}
             type={type}
         >
-            <PhosphorIcon size="small" color="currentColor" icon={icon} />
+            {/* If the icon is not a string, it is a custom icon that can be
+            rendered directly with the corresponding styles */}
+            {typeof icon !== "string" ? (
+                React.cloneElement(icon, {style: [staticStyles.icon]})
+            ) : (
+                <PhosphorIcon size="small" color="currentColor" icon={icon} />
+            )}
         </IconButtonUnstyled>
     );
+});
+
+const staticStyles = StyleSheet.create({
+    icon: {
+        width: sizing.size_160,
+        height: sizing.size_160,
+    },
 });
 
 const styles: Record<string, any> = {};

--- a/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button.tsx
@@ -36,6 +36,14 @@ function IconChooser({
         height: theme.icon.sizing[size],
     };
 
+    // If the icon is not a string, it is a custom icon that can be rendered
+    // directly with the corresponding styles
+    if (typeof icon !== "string") {
+        return React.cloneElement(icon, {
+            style: [iconStyle],
+        });
+    }
+
     switch (size) {
         case "small":
             return (

--- a/packages/wonder-blocks-icon-button/src/util/icon-button.types.ts
+++ b/packages/wonder-blocks-icon-button/src/util/icon-button.types.ts
@@ -17,9 +17,11 @@ export type BaseIconButtonProps = Partial<Omit<AriaProps, "aria-disabled">> & {
      */
     id?: string;
     /**
-     * A Phosphor icon asset (imported as a static SVG file).
+     * A Phosphor icon asset (imported as a static SVG file), or for
+     * non-Phosphor icons, pass in a WB Icon component that wraps the custom
+     * icon.
      */
-    icon: PhosphorIconAsset;
+    icon: PhosphorIconAsset | React.ReactElement;
     /**
      * The kind of the icon button, either primary, secondary, or tertiary.
      *


### PR DESCRIPTION
## Summary:

Adds support for custom non-Phosphor icons in IconButton and ConversationIconButton (ActivityIconButton already supports custom icons). These components now accept either a `PhosphorIconAsset` or a `ReactElement`. In the docs, we recommend using the Wonder Blocks Icon component for custom icons.

Issue: WB-2082

## Test plan:
1. Confirm that all the components in the icon button package support custom icons:
- `?path=/story/packages-iconbutton-conversationiconbutton--with-custom-icon`
- `?path=/story/packages-iconbutton-iconbutton--with-custom-icon`
- `?path=/story/packages-iconbutton-activityiconbutton--with-custom-icon`