### PR TITLE
[WB-2059] Sync shadow color tokens with Figma tokens

### DIFF
--- a/.changeset/chilly-rockets-know.md
+++ b/.changeset/chilly-rockets-know.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": major
+---
+
+Updates `core.shadow.transparent` to include `low`, `mid` and `high` tokens. Renames `shadow.chonky.progressive` to `shadow.chonky.instructive`.

--- a/.changeset/mighty-countries-vanish.md
+++ b/.changeset/mighty-countries-vanish.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Updated `core.shadow.transparent` to use the new subcategories (`low`, `mid`, `high`)

--- a/.changeset/ninety-poets-rest.md
+++ b/.changeset/ninety-poets-rest.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+Updates boxShadow to use `core.shadow.transparent.low` instead of a primitive `color` token.

--- a/packages/wonder-blocks-dropdown/src/theme/default.ts
+++ b/packages/wonder-blocks-dropdown/src/theme/default.ts
@@ -17,7 +17,7 @@ export default {
             },
         },
         shadow: {
-            default: `0 ${sizing.size_080} ${sizing.size_080} 0 ${semanticColor.core.shadow.transparent}`,
+            default: `0 ${sizing.size_080} ${sizing.size_080} 0 ${semanticColor.core.shadow.transparent.low}`,
         },
     },
     opener: {

--- a/packages/wonder-blocks-dropdown/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-dropdown/src/theme/thunderblocks.ts
@@ -20,7 +20,7 @@ export default mergeTheme(defaultTheme, {
             },
         },
         shadow: {
-            default: `0 ${sizing.size_020} ${sizing.size_020} 0 ${semanticColor.core.shadow.transparent}`,
+            default: `0 ${sizing.size_020} ${sizing.size_020} 0 ${semanticColor.core.shadow.transparent.low}`,
         },
     },
     opener: {

--- a/packages/wonder-blocks-modal/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-modal/src/theme/thunderblocks.ts
@@ -10,7 +10,7 @@ export default mergeTheme(defaultTheme, {
     },
     dialog: {
         shadow: {
-            default: `0 ${sizing.size_080} ${sizing.size_160} 0 ${semanticColor.core.shadow.transparent}`,
+            default: `0 ${sizing.size_080} ${sizing.size_160} 0 ${semanticColor.core.shadow.transparent.high}`,
         },
     },
     header: {

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -5,7 +5,6 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {
     border,
-    color,
     semanticColor,
     spacing,
 } from "@khanacademy/wonder-blocks-tokens";
@@ -106,7 +105,7 @@ const styles = StyleSheet.create({
         border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         backgroundColor: semanticColor.core.background.base.default,
         // TODO(WB-1878): Use `elevation` token.
-        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,
+        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${semanticColor.core.shadow.transparent.low}`,
         margin: 0,
         maxWidth: spacing.medium_16 * 18, // 288px
         padding: spacing.large_24,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -137,7 +137,7 @@ const core = {
         // with the CSS `rgba` function or the `fade` JS function.
         transparent: `color-mix(in srgb, ${color.blue_05} 20%, ${transparent})`,
         chonky: {
-            progressive: {
+            instructive: {
                 subtle: color.blue_60,
                 default: color.blue_10,
             },
@@ -415,22 +415,22 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
             },
             shadow: {
                 primary: {
-                    rest: core.shadow.chonky.progressive.default,
-                    hover: core.shadow.chonky.progressive.default,
-                    press: core.shadow.chonky.progressive.default,
-                    selected: core.shadow.chonky.progressive.default,
+                    rest: core.shadow.chonky.instructive.default,
+                    hover: core.shadow.chonky.instructive.default,
+                    press: core.shadow.chonky.instructive.default,
+                    selected: core.shadow.chonky.instructive.default,
                 },
                 secondary: {
-                    rest: core.shadow.chonky.progressive.subtle,
-                    hover: core.shadow.chonky.progressive.subtle,
-                    press: core.shadow.chonky.progressive.subtle,
-                    selected: core.shadow.chonky.progressive.subtle,
+                    rest: core.shadow.chonky.instructive.subtle,
+                    hover: core.shadow.chonky.instructive.subtle,
+                    press: core.shadow.chonky.instructive.subtle,
+                    selected: core.shadow.chonky.instructive.subtle,
                 },
                 tertiary: {
                     rest: core.transparent,
                     hover: core.shadow.chonky.neutral.subtle,
                     press: core.shadow.chonky.neutral.subtle,
-                    selected: core.shadow.chonky.progressive.subtle,
+                    selected: core.shadow.chonky.instructive.subtle,
                 },
             },
         },
@@ -512,7 +512,7 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                     rest: core.transparent,
                     hover: core.shadow.chonky.neutral.subtle,
                     press: core.shadow.chonky.neutral.subtle,
-                    selected: core.shadow.chonky.progressive.subtle,
+                    selected: core.shadow.chonky.instructive.subtle,
                 },
             },
         },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -5,6 +5,11 @@ import {semanticColor as defaultSemanticColor} from "./semantic-color";
 
 const transparent = "transparent";
 
+// NOTE: We use `color-mix` to generate a transparent color because it supports
+// using CSS variables as input, which is not possible with the CSS `rgba`
+// function or the `fade` JS function.
+const transparentShadowColor = `color-mix(in srgb, ${color.blue_05} 20%, ${transparent})`;
+
 const core = {
     transparent,
     border: {
@@ -132,10 +137,11 @@ const core = {
         },
     },
     shadow: {
-        // NOTE: We use `color-mix` to generate a transparent color because
-        // it supports using CSS variables as input, which is not possible
-        // with the CSS `rgba` function or the `fade` JS function.
-        transparent: `color-mix(in srgb, ${color.blue_05} 20%, ${transparent})`,
+        transparent: {
+            low: transparentShadowColor,
+            mid: transparentShadowColor,
+            high: transparentShadowColor,
+        },
         chonky: {
             instructive: {
                 subtle: color.blue_60,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -8,6 +8,8 @@ import {color as thunderBlocksColor} from "./internal/primitive-color-thunderblo
 
 const transparent = "transparent";
 
+const transparentShadowColor = color.offBlack16;
+
 const core = {
     transparent,
     border: {
@@ -135,7 +137,11 @@ const core = {
         },
     },
     shadow: {
-        transparent: color.offBlack16,
+        transparent: {
+            low: transparentShadowColor,
+            mid: transparentShadowColor,
+            high: transparentShadowColor,
+        },
         chonky: {
             instructive: {
                 subtle: color.fadedBlue,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -137,7 +137,7 @@ const core = {
     shadow: {
         transparent: color.offBlack16,
         chonky: {
-            progressive: {
+            instructive: {
                 subtle: color.fadedBlue,
                 default: color.activeBlue,
             },
@@ -541,22 +541,22 @@ export const semanticColor = {
             },
             shadow: {
                 primary: {
-                    rest: core.shadow.chonky.progressive.default,
-                    hover: core.shadow.chonky.progressive.default,
-                    press: core.shadow.chonky.progressive.default,
-                    selected: core.shadow.chonky.progressive.default,
+                    rest: core.shadow.chonky.instructive.default,
+                    hover: core.shadow.chonky.instructive.default,
+                    press: core.shadow.chonky.instructive.default,
+                    selected: core.shadow.chonky.instructive.default,
                 },
                 secondary: {
-                    rest: core.shadow.chonky.progressive.subtle,
-                    hover: core.shadow.chonky.progressive.subtle,
-                    press: core.shadow.chonky.progressive.subtle,
-                    selected: core.shadow.chonky.progressive.subtle,
+                    rest: core.shadow.chonky.instructive.subtle,
+                    hover: core.shadow.chonky.instructive.subtle,
+                    press: core.shadow.chonky.instructive.subtle,
+                    selected: core.shadow.chonky.instructive.subtle,
                 },
                 tertiary: {
                     rest: core.transparent,
                     hover: core.shadow.chonky.neutral.subtle,
                     press: core.shadow.chonky.neutral.subtle,
-                    selected: core.shadow.chonky.progressive.subtle,
+                    selected: core.shadow.chonky.instructive.subtle,
                 },
             },
         },
@@ -638,7 +638,7 @@ export const semanticColor = {
                     rest: core.transparent,
                     hover: core.shadow.chonky.neutral.subtle,
                     press: core.shadow.chonky.neutral.subtle,
-                    selected: core.shadow.chonky.progressive.subtle,
+                    selected: core.shadow.chonky.instructive.subtle,
                 },
             },
         },

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
@@ -46,65 +46,65 @@ describe("TooltipTail", () => {
 
             // Assert
             expect(container).toMatchInlineSnapshot(`
-                <div>
-                  <div
-                    class=""
-                    data-placement="top"
-                    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="arrow_oo4scr"
-                      height="12"
-                      style="margin-left: 8px; margin-right: 8px; padding-bottom: 8px;"
-                      width="24"
-                    >
-                      <filter
-                        height="200%"
-                        id="tooltip-dropshadow-top-3"
-                        width="200%"
-                        x="-50%"
-                        y="-50%"
-                      >
-                        <fegaussianblur
-                          in="SourceAlpha"
-                          stdDeviation="3"
-                        />
-                        <fecomponenttransfer>
-                          <fefunca
-                            slope="0.3"
-                            type="linear"
-                          />
-                        </fecomponenttransfer>
-                      </filter>
-                      <g
-                        transform="translate(0,5.5)"
-                      >
-                        <polyline
-                          fill="rgba(33,36,44,0.16)"
-                          filter="url(#tooltip-dropshadow-top-3)"
-                          points="0,0 12,12 24,0"
-                          stroke="rgba(33,36,44,0.32)"
-                        />
-                      </g>
-                      <polyline
-                        fill="#ffffff"
-                        points="0,0 12,12 24,0"
-                        stroke="#ffffff"
-                      />
-                      <polyline
-                        fill="#ffffff"
-                        points="0,0 12,12 24,0"
-                        stroke="rgba(33,36,44,0.16)"
-                      />
-                      <polyline
-                        points="0,-0.5 24,-0.5"
-                        stroke="#ffffff"
-                      />
-                    </svg>
-                  </div>
-                </div>
-            `);
+<div>
+  <div
+    class=""
+    data-placement="top"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
+  >
+    <svg
+      aria-hidden="true"
+      class="arrow_oo4scr"
+      height="12"
+      style="margin-left: 8px; margin-right: 8px; padding-bottom: 8px;"
+      width="24"
+    >
+      <filter
+        height="200%"
+        id="tooltip-dropshadow-top-3"
+        width="200%"
+        x="-50%"
+        y="-50%"
+      >
+        <fegaussianblur
+          in="SourceAlpha"
+          stdDeviation="3"
+        />
+        <fecomponenttransfer>
+          <fefunca
+            slope="0.3"
+            type="linear"
+          />
+        </fecomponenttransfer>
+      </filter>
+      <g
+        transform="translate(0,5.5)"
+      >
+        <polyline
+          fill="var(--wb-semanticColor-core-shadow-transparent-low)"
+          filter="url(#tooltip-dropshadow-top-3)"
+          points="0,0 12,12 24,0"
+          stroke="var(--wb-semanticColor-core-shadow-transparent-low)"
+        />
+      </g>
+      <polyline
+        fill="#ffffff"
+        points="0,0 12,12 24,0"
+        stroke="#ffffff"
+      />
+      <polyline
+        fill="#ffffff"
+        points="0,0 12,12 24,0"
+        stroke="var(--wb-semanticColor-core-shadow-transparent-low)"
+      />
+      <polyline
+        points="0,-0.5 24,-0.5"
+        stroke="#ffffff"
+      />
+    </svg>
+  </div>
+</div>
+`);
         });
 
         it("should render a spacer when show is false", () => {

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -132,7 +132,7 @@ const styles = StyleSheet.create({
         border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         backgroundColor: semanticColor.core.background.base.default,
         // TODO(WB-1878): Use `elevation` token.
-        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,
+        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${semanticColor.core.shadow.transparent.low}`,
         justifyContent: "center",
     },
 });

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {css, StyleSheet} from "aphrodite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, spacing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
@@ -240,9 +240,9 @@ export default class TooltipTail extends React.Component<Props> {
              */
             <g key="dropshadow" transform={`translate(${offsetShadowX},5.5)`}>
                 <polyline
-                    fill={color.offBlack16}
+                    fill={semanticColor.core.shadow.transparent.low}
                     points={points.join(" ")}
-                    stroke={color.offBlack32}
+                    stroke={semanticColor.core.shadow.transparent.low}
                     filter={`url(#${dropShadowFilterId})`}
                 />
             </g>,
@@ -385,7 +385,7 @@ export default class TooltipTail extends React.Component<Props> {
                     // the border of the tooltip.
                     fill={color[arrowColor]}
                     points={points.join(" ")}
-                    stroke={color.offBlack16}
+                    stroke={semanticColor.core.shadow.transparent.low}
                 />
                 {/* Draw a trimline to make the arrow appear flush */}
                 <polyline


### PR DESCRIPTION
## Summary:

- Tokens:
  - Updated `core.shadow.transparent` to include `low`, `mid` and `high` tokens. Renames `shadow.chonky.progressive` to `shadow.chonky.instructive`.
  - Updated `core.shadow.chonky.progressive` with `*.instructive`
- Dropdown and Modal: Updates boxShadow to use `core.shadow.transparent.{low, high}` instead of the previous `core.shadow.transparent` token.
- Popover and Tooltip: Updates boxShadow to use `core.shadow.transparent.low` instead of a primitive `color` token.

Issue: https://khanacademy.atlassian.net/browse/WB-2059

## Test plan:

Navigate to the Popover and Tooltip examples and verify that the box shadow now uses the updated shadow color token.

In OG, the new value should be `offBlack16` instead of `offBlack8`.