### PR TITLE
[WB-1990] Consolidate Cell style props into a single styles prop

### DIFF
--- a/.changeset/neat-eels-press.md
+++ b/.changeset/neat-eels-press.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": major
+---
+
+Removes `contentStyle`, `leftAccessoryStyle`, `rightAccessoryStyle` and `style` to consolidate it into a single `styles` prop object that contains all keys.

--- a/.changeset/spicy-poems-tap.md
+++ b/.changeset/spicy-poems-tap.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Updates Dropdown components internally to adapt to the new Cell `styles` prop.

--- a/__docs__/wonder-blocks-cell/compact-cell.argtypes.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.argtypes.tsx
@@ -52,16 +52,6 @@ export default {
             },
         },
     },
-    contentStyle: {
-        description: `Optional custom styles applied to the content wrapper. For example, it can be used to set a custom minWidth or a custom alignment.`,
-        table: {
-            category: "Styling",
-            type: {
-                summary: "AccessoryStyle",
-                detail: '"minWidth" | "alignSelf" | "alignItems"',
-            },
-        },
-    },
     leftAccessory: {
         description: `If provided, this adds a left accessory to the cell. Left Accessories can be defined using WB components such as PhosphorIcon, IconButton, or it can even be used for a custom node/component if needed. What ever is passed in will occupy the "LeftAccessory” area of the Cell.`,
         control: {type: "select"},
@@ -72,16 +62,6 @@ export default {
             type: {
                 summary: "React.Node",
                 detail: "By default it uses a free width and its default alignment is center (for both vertical and horizontal).",
-            },
-        },
-    },
-    leftAccessoryStyle: {
-        description: `Optional custom styles applied to the leftAccessory wrapper. For example, it can be used to set a custom minWidth or a custom alignment.`,
-        table: {
-            category: "Styling",
-            type: {
-                summary: "AccessoryStyle",
-                detail: "NOTE: leftAccessoryStyle can only be used if leftAccessory is set.",
             },
         },
     },
@@ -98,16 +78,6 @@ export default {
             },
         },
     },
-    rightAccessoryStyle: {
-        description: `Optional custom styles applied to the rightAccessory wrapper. For example, it can be used to set a custom minWidth or a custom alignment.`,
-        table: {
-            category: "Styling",
-            type: {
-                summary: "AccessoryStyle",
-                detail: "NOTE: rightAccessoryStyle can only be used if rightAccessory is set.",
-            },
-        },
-    },
     horizontalRule: {
         description:
             "Adds a horizontal rule at the bottom of the cell that can be used to separate cells within groups such as lists. Defaults to `inset`.",
@@ -121,14 +91,9 @@ export default {
             },
         },
     },
-    style: {
-        description: "Optional custom styles.",
-        control: {type: "object"},
+    styles: {
         table: {
-            category: "Styling",
-            type: {
-                summary: "StyleType",
-            },
+            category: "Layout",
         },
     },
     testId: {

--- a/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
@@ -170,18 +170,20 @@ export const CompactCellAccessoryStyles: StoryComponentType = {
             leftAccessory={
                 <PhosphorIcon icon={IconMappings.article} size="medium" />
             }
-            leftAccessoryStyle={{
-                minWidth: spacing.xxLarge_48,
-                alignSelf: "flex-start",
-                alignItems: "flex-start",
-            }}
             rightAccessory={
                 <PhosphorIcon icon={IconMappings.caretRightBold} size="small" />
             }
-            rightAccessoryStyle={{
-                minWidth: spacing.large_24,
-                alignSelf: "flex-end",
-                alignItems: "flex-end",
+            styles={{
+                leftAccessory: {
+                    minWidth: spacing.xxLarge_48,
+                    alignSelf: "flex-start",
+                    alignItems: "flex-start",
+                },
+                rightAccessory: {
+                    minWidth: spacing.large_24,
+                    alignSelf: "flex-end",
+                    alignItems: "flex-end",
+                },
             }}
         />
     ),

--- a/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
@@ -142,24 +142,23 @@ export const DetailCellWithCustomStyles: StoryComponentType = {
     render: () => (
         <DetailCell
             title="Title for article item"
-            contentStyle={{
-                alignSelf: "flex-start",
-            }}
             leftAccessory={
                 <PhosphorIcon icon={IconMappings.caretLeftBold} size="small" />
             }
-            leftAccessoryStyle={{
-                alignSelf: "flex-start",
-            }}
             rightAccessory={
                 <PhosphorIcon icon={IconMappings.caretRightBold} size="small" />
             }
-            rightAccessoryStyle={{
-                alignSelf: "flex-start",
-            }}
-            style={{
-                textAlign: "center",
-                minHeight: 88,
+            styles={{
+                root: {
+                    textAlign: "center",
+                    minHeight: 88,
+                },
+                leftAccessory: {
+                    alignSelf: "flex-start",
+                },
+                rightAccessory: {
+                    alignSelf: "flex-start",
+                },
             }}
         />
     ),
@@ -383,10 +382,12 @@ export const CustomStyles = {
                 Active
                 <DetailCell
                     {...args}
-                    style={{
-                        borderRadius: border.radius.radius_120,
-                        ":active": {
+                    styles={{
+                        root: {
                             borderRadius: border.radius.radius_120,
+                            ":active": {
+                                borderRadius: border.radius.radius_120,
+                            },
                         },
                     }}
                     active={true}
@@ -394,9 +395,11 @@ export const CustomStyles = {
                 Pressed
                 <DetailCell
                     {...args}
-                    style={{
-                        ":active": {
-                            borderRadius: border.radius.radius_120,
+                    styles={{
+                        root: {
+                            ":active": {
+                                borderRadius: border.radius.radius_120,
+                            },
                         },
                     }}
                 />

--- a/packages/wonder-blocks-cell/src/components/detail-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.tsx
@@ -84,13 +84,15 @@ type DetailCellProps = CellProps & {
  * ```
  */
 const DetailCell = function (props: DetailCellProps): React.ReactElement {
-    const {contentStyle, title, subtitle1, subtitle2, ...coreProps} = props;
+    const {title, subtitle1, subtitle2, ...coreProps} = props;
 
     return (
         <CellCore
             {...coreProps}
             innerStyle={styles.innerWrapper}
-            contentStyle={{gap: theme.root.layout.gap.detail, ...contentStyle}}
+            contentStyle={{
+                gap: theme.root.layout.gap.detail,
+            }}
         >
             <Subtitle subtitle={subtitle1} disabled={coreProps.disabled} />
             {typeof title === "string" ? (

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -15,7 +15,7 @@ import theme from "../../theme";
 
 type LeftAccessoryProps = {
     leftAccessory?: CellProps["leftAccessory"];
-    leftAccessoryStyle?: CellProps["leftAccessoryStyle"];
+    style?: StyleType;
     disabled?: CellProps["disabled"];
 };
 
@@ -25,7 +25,7 @@ type LeftAccessoryProps = {
  */
 const LeftAccessory = ({
     leftAccessory,
-    leftAccessoryStyle,
+    style,
     disabled,
 }: LeftAccessoryProps): React.ReactElement => {
     if (!leftAccessory) {
@@ -39,7 +39,7 @@ const LeftAccessory = ({
                 styles.accessory,
                 styles.accessoryLeft,
                 disabled && styles.accessoryDisabled,
-                {...leftAccessoryStyle},
+                {...style},
             ]}
         >
             {leftAccessory}
@@ -49,7 +49,7 @@ const LeftAccessory = ({
 
 type RightAccessoryProps = {
     rightAccessory?: CellProps["rightAccessory"];
-    rightAccessoryStyle?: CellProps["rightAccessoryStyle"];
+    style?: StyleType;
     active?: CellProps["active"];
     disabled?: CellProps["disabled"];
 };
@@ -60,7 +60,7 @@ type RightAccessoryProps = {
  */
 const RightAccessory = ({
     rightAccessory,
-    rightAccessoryStyle,
+    style,
     active,
     disabled,
 }: RightAccessoryProps): React.ReactElement => {
@@ -75,7 +75,7 @@ const RightAccessory = ({
                 styles.accessory,
                 styles.accessoryRight,
                 disabled && styles.accessoryDisabled,
-                {...rightAccessoryStyle},
+                {...style},
                 active && styles.accessoryActive,
             ]}
         >
@@ -96,9 +96,8 @@ function CellInner(props: CellCoreProps): React.ReactElement {
         disabled,
         contentStyle = undefined,
         leftAccessory = undefined,
-        leftAccessoryStyle = undefined,
         rightAccessory = undefined,
-        rightAccessoryStyle = undefined,
+        styles: stylesProp,
         testId,
     } = props;
 
@@ -107,19 +106,22 @@ function CellInner(props: CellCoreProps): React.ReactElement {
             {/* Left accessory */}
             <LeftAccessory
                 leftAccessory={leftAccessory}
-                leftAccessoryStyle={leftAccessoryStyle}
+                style={stylesProp?.leftAccessory}
                 disabled={disabled}
             />
 
             {/* Cell contents */}
-            <View style={[styles.content, contentStyle]} testId={testId}>
+            <View
+                style={[styles.content, contentStyle, stylesProp?.content]}
+                testId={testId}
+            >
                 {children}
             </View>
 
             {/* Right accessory */}
             <RightAccessory
                 rightAccessory={rightAccessory}
-                rightAccessoryStyle={rightAccessoryStyle}
+                style={stylesProp?.rightAccessory}
                 active={active}
                 disabled={disabled}
             />
@@ -132,6 +134,13 @@ type CellCoreProps = Partial<Omit<CellProps, "title">> & {
      * The content of the cell.
      */
     children: React.ReactNode;
+
+    /**
+     * Optional custom styles applied to the content wrapper. For example, it
+     * can be used to set a custom minWidth or a custom alignment.
+     */
+    contentStyle?: StyleType;
+
     /**
      * The optional styles applied to the inner wrapper.
      *
@@ -163,7 +172,7 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
         tabIndex,
 
         horizontalRule = "inset",
-        style,
+        styles: stylesProp,
         innerStyle,
     } = props;
 
@@ -194,7 +203,7 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
                     styles.clickable,
                     disabled && styles.disabled,
                     // custom styles
-                    style,
+                    stylesProp?.root,
                 ]}
                 aria-current={active ? "true" : undefined}
                 tabIndex={tabIndex}
@@ -210,7 +219,7 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
         <View
             style={[
                 sharedStyles, // custom styles
-                style,
+                stylesProp?.root,
             ]}
             aria-current={active ? "true" : undefined}
             role={role}

--- a/packages/wonder-blocks-cell/src/util/types.ts
+++ b/packages/wonder-blocks-cell/src/util/types.ts
@@ -15,29 +15,6 @@ export type HorizontalRuleVariant = "full-width" | "inset" | "none";
 type Accessory = React.ReactNode;
 
 /**
- * A subset of CSS Properties to allow overriding some of the default styles set
- * on the accessory wrapper (loosely based on StyleType).
- */
-export type AccessoryStyle = {
-    /**
-     * A subset of valid Spacing values.
-     */
-    minWidth?: 16 | 24 | 32 | 48;
-    /**
-     * To vertically align the accessory.
-     */
-    alignSelf?: "flex-start" | "flex-end" | "center";
-    /**
-     * To horizontally align the accessory.
-     */
-    alignItems?: "flex-start" | "flex-end" | "center";
-    /**
-     * To set spacing between child elements.
-     */
-    gap?: number | string;
-};
-
-/**
  * A union that allows using  plain text or WB Typography elements.
  */
 export type TypographyText =
@@ -55,12 +32,6 @@ export type CellProps = {
      */
     title: TypographyText;
     /**
-     * Optional custom styles applied to the content wrapper. For
-     * example, it can be used to set a custom minWidth or a custom
-     * alignment.
-     */
-    contentStyle?: AccessoryStyle;
-    /**
      * If provided, this adds a left accessory to the cell. Left
      * Accessories can be defined using WB components such as Icon,
      * IconButton, or it can even be used for a custom node/component if
@@ -69,14 +40,6 @@ export type CellProps = {
      */
     leftAccessory?: Accessory;
     /**
-     * Optional custom styles applied to the leftAccessory wrapper. For
-     * example, it can be used to set a custom minWidth or a custom
-     * alignment.
-     *
-     * NOTE: leftAccessoryStyle can only be used if leftAccessory is set.
-     */
-    leftAccessoryStyle?: AccessoryStyle;
-    /**
      * If provided, this adds a right accessory to the cell. Right
      * Accessories can be defined using WB components such as Icon,
      * IconButton, or it can even be used for a custom node/component if
@@ -84,15 +47,6 @@ export type CellProps = {
      * area of the Cell.
      */
     rightAccessory?: Accessory;
-    /**
-     * Optional custom styles applied to the rightAccessory wrapper. For
-     * example, it can be used to set a custom minWidth or a custom
-     * alignment.
-     *
-     * NOTE: rightAccessoryStyle can only be used if rightAccessory is
-     * set.
-     */
-    rightAccessoryStyle?: AccessoryStyle;
     /**
      * Adds a horizontal rule at the bottom of the cell that can be used to
      * separate cells within groups such as lists. Defaults to `inset`.
@@ -107,6 +61,18 @@ export type CellProps = {
      * Optional custom styles applied to the cell container.
      */
     style?: StyleType;
+    /**
+     * Custom styles for the elements of Cell. Useful if there are
+     * specific cases where spacing between elements needs to be customized.
+     */
+    styles?: {
+        root?: StyleType;
+        content?: StyleType;
+        // NOTE: This can only be used if leftAccessory is set.
+        leftAccessory?: StyleType;
+        // NOTE: This can only be used if rightAccessory is set.
+        rightAccessory?: StyleType;
+    };
     /**
      * Optional test ID for e2e testing.
      */

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -180,7 +180,13 @@ export default class ActionItem extends React.Component<ActionProps> {
                 horizontalRule={horizontalRule}
                 leftAccessory={leftAccessory}
                 rightAccessory={rightAccessory}
-                style={[defaultStyle, styles.shared, indent && styles.indent]}
+                styles={{
+                    root: [
+                        defaultStyle,
+                        styles.shared,
+                        indent && styles.indent,
+                    ],
+                }}
                 role={role}
                 testId={testId}
                 subtitle1={subtitle1}

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -648,16 +648,18 @@ export default function Combobox({
                                 // No items to display
                                 <DetailCell
                                     title={labels.noItems}
-                                    style={[
-                                        styles.listbox,
-                                        // The listbox width is at least the
-                                        // width of the combobox.
-                                        {
-                                            minWidth:
-                                                rootNodeRef?.current
-                                                    ?.offsetWidth,
-                                        },
-                                    ]}
+                                    styles={{
+                                        root: [
+                                            styles.listbox,
+                                            // The listbox width is at least the
+                                            // width of the combobox.
+                                            {
+                                                minWidth:
+                                                    rootNodeRef?.current
+                                                        ?.offsetWidth,
+                                            },
+                                        ],
+                                    }}
                                     horizontalRule="none"
                                 />
                             ) : (

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -214,12 +214,14 @@ export default class OptionItem extends React.Component<OptionProps> {
             <DetailCell
                 disabled={disabled}
                 horizontalRule={horizontalRule}
-                style={[
-                    defaultStyle,
-                    parentComponent === "listbox"
-                        ? listboxStyles
-                        : selectStyles,
-                ]}
+                styles={{
+                    root: [
+                        defaultStyle,
+                        parentComponent === "listbox"
+                            ? listboxStyles
+                            : selectStyles,
+                    ],
+                }}
                 aria-selected={selected ? "true" : "false"}
                 role={role}
                 testId={testId}


### PR DESCRIPTION
## Summary:

- `Cell`: Removes `contentStyle`, `leftAccessoryStyle`, `rightAccessoryStyle`
and `style` to consolidate it into a single `styles` prop object that contains
all keys.

- `Dropdown`: Updates Dropdown components internally to adapt to the new Cell
`styles` prop.

Issue: https://khanacademy.atlassian.net/browse/WB-1990

## Test plan:

Navigate to the `Cell` and `Dropdown` stories and verify that everything looks
correctly and that the styles are being applied correctly.