### PR TITLE
[WB-1878] Add elevation tokens

### DIFF
--- a/.changeset/khaki-jeans-return.md
+++ b/.changeset/khaki-jeans-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Adds `elevation` tokens to systematize box shadows.

--- a/.changeset/large-oranges-camp.md
+++ b/.changeset/large-oranges-camp.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Updates listbox to use elevation tokens

--- a/.changeset/wicked-ravens-obey.md
+++ b/.changeset/wicked-ravens-obey.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-popover": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Updates boxShadow to use `elevation` tokens.

--- a/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
@@ -4,7 +4,11 @@ import {StyleSheet} from "aphrodite";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {color, semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    elevation,
+    semanticColor,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
@@ -33,8 +37,7 @@ const styles = StyleSheet.create({
     },
     panel: {
         padding: spacing.medium_16,
-        // TODO(WB-1878): Use elevation token.
-        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${color.offBlack8}`,
+        boxShadow: `${elevation.mid} ${semanticColor.core.shadow.transparent.mid}`,
     },
     tabButton: {
         width: "100%",

--- a/__docs__/wonder-blocks-tokens/elevation.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/elevation.stories.tsx
@@ -1,0 +1,100 @@
+import * as React from "react";
+import {Title, Subtitle, Description, Stories} from "@storybook/blocks";
+import {Meta} from "@storybook/react";
+import {View} from "@khanacademy/wonder-blocks-core";
+import TokenTable from "../components/token-table";
+import {
+    elevation,
+    semanticColor,
+    sizing,
+} from "@khanacademy/wonder-blocks-tokens";
+import ComponentInfo from "../components/component-info";
+import packageConfig from "../../packages/wonder-blocks-tokens/package.json";
+import {Code} from "../components/code";
+
+/**
+ * The `elevation` tokens are used to define the box-shadow of an element.
+ *
+ * Note: We don't define box-shadow colors here, and instead we recommend you to
+ * rely on the `semanticColor.core.shadow` tokens to build on top of that.
+ *
+ * ## Usage
+ *
+ * ```ts
+ *   import {elevation} from "@khanacademy/wonder-blocks-tokens";
+ *   const styles = {
+ *       elevatedContainer: {
+ *           boxShadow: `{elevation.low} ${semanticColor.core.shadow.transparent.low}`,
+ *       },
+ *   };
+ * ```
+ */
+export default {
+    title: "Packages /Tokens / Elevation",
+    parameters: {
+        docs: {
+            // Use a custom page so the SB <Primary> component is not rendered
+            // <Primary> renders the first story as part of the description,
+            // which isn't necessary for the token pages.
+            page: () => (
+                <>
+                    <Title />
+                    <Subtitle />
+                    <Description />
+                    <Stories title="Tokens" />
+                </>
+            ),
+        },
+        componentSubtitle: (
+            <ComponentInfo
+                name={packageConfig.name}
+                version={packageConfig.version}
+            />
+        ),
+    },
+    tags: ["!dev"],
+} as Meta;
+
+type Row = {label: string; css: string; value: string};
+const baseColumns = (kind: string) => [
+    {
+        label: "Token",
+        cell: (row: Row) => <Code>{`elevation.${row.label}`}</Code>,
+    },
+    {
+        label: "CSS Variable",
+        cell: (row: Row) => <Code>{row.css}</Code>,
+    },
+    {
+        label: "Value",
+        cell: "value",
+    },
+];
+
+export const Elevation = {
+    render: () => (
+        <TokenTable
+            columns={[
+                ...baseColumns("elevation"),
+                {
+                    label: "Example",
+                    cell: (row) => (
+                        <View
+                            style={{
+                                backgroundColor:
+                                    semanticColor.core.background.instructive
+                                        .default,
+                                boxShadow: `var(${row.css}) ${semanticColor.core.shadow.transparent.low}`,
+                                width: sizing.size_480,
+                                height: sizing.size_480,
+                            }}
+                        >
+                            &nbsp;
+                        </View>
+                    ),
+                },
+            ]}
+            tokens={elevation}
+        />
+    ),
+};

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -745,7 +745,6 @@ const styles = StyleSheet.create({
         backgroundColor: semanticColor.core.background.base.default,
         borderRadius: theme.listbox.border.radius,
         border: `solid ${border.width.thin} ${semanticColor.core.border.neutral.subtle}`,
-        // TODO(WB-1878): Move to elevation tokens.
         boxShadow: theme.listbox.shadow.default,
         // We use a custom property to set the max height of the dropdown.
         // This comes from the maxHeight custom modifier.

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -1078,7 +1078,6 @@ const styles = StyleSheet.create({
         paddingBlock: theme.listbox.layout.padding.block,
         paddingInline: theme.listbox.layout.padding.inline,
         border: `solid ${border.width.thin} ${semanticColor.core.border.neutral.subtle}`,
-        // TODO(WB-1878): Move to elevation tokens.
         boxShadow: theme.listbox.shadow.default,
         // We use a custom property to set the max height of the dropdown.
         // This comes from the maxHeight custom modifier.

--- a/packages/wonder-blocks-dropdown/src/theme/default.ts
+++ b/packages/wonder-blocks-dropdown/src/theme/default.ts
@@ -1,5 +1,6 @@
 import {
     border,
+    elevation,
     font,
     semanticColor,
     sizing,
@@ -17,7 +18,7 @@ export default {
             },
         },
         shadow: {
-            default: `0 ${sizing.size_080} ${sizing.size_080} 0 ${semanticColor.core.shadow.transparent.low}`,
+            default: `${elevation.mid} ${semanticColor.core.shadow.transparent.mid}`,
         },
     },
     opener: {

--- a/packages/wonder-blocks-dropdown/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-dropdown/src/theme/thunderblocks.ts
@@ -2,6 +2,7 @@ import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
 
 import {
     border,
+    elevation,
     font,
     semanticColor,
     sizing,
@@ -20,7 +21,7 @@ export default mergeTheme(defaultTheme, {
             },
         },
         shadow: {
-            default: `0 ${sizing.size_020} ${sizing.size_020} 0 ${semanticColor.core.shadow.transparent.low}`,
+            default: `${elevation.low} ${semanticColor.core.shadow.transparent.low}`,
         },
     },
     opener: {

--- a/packages/wonder-blocks-modal/src/components/modal-header.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-header.tsx
@@ -137,7 +137,6 @@ const small = "@media (max-width: 767px)";
 
 const styles = StyleSheet.create({
     header: {
-        // TODO(WB-1878): Move this to an `elevation` theme token.
         boxShadow: `0px 1px 0px ${semanticColor.core.border.neutral.subtle}`,
         display: "flex",
         flexDirection: "column",

--- a/packages/wonder-blocks-modal/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-modal/src/theme/thunderblocks.ts
@@ -1,5 +1,10 @@
 import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    elevation,
+    semanticColor,
+    sizing,
+} from "@khanacademy/wonder-blocks-tokens";
 import defaultTheme from "./default";
 
 export default mergeTheme(defaultTheme, {
@@ -10,7 +15,7 @@ export default mergeTheme(defaultTheme, {
     },
     dialog: {
         shadow: {
-            default: `0 ${sizing.size_080} ${sizing.size_160} 0 ${semanticColor.core.shadow.transparent.high}`,
+            default: `${elevation.high} ${semanticColor.core.shadow.transparent.high}`,
         },
     },
     header: {

--- a/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content-core.tsx
@@ -5,6 +5,7 @@ import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {
     border,
+    elevation,
     semanticColor,
     spacing,
 } from "@khanacademy/wonder-blocks-tokens";
@@ -104,8 +105,7 @@ const styles = StyleSheet.create({
         borderRadius: border.radius.radius_040,
         border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         backgroundColor: semanticColor.core.background.base.default,
-        // TODO(WB-1878): Use `elevation` token.
-        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${semanticColor.core.shadow.transparent.low}`,
+        boxShadow: `${elevation.mid} ${semanticColor.core.shadow.transparent.mid}`,
         margin: 0,
         maxWidth: spacing.medium_16 * 18, // 288px
         padding: spacing.large_24,

--- a/packages/wonder-blocks-tokens/src/index.ts
+++ b/packages/wonder-blocks-tokens/src/index.ts
@@ -15,7 +15,7 @@ import {mapValuesToCssVars} from "./internal/map-values-to-css-vars";
 // theme
 import theme from "./tokens/theme";
 
-const {border, semanticColor, sizing, font} = theme;
+const {border, elevation, semanticColor, sizing, font} = theme;
 
 export {
     /**
@@ -25,6 +25,7 @@ export {
     // TODO(WB-1989): Remove this export once all consumers have migrated to
     // using semanticColor.
     color,
+    elevation,
     font,
     pxToRem,
     remToPx,

--- a/packages/wonder-blocks-tokens/src/theme/default.ts
+++ b/packages/wonder-blocks-tokens/src/theme/default.ts
@@ -2,6 +2,7 @@ import {sizing} from "./primitive/sizing";
 import {font} from "./primitive/font";
 import {semanticColor} from "./semantic/semantic-color";
 import {border} from "./primitive/border";
+import {elevation} from "./primitive/elevation";
 
 /**
  * NOTE: All the tokens included in this `theme` file will be automatically
@@ -14,6 +15,7 @@ import {border} from "./primitive/border";
  */
 export default {
     border,
+    elevation,
     font,
     semanticColor,
     sizing,

--- a/packages/wonder-blocks-tokens/src/theme/primitive/elevation.ts
+++ b/packages/wonder-blocks-tokens/src/theme/primitive/elevation.ts
@@ -1,0 +1,20 @@
+import {remToPx} from "../../util";
+import {sizing} from "./sizing";
+
+const SIZE_20_PX = remToPx(sizing.size_020);
+const SIZE_40_PX = remToPx(sizing.size_040);
+const SIZE_80_PX = remToPx(sizing.size_080);
+const SIZE_160_PX = remToPx(sizing.size_160);
+
+export const elevation = {
+    /**
+     * Elevation values for box shadows.
+     *
+     * NOTE: We use fixed values for the box shadows instead of using the
+     * regular `sizing` tokens to ensure that the shadows are consistent across
+     * different root font sizes.
+     */
+    low: `${sizing.size_0} ${SIZE_20_PX} ${SIZE_20_PX} ${sizing.size_0}`,
+    medium: `${sizing.size_0} ${SIZE_40_PX} ${SIZE_80_PX} ${sizing.size_0}`,
+    high: `${sizing.size_0} ${SIZE_80_PX} ${SIZE_160_PX} ${sizing.size_0}`,
+};

--- a/packages/wonder-blocks-tokens/src/theme/primitive/elevation.ts
+++ b/packages/wonder-blocks-tokens/src/theme/primitive/elevation.ts
@@ -15,6 +15,6 @@ export const elevation = {
      * different root font sizes.
      */
     low: `${sizing.size_0} ${SIZE_20_PX} ${SIZE_20_PX} ${sizing.size_0}`,
-    medium: `${sizing.size_0} ${SIZE_40_PX} ${SIZE_80_PX} ${sizing.size_0}`,
+    mid: `${sizing.size_0} ${SIZE_40_PX} ${SIZE_80_PX} ${sizing.size_0}`,
     high: `${sizing.size_0} ${SIZE_80_PX} ${SIZE_160_PX} ${sizing.size_0}`,
 };

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -4,8 +4,8 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {
     border,
     color,
+    elevation,
     semanticColor,
-    spacing,
 } from "@khanacademy/wonder-blocks-tokens";
 
 import TooltipContent from "./tooltip-content";
@@ -131,8 +131,7 @@ const styles = StyleSheet.create({
         borderRadius: border.radius.radius_040,
         border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         backgroundColor: semanticColor.core.background.base.default,
-        // TODO(WB-1878): Use `elevation` token.
-        boxShadow: `0 ${spacing.xSmall_8}px ${spacing.xSmall_8}px 0 ${semanticColor.core.shadow.transparent.low}`,
+        boxShadow: `${elevation.mid} ${semanticColor.core.shadow.transparent.mid}`,
         justifyContent: "center",
     },
 });

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -240,9 +240,9 @@ export default class TooltipTail extends React.Component<Props> {
              */
             <g key="dropshadow" transform={`translate(${offsetShadowX},5.5)`}>
                 <polyline
-                    fill={semanticColor.core.shadow.transparent.low}
+                    fill={semanticColor.core.shadow.transparent.mid}
                     points={points.join(" ")}
-                    stroke={semanticColor.core.shadow.transparent.low}
+                    stroke={semanticColor.core.shadow.transparent.mid}
                     filter={`url(#${dropShadowFilterId})`}
                 />
             </g>,
@@ -385,7 +385,7 @@ export default class TooltipTail extends React.Component<Props> {
                     // the border of the tooltip.
                     fill={color[arrowColor]}
                     points={points.join(" ")}
-                    stroke={semanticColor.core.shadow.transparent.low}
+                    stroke={semanticColor.core.shadow.transparent.mid}
                 />
                 {/* Draw a trimline to make the arrow appear flush */}
                 <polyline


### PR DESCRIPTION
## Summary:

- Adds elevation tokens to `wonder-blocks-tokens`.
- Updates components to use elevation tokens instead of hardcoded box shadows.
- Updates Tooltip and Popover to use the correct elevation tokens.

Issue: WB-1878

## Test plan:

Navigate to `dropdown`, `modal`, `popover`, and `tooltip` stories in Storybook
to ensure they render correctly with the new elevation tokens.