### PR TITLE
Allow ActionMenu to support any valid popper placement

### DIFF
--- a/.changeset/hungry-carrots-leave.md
+++ b/.changeset/hungry-carrots-leave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Allow ActionMenu to support any valid popper placement

--- a/__docs__/wonder-blocks-dropdown/action-menu.argtypes.ts
+++ b/__docs__/wonder-blocks-dropdown/action-menu.argtypes.ts
@@ -3,6 +3,55 @@ import baseSelectArgTypes from "./base-select.argtypes";
 
 export default {
     ...baseSelectArgTypes,
+    alignment: {
+        control: {type: "select"},
+        description: `The alignment of the menu component in relation to the
+            opener component. Defaults to "left", which is below the opener and
+            left aligned. Any valid Popper placement is also supported.`,
+        options: [
+            "left",
+            "right",
+            "top",
+            "bottom",
+            "top-start",
+            "top-end",
+            "bottom-start",
+            "bottom-end",
+            "right-start",
+            "right-end",
+            "left-start",
+            "left-end",
+            "auto",
+            "auto-start",
+            "auto-end",
+        ],
+        table: {
+            category: "Layout",
+            type: {summary: `"left" | "right" | Placement`},
+            defaultValue: {summary: `"left"`},
+        },
+        type: {
+            name: "enum",
+            value: [
+                "left",
+                "right",
+                "top",
+                "bottom",
+                "top-start",
+                "top-end",
+                "bottom-start",
+                "bottom-end",
+                "right-start",
+                "right-end",
+                "left-start",
+                "left-end",
+                "auto",
+                "auto-start",
+                "auto-end",
+            ],
+            required: false,
+        },
+    },
     children: {
         control: {type: undefined},
         description: "The items in this dropdown.",

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -395,6 +395,24 @@ export const CustomOpener: StoryComponentType = {
  */
 export const WithPopperPlacement: StoryComponentType = {
     name: "With popper placement",
+    render: function Render(args) {
+        const [opened, setOpened] = React.useState(false);
+
+        React.useEffect(() => {
+            setOpened(true);
+        }, []);
+
+        return (
+            <ActionMenu
+                menuText="Betsy Appleseed"
+                {...args}
+                opened={opened}
+                onToggle={setOpened}
+            >
+                {actionItems.map((actionItem, index) => actionItem)}
+            </ActionMenu>
+        );
+    },
     args: {
         alignment: "right-start",
         opener: ({text}: any) => (

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -389,6 +389,21 @@ export const CustomOpener: StoryComponentType = {
 };
 
 /**
+ * Sometimes you may want to align the dropdown somewhere besides below the
+ * opener. In these cases, you can specify any valid popper placement as the
+ * alignment.
+ */
+export const WithPopperPlacement: StoryComponentType = {
+    name: "With popper placement",
+    args: {
+        alignment: "right-start",
+        opener: ({text}: any) => (
+            <Button endIcon={IconMappings.caretRight}>{text}</Button>
+        ),
+    } as Partial<typeof ActionMenu>,
+};
+
+/**
  * You can use the `lang` attribute to specify the language of the action
  * item(s). This is useful if you want to avoid issues with Screen Readers
  * trying to read the proper language for the rendered text.

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
@@ -46,8 +46,9 @@ type Props = AriaProps &
          */
         selectedValues?: Array<string>;
         /**
-         * Whether this menu should be left-aligned or right-aligned with the
-         * opener component. Defaults to left-aligned.
+         * The alignment of the menu component in relation to the opener
+         * component. Defaults to "left", which is below the opener and left
+         * aligned. Any valid Popper placement is also supported.
          */
         alignment: "left" | "right" | Placement;
         /**

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
@@ -7,6 +7,7 @@ import {
     type StyleType,
 } from "@khanacademy/wonder-blocks-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {Placement} from "@popperjs/core";
 import DropdownOpener from "./dropdown-opener";
 import ActionItem from "./action-item";
 import OptionItem from "./option-item";
@@ -48,7 +49,7 @@ type Props = AriaProps &
          * Whether this menu should be left-aligned or right-aligned with the
          * opener component. Defaults to left-aligned.
          */
-        alignment: "left" | "right";
+        alignment: "left" | "right" | Placement;
         /**
          * Whether this component is disabled. A disabled dropdown may not be opened
          * and does not support interaction. Defaults to false.

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -16,6 +16,7 @@ import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
 
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
 import type {WithActionSchedulerProps} from "@khanacademy/wonder-blocks-timing";
+import {Placement} from "@popperjs/core";
 import DropdownCoreVirtualized from "./dropdown-core-virtualized";
 import SeparatorItem from "./separator-item";
 import {defaultLabels} from "../util/constants";
@@ -65,7 +66,7 @@ type DefaultProps = Readonly<{
      * Whether this menu should be left-aligned or right-aligned with the
      * opener component. Defaults to left-aligned.
      */
-    alignment: "left" | "right";
+    alignment: "left" | "right" | Placement;
     /**
      * Whether to auto focus an option. Defaults to true.
      */
@@ -177,7 +178,7 @@ type ExportProps = Readonly<{
      * Whether this menu should be left-aligned or right-aligned with the
      * opener component. Defaults to left-aligned.
      */
-    alignment?: "left" | "right";
+    alignment?: "left" | "right" | Placement;
     /**
      * Whether to auto focus an option. Defaults to true.
      */

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
@@ -5,6 +5,7 @@ import {Popper} from "react-popper";
 import {maybeGetPortalMountedModalHostElement} from "@khanacademy/wonder-blocks-modal";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import {Placement} from "@popperjs/core";
 import {maxHeightModifier} from "../util/popper-max-height-modifier";
 
 const modifiers = [
@@ -36,7 +37,7 @@ type Props = {
      * Whether this menu should be left-aligned or right-aligned with the
      * reference component. Defaults to left-aligned.
      */
-    alignment?: "left" | "right";
+    alignment?: "left" | "right" | Placement;
     /**
      * The popper's reference.
      * @see https://popper.js.org/react-popper/v2/render-props/#innerref
@@ -71,6 +72,13 @@ const DropdownPopper = function ({
         return null;
     }
 
+    const placement =
+        alignment === "left"
+            ? "bottom-start"
+            : alignment === "right"
+              ? "bottom-end"
+              : alignment;
+
     return ReactDOM.createPortal(
         <Popper
             innerRef={(node?: HTMLElement | null) => {
@@ -80,7 +88,7 @@ const DropdownPopper = function ({
             }}
             referenceElement={referenceElement}
             strategy="fixed"
-            placement={alignment === "left" ? "bottom-start" : "bottom-end"}
+            placement={placement}
             modifiers={modifiers}
         >
             {({placement, ref, style, hasPopperEscaped, isReferenceHidden}) => {


### PR DESCRIPTION
## Summary:
In some niche scenarios, we may want to position an ActionMenu somewhere other than below the opener. To support this, we can update the `alignment` prop to allow any valid popper placement as a value.

## Test plan:
- Ensure tests pass
- View storybook and make sure the ActionMenu stories are rendering correctly