### PR TITLE
Banner: Make `layout` prop optional

### DIFF
--- a/.changeset/silver-fishes-speak.md
+++ b/.changeset/silver-fishes-speak.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": minor
+---
+
+Banner: Make `layout` prop optional so that we can start removing usage of this prop before removing the prop completely. `layout` has been deprecated and is not used in Banner

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -95,7 +95,7 @@ type Props = {
      *
      * @deprecated
      */
-    layout: BannerLayout;
+    layout?: BannerLayout;
     /**
      * Text on the banner or a node if you want something different. For the
      * best results, use the default styles provided by the Banner component and


### PR DESCRIPTION
## Summary:
Make banner layout prop optional so we can start removing it's usage before removing the prop in other repos.
Issue: WB-1979

## Test plan: