### PR TITLE
Banner: Support custom icons

### DIFF
--- a/.changeset/wicked-rabbits-buy.md
+++ b/.changeset/wicked-rabbits-buy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": minor
+---
+
+Banner: Support custom icons

--- a/__docs__/wonder-blocks-banner/banner-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner-testing-snapshots.stories.tsx
@@ -15,6 +15,7 @@ import Link from "@khanacademy/wonder-blocks-link";
 import Button from "@khanacademy/wonder-blocks-button";
 import crownIcon from "../wonder-blocks-icon/icons/crown.svg";
 import {AllVariants} from "../components/all-variants";
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -263,7 +264,7 @@ const scenarios = [
         },
     },
     {
-        name: "With custom icon",
+        name: "With custom filled icon",
         props: {
             icon: crownIcon,
         },
@@ -272,6 +273,16 @@ const scenarios = [
         name: "With no icon",
         props: {
             icon: "none",
+        },
+    },
+    {
+        name: "With custom icon",
+        props: {
+            icon: (
+                <Icon>
+                    <img src="logo.svg" alt="Wonder Blocks" />
+                </Icon>
+            ),
         },
     },
 ];

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -14,6 +14,7 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-banner/package.json";
 import crownIcon from "../wonder-blocks-icon/icons/crown.svg";
 import {reallyLongText} from "../components/text-for-testing";
+import {Icon} from "@khanacademy/wonder-blocks-icon";
 
 type StoryComponentType = StoryObj<typeof Banner>;
 
@@ -541,7 +542,7 @@ export const WithPhosphorIcon: StoryComponentType = {
  * `icon` prop is not set, a default icon will be used in the banner depending
  * on the `kind` prop.
  *
- * To use a custom icon, you can use the following syntax:
+ * To use a custom icon that has a solid fill, you can use the following syntax:
  *
  * ```jsx
  * // This SVG should have the following attributes:
@@ -557,13 +558,37 @@ export const WithPhosphorIcon: StoryComponentType = {
  * will always have an `aria-label` that communicates the kind of banner
  * (e.g. "info").
  */
-export const WithCustomIcon: StoryComponentType = {
+export const WithCustomSolidIcon: StoryComponentType = {
     render: (args) => (
         <Banner
             icon={crownIcon}
             {...args}
             layout="floating"
             text="Here is an example with a custom icon"
+        />
+    ),
+};
+
+/**
+ * For non-Phosphor icons, you can use the Wonder Blocks Icon component to wrap
+ * a custom icon. The Banner component will handle the sizing for the icon.
+ *
+ * Accessibility: When customizing the icon, make sure to:
+ * - Provide alt text for the icon
+ * - Make sure important information about the banner kind is still communicated
+ * to the user so that color alone isn't used to convey meaning.
+ */
+export const WithCustomIcon: StoryComponentType = {
+    render: (args) => (
+        <Banner
+            {...args}
+            icon={
+                <Icon>
+                    <img src="logo.svg" alt="Wonder Blocks" />
+                </Icon>
+            }
+            kind="success"
+            text="Success! Here is an example with a custom icon"
         />
     ),
 };

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -135,7 +135,7 @@ type Props = {
      * conveyed in the text of the banner, since color should not be the only
      * way to convey status information.
      */
-    icon?: PhosphorIconAsset | string | "none";
+    icon?: PhosphorIconAsset | string | "none" | React.ReactElement;
     /**
      * Custom styles for the elements in the Banner component.
      * - `root`: Styles the root element
@@ -289,6 +289,33 @@ const Banner = (props: Props): React.ReactElement => {
     const bannerKindStyle = getBannerKindStyle(kind);
     const bannerIconKindStyle = getBannerIconKindStyle(kind);
 
+    let iconElement = <React.Fragment />;
+    // Only change the iconElement if the icon prop is not "none"
+    if (icon !== "none") {
+        // If icon is defined and it is not a string, it is a custom icon that
+        // can be rendered directly with the corresponding styles
+        if (icon !== undefined && typeof icon !== "string") {
+            iconElement = React.cloneElement(icon, {
+                style: styles.icon,
+                testId: "banner-kind-icon",
+                // When a custom icon element is used, leave it up to the
+                // consumers to provide alt text for the icon
+            });
+        } else {
+            // The icon is compatible with PhosphorIcon so we render the provided
+            // icon or the default icon for the kind
+            iconElement = (
+                <PhosphorIcon
+                    icon={icon || valuesForKind.icon}
+                    style={[styles.icon, bannerIconKindStyle]}
+                    aria-label={kind}
+                    testId="banner-kind-icon"
+                    role="img"
+                />
+            );
+        }
+    }
+
     return (
         <View
             style={[styles.containerOuter, bannerKindStyle, stylesProp?.root]}
@@ -298,15 +325,7 @@ const Banner = (props: Props): React.ReactElement => {
             testId={testId}
         >
             <View style={styles.containerInner}>
-                {icon !== "none" && (
-                    <PhosphorIcon
-                        icon={icon || valuesForKind.icon}
-                        style={[styles.icon, bannerIconKindStyle]}
-                        aria-label={kind}
-                        testId="banner-kind-icon"
-                        role="img"
-                    />
-                )}
+                {iconElement}
                 <View style={styles.labelAndButtonsContainer}>
                     <View style={styles.labelContainer}>
                         {/* We use a div here since text can be a React node with other elements */}


### PR DESCRIPTION
## Summary:
Adds support for custom non-Phosphor icons in the Banner component. It can now also accept a `ReactElement` for the `icon` prop. In the docs, we recommend using the Wonder Blocks Icon component for custom icons.

Issue: WB-2081

## Test plan:
1. Confirm that the Banner component supports custom icons: `?path=/story/packages-banner--with-custom-icon`