### PR TITLE
Tabs: Set type on tabs to prevent form submission

### DIFF
--- a/.changeset/rare-cheetahs-scream.md
+++ b/.changeset/rare-cheetahs-scream.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tabs": patch
+---
+
+Tabs: Set type="button" on tab elements to prevent form submission when placed within a <form> element

--- a/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
+++ b/packages/wonder-blocks-tabs/src/components/__tests__/tab.test.tsx
@@ -27,6 +27,21 @@ describe("Tab", () => {
         expect(tab.tagName).toBe("BUTTON");
     });
 
+    it("should render the tab with type=button to prevent form submissions", async () => {
+        // Arrange
+        render(
+            <Tab id={id} aria-controls={ariaControlsId}>
+                Tab
+            </Tab>,
+        );
+
+        // Act
+        const tab = await screen.findByRole("tab");
+
+        // Assert
+        expect(tab.getAttribute("type")).toBe("button");
+    });
+
     it("should render the provided children", async () => {
         // Arrange
         const childrenId = "children-id";

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -65,6 +65,7 @@ export const Tab = React.forwardRef(function Tab(
     return (
         <StyledButton
             {...otherProps}
+            type="button" // this prevents form submissions if the tab is inside a form
             role="tab"
             onClick={onClick}
             ref={ref}


### PR DESCRIPTION
## Summary:

Set `type=button` in the Tab component to prevent form submission when Tabs are used within a form element


Issue: WB-2089

## Test plan:
1. Confirm that tabs have type="button" set `?path=/story/packages-tabs-tabs--default`

<img width="1057" height="323" alt="Screenshot 2025-09-18 at 3 01 04 PM" src="https://github.com/user-attachments/assets/0a2501c3-1498-4861-88d6-a9f529cc72a9" alt="The button element with role=tab has type=button" />
