### PR TITLE
Banner: Remove `layout` prop

### DIFF
--- a/.changeset/cool-dogs-lay.md
+++ b/.changeset/cool-dogs-lay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-banner": major
+---
+
+Banner: Remove `layout` prop

--- a/__docs__/components/gallery/component-gallery.tsx
+++ b/__docs__/components/gallery/component-gallery.tsx
@@ -31,7 +31,6 @@ export default function ComponentGallery() {
             <View>
                 <Banner
                     kind="info"
-                    layout="floating"
                     text={`Note: The core, data, translations, layout, testing,
                     theming, timing, tokens, and typography packages are not
                     featured in this gallery.`}

--- a/__docs__/components/gallery/tiles/banner-tile.tsx
+++ b/__docs__/components/gallery/tiles/banner-tile.tsx
@@ -15,7 +15,7 @@ export default function BannerTile(props: CommonTileProps) {
                     of informing the user of important changes.`}
             {...props}
         >
-            <Banner text="This is a banner!" layout="floating" />
+            <Banner text="This is a banner!" />
         </ComponentTile>
     );
 }

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -56,7 +56,6 @@ how to use these colors depending on the context.
 <View style={styles.banner}>
     <Banner
         kind="info"
-        layout="full-width"
         text="This is the recommended approach. To use these colors in your project, check out the corresponding tokens page."
         actions={[
             {
@@ -107,7 +106,6 @@ important for ensuring that the text and icons are legible and accessible.
 
 <Banner
     kind="success"
-    layout="full-width"
     text="Make sure to use these colors consistently to ensure readability and accessibility. This includes checking contrast ratios for text and background colors."
     actions={[
         {
@@ -133,7 +131,6 @@ in the system.
 
 <Banner
     kind="success"
-    layout="full-width"
     text="Make sure to use these colors consistently to communicate the same meaning
 and include an icon or label to provide more context and clarity."
     actions={[

--- a/__docs__/wonder-blocks-banner/banner-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner-testing-snapshots.stories.tsx
@@ -127,11 +127,6 @@ export const AllVariantsStory: StoryComponentType = {
                             text={`Custom Icon. ${longText}`}
                             icon={IconMappings.cookieBold}
                         />
-                        <Banner
-                            {...props}
-                            text={`Floating. ${longText}`}
-                            layout="floating"
-                        />
                     </View>
                 )}
             </AllVariants>

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -23,11 +23,6 @@ type StoryComponentType = StoryObj<typeof Banner>;
  * It can be used as a way of informing the user of important changes.
  * Typically, it is displayed toward the top of the screen.
  *
- * There are two possible layouts for banners - floating and full-width. The
- * `floating` layout is intended to be used when there is whitespace around the
- * banner. The `full-width` layout is intended to be used when the banner needs
- * to be flush with surrounding elements.
- *
  * ### Usage
  * ```jsx
  * import Banner from "@khanacademy/wonder-blocks-banner";
@@ -35,7 +30,6 @@ type StoryComponentType = StoryObj<typeof Banner>;
  * <Banner
  *     text="Here is some example text."
  *     kind="success"
- *     layout="floating"
  *     actions={[
  *         {title: "Button 1", onClick: () => {}},
  *         {title: "Button 2", onClick: () => {}},
@@ -97,82 +91,21 @@ export const Kinds: StoryComponentType = {
             <Banner
                 text="kind: info - This is a message about something informative like an announcement."
                 kind="info"
-                layout="floating"
             />
             <Banner
                 text="kind: success - This is a message about something positive or successful!"
                 kind="success"
-                layout="floating"
             />
             <Banner
                 text="kind: warning - This is a message warning the user about a potential issue."
                 kind="warning"
-                layout="floating"
             />
             <Banner
                 text="kind: critical - This is a message about something critical or an error."
                 kind="critical"
-                layout="floating"
             />
         </View>
     ),
-};
-
-/**
- * DEPRECATED: The `layout` prop is deprecated and will be removed in a future
- * release. Currently, it has no effect on the component.
- *
- * Banners come with two layouts: `full-width` and `floating`. Full-width layout
- * gives the banner squared edges, and floating layout gives the banner rounded
- * edges. Floating banners should have space around them and should not be
- * touching other components. The space around floating banners is not
- * automatically added to the container, it must be manually managed by the
- * developer. To demonstrate this, there are also examples with outlines around
- * them - the full-width banner is touching its outline, but padding has been
- * added around the floating banner so that it will not touch its outline.
- */
-export const Layouts: StoryComponentType = () => {
-    const borderStyle = {
-        border: `${border.width.medium} solid ${semanticColor.core.border.knockout.default}`,
-    } as const;
-    const floatingContainerStyle = {padding: sizing.size_080} as const;
-
-    return (
-        <View style={styles.container}>
-            <Banner
-                text="This banner has full-width layout."
-                layout="full-width"
-                kind="success"
-            />
-            <Banner
-                text="This banner has floating layout."
-                layout="floating"
-                kind="success"
-            />
-            <View style={borderStyle}>
-                <Banner
-                    text="This banner has full-width layout. There is no space around it."
-                    layout="full-width"
-                    kind="success"
-                />
-            </View>
-            <View style={[borderStyle, floatingContainerStyle]}>
-                <Banner
-                    text={`This banner has floating layout. Padding has been
-                        added to its container manually in order for the
-                        banner to not touch any other elements.`}
-                    layout="floating"
-                    kind="success"
-                />
-            </View>
-        </View>
-    );
-};
-
-Layouts.parameters = {
-    backgrounds: {
-        default: "neutralStrong",
-    },
 };
 
 /**
@@ -183,7 +116,6 @@ Layouts.parameters = {
 export const LongText: StoryComponentType = {
     args: {
         text: "We couldn't deliver your sign-up email to Adolph.Blaine.Charles.David.Earl.Frederick.Gerald.Hubert.Irvin.John.Kenneth.Lloyd.Martin.Nero.Oliver.Paul.Quincy.Randolph.Sherman.Thomas.Uncas.Victor.William.Xerxes.Yancy.Zeus.Wolfe­schlegel­stein­hausen­berger­dorff­welche­vor­altern­waren­gewissen­haft­schafers­wessen­schafe­waren­wohl­gepflege­und­sorg­faltig­keit­be­schutzen­vor­an­greifen­durch­ihr­raub­gierig­feinde­welche­vor­altern­zwolf­hundert­tausend­jah­res­voran­die­er­scheinen­von­der­erste­erde­mensch­der­raum­schiff­genacht­mit­tung­stein­und­sieben­iridium­elek­trisch­motors­ge­brauch­licht­als­sein­ur­sprung­von­kraft­ge­start­sein­lange­fahrt­hin­zwischen­stern­artig­raum­auf­de­suchen­nach­bar­schaft­der­stern­welche­ge­habt­be­wohn­bar­planeten­kreise­drehen­sich­und­wo­hin­der­neue­rasse­von­ver­stand­ig­mensch­lich­keit­konnte­fort­pflanzen­und­sicher­freuen­an­lebens­lang­lich­freude­und­ru­he­mit­nicht­ein­furcht­vor­an­greifen­vor­anderer­intelligent­ge­schopfs­von­hin­zwischen­stern­art­ig­raum.Sr@khanacademy.org. You may need to change it.",
-        layout: "floating",
         kind: "critical",
         onDismiss: () => {},
         actions: [
@@ -201,10 +133,10 @@ export const LongText: StoryComponentType = {
  */
 export const DarkBackground: StoryComponentType = () => (
     <View style={styles.container}>
-        <Banner text="kind: info" kind="info" layout="full-width" />
-        <Banner text="kind: success" kind="success" layout="full-width" />
-        <Banner text="kind: warning" kind="warning" layout="full-width" />
-        <Banner text="kind: critical" kind="critical" layout="full-width" />
+        <Banner text="kind: info" kind="info" />
+        <Banner text="kind: success" kind="success" />
+        <Banner text="kind: warning" kind="warning" />
+        <Banner text="kind: critical" kind="critical" />
     </View>
 );
 
@@ -266,7 +198,6 @@ export const WithInlineLinks: StoryComponentType = {
             <Banner
                 text="Oh no! The button and link on the right look different! Don't mix button and link actions."
                 kind="critical"
-                layout="floating"
                 actions={[
                     {type: "link", title: "Link", href: "/"},
                     {type: "button", title: "Button", onClick: () => {}},
@@ -285,7 +216,6 @@ export const WithInlineLinks: StoryComponentType = {
                     </>
                 }
                 kind="success"
-                layout="floating"
                 actions={[{type: "button", title: "Button", onClick: () => {}}]}
             />
         </View>
@@ -302,7 +232,6 @@ export const Multiline: StoryComponentType = {
                 text={
                     "This is a multi-line banner. These have wrapping text and actions would be below."
                 }
-                layout="full-width"
             />
         </View>
     ),
@@ -323,7 +252,6 @@ export const MultilineWithButtons: StoryComponentType = {
                     {type: "button", title: "Button 1", onClick: () => {}},
                     {type: "button", title: "Button 2", onClick: () => {}},
                 ]}
-                layout="floating"
             />
         </View>
     ),
@@ -344,7 +272,6 @@ export const MultilineWithLinks: StoryComponentType = {
                     {type: "link", title: "Link 1", href: "/"},
                     {type: "link", title: "Link 2", href: "/"},
                 ]}
-                layout="full-width"
             />
         </View>
     ),
@@ -391,7 +318,6 @@ export const WithDismissal: StoryComponentType = {
                         onClick: handleDismiss,
                     },
                 ]}
-                layout="floating"
                 aria-label="Notification banner."
             />
         );
@@ -413,7 +339,6 @@ export const WithCustomAction: StoryComponentType = {
     render: () => (
         <Banner
             text="some text"
-            layout="floating"
             actions={[
                 {
                     type: "custom",
@@ -444,7 +369,6 @@ export const WithCustomActionPrimary: StoryComponentType = {
     render: () => (
         <Banner
             text="some text"
-            layout="floating"
             actions={[
                 {
                     type: "custom",
@@ -466,7 +390,6 @@ export const WithMixedActions: StoryComponentType = {
     render: () => (
         <Banner
             text="some text"
-            layout="floating"
             actions={[
                 {
                     type: "button",
@@ -519,7 +442,7 @@ export const WithMixedActions: StoryComponentType = {
  *
  * ```jsx
  * import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
- * <Banner icon={magnifyingGlass} layout="floating" text="text" />
+ * <Banner icon={magnifyingGlass} text="text" />
  * ```
  *
  * __Accessibility__: The icon chosen for the banner is decorative and
@@ -531,7 +454,6 @@ export const WithPhosphorIcon: StoryComponentType = {
         <Banner
             icon={magnifyingGlass}
             {...args}
-            layout="floating"
             text="Here is an example with a Phosphor Icon"
         />
     ),
@@ -551,7 +473,7 @@ export const WithPhosphorIcon: StoryComponentType = {
  * // - A path (or paths) scaled up to fit in the 256x256 viewport.
  *
  * import crownIcon from "./icons/crown.svg";
- * <Banner icon={crownIcon} layout="floating" text="text" />
+ * <Banner icon={crownIcon} text="text" />
  * ```
  *
  * __Accessibility__: The icon chosen for the banner is decorative and
@@ -563,7 +485,6 @@ export const WithCustomSolidIcon: StoryComponentType = {
         <Banner
             icon={crownIcon}
             {...args}
-            layout="floating"
             text="Here is an example with a custom icon"
         />
     ),
@@ -620,7 +541,6 @@ export const RightToLeft: StoryComponentType = {
                     {type: "button", title: "پہلا بٹن", onClick: () => {}},
                     {type: "button", title: "دوسرا بٹن", onClick: () => {}},
                 ]}
-                layout="full-width"
             />
             <Banner
                 text="یہ اردو میں لکھا ہے۔"
@@ -628,7 +548,6 @@ export const RightToLeft: StoryComponentType = {
                     {type: "button", title: "پہلا بٹن", onClick: () => {}},
                     {type: "button", title: "دوسرا بٹن", onClick: () => {}},
                 ]}
-                layout="floating"
             />
         </View>
     ),
@@ -660,7 +579,6 @@ export const RightToLeftMultiline: StoryComponentType = {
                     {type: "button", title: "پہلا بٹن", onClick: () => {}},
                     {type: "button", title: "دوسرا بٹن", onClick: () => {}},
                 ]}
-                layout="full-width"
             />
         </View>
     ),
@@ -684,11 +602,7 @@ export const RightToLeftMultiline: StoryComponentType = {
 export const WithCustomStyles: StoryComponentType = {
     render: () => (
         <View style={{height: "500px", width: "300px", gap: sizing.size_160}}>
-            <Banner
-                text={reallyLongText}
-                layout="floating"
-                styles={{root: {flexShrink: 0}}}
-            />
+            <Banner text={reallyLongText} styles={{root: {flexShrink: 0}}} />
             <View
                 style={{
                     backgroundColor:

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -6,7 +6,7 @@ import magnifyingGlass from "@phosphor-icons/core/regular/magnifying-glass.svg";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import Banner from "@khanacademy/wonder-blocks-banner";
 
 import BannerArgTypes from "./banner.argtypes";

--- a/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
@@ -246,10 +246,7 @@ export const Variants: StoryComponentType = {
     decorators: [
         (Story) => (
             <View style={{gap: tokens.spacing.medium_16}}>
-                <Banner
-                    layout="floating"
-                    text="This is a preview of the icons available in the Phosphor Icons package."
-                />
+                <Banner text="This is a preview of the icons available in the Phosphor Icons package." />
                 <Story />
             </View>
         ),

--- a/__docs__/wonder-blocks-styles/__overview__.mdx
+++ b/__docs__/wonder-blocks-styles/__overview__.mdx
@@ -20,7 +20,6 @@ styles as a last resort to enforce consistency across experiences.
 <View style={{marginBlock: spacing.medium_16}}>
     <Banner
         kind="info"
-        layout="full-width"
         text="We highly recommend using existing Wonder Blocks components instead of
         creating your own components. Use these styles to augment existing components
         when necessary."

--- a/packages/wonder-blocks-banner/src/components/__tests__/banner.test.tsx
+++ b/packages/wonder-blocks-banner/src/components/__tests__/banner.test.tsx
@@ -12,7 +12,7 @@ describe("Banner", () => {
         // Arrange
 
         // Act
-        render(<Banner text="test text" layout="floating" />);
+        render(<Banner text="test text" />);
 
         // Assert
         const button = screen.queryByRole("button");
@@ -23,9 +23,7 @@ describe("Banner", () => {
         // Arrange
 
         // Act
-        render(
-            <Banner text="test text" onDismiss={() => {}} layout="floating" />,
-        );
+        render(<Banner text="test text" onDismiss={() => {}} />);
 
         // Assert
         const button = screen.queryByRole("button");
@@ -35,13 +33,7 @@ describe("Banner", () => {
     test("clicking the dismiss button triggers `onDismiss`", () => {
         // Arrange
         const onDismissSpy = jest.fn();
-        render(
-            <Banner
-                text="test text"
-                onDismiss={onDismissSpy}
-                layout="floating"
-            />,
-        );
+        render(<Banner text="test text" onDismiss={onDismissSpy} />);
 
         // Act
         const button = screen.getByRole("button");
@@ -58,7 +50,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {
                         type: "link",
@@ -82,7 +73,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {type: "button", title: "some button", onClick: () => {}},
                 ]}
@@ -101,7 +91,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="some text"
-                layout="floating"
                 actions={[
                     {
                         type: "custom",
@@ -133,7 +122,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {type: "button", title: "button 1", onClick: () => {}},
                     {type: "button", title: "button 2", onClick: () => {}},
@@ -166,7 +154,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {type: "button", title: "a button", onClick: actionSpy},
                 ]}
@@ -188,7 +175,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {
                         type: "link",
@@ -214,7 +200,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {
                         type: "link",
@@ -239,7 +224,7 @@ describe("Banner", () => {
         // Arrange
 
         // Act
-        render(<Banner text="test text" layout="floating" />);
+        render(<Banner text="test text" />);
 
         // Assert
         const icon = screen.getByTestId("banner-kind-icon");
@@ -252,7 +237,7 @@ describe("Banner", () => {
             // Arrange
 
             // Act
-            render(<Banner text="test text" kind={kind} layout="floating" />);
+            render(<Banner text="test text" kind={kind} />);
 
             // Assert
             const icon = screen.getByTestId("banner-kind-icon");
@@ -266,9 +251,7 @@ describe("Banner", () => {
         // Arrange
 
         // Act
-        render(
-            <Banner text="test text" layout="floating" onDismiss={() => {}} />,
-        );
+        render(<Banner text="test text" onDismiss={() => {}} />);
 
         // Assert
         const dismissButton = screen.getByRole("button");
@@ -282,7 +265,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 onDismiss={() => {}}
                 dismissAriaLabel="Test dismiss aria label"
             />,
@@ -303,7 +285,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {
                         type: "button",
@@ -326,7 +307,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[{type: "link", title: "Test link title", href: "/"}]}
             />,
         );
@@ -343,7 +323,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {
                         type: "button",
@@ -370,7 +349,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="floating"
                 actions={[
                     {
                         type: "link",
@@ -403,7 +381,6 @@ describe("Banner", () => {
             <Banner
                 text="test text"
                 kind={kind}
-                layout="floating"
                 testId="wonder-blocks-banner-test-id"
             />,
         );
@@ -421,7 +398,6 @@ describe("Banner", () => {
             <Banner
                 text="test text"
                 kind="warning"
-                layout="floating"
                 testId="wonder-blocks-banner-test-id"
             />,
         );
@@ -438,7 +414,6 @@ describe("Banner", () => {
         render(
             <Banner
                 text="test text"
-                layout="full-width"
                 testId="wonder-blocks-banner-test-id"
                 aria-label="This is a banner aria label."
             />,
@@ -460,7 +435,6 @@ describe("Banner", () => {
             render(
                 <Banner
                     text="test text"
-                    layout="full-width"
                     testId="wonder-blocks-banner-test-id"
                     aria-label="This is a banner aria label."
                     kind="warning"
@@ -481,7 +455,6 @@ describe("Banner", () => {
             render(
                 <Banner
                     text="test text"
-                    layout="full-width"
                     testId="wonder-blocks-banner-test-id"
                     aria-label="This is a banner aria label."
                     kind="warning"
@@ -501,7 +474,6 @@ describe("Banner", () => {
             render(
                 <Banner
                     text="test text"
-                    layout="full-width"
                     testId="wonder-blocks-banner-test-id"
                     aria-label="This is a banner aria label."
                     kind="warning"
@@ -522,7 +494,6 @@ describe("Banner", () => {
             render(
                 <Banner
                     text="test text"
-                    layout="full-width"
                     testId="wonder-blocks-banner-test-id"
                     aria-label="This is a banner aria label."
                     kind="warning"

--- a/packages/wonder-blocks-banner/src/components/banner.tsx
+++ b/packages/wonder-blocks-banner/src/components/banner.tsx
@@ -60,17 +60,6 @@ type BannerKind =
      */
     | "critical";
 
-type BannerLayout =
-    /**
-     * Renders a rounded rectangle, usually for when banner is used as an inset
-     * element on a screen (e.g., the SOT card) that appears to be floating.
-     */
-    | "floating"
-    /**
-     * Renders a full-width banner, with no rounded corners.
-     */
-    | "full-width";
-
 type BannerValues = {
     icon: PhosphorIconAsset;
     role: "status" | "alert";
@@ -87,15 +76,6 @@ type Props = {
      * Determines the color and icon of the banner.
      */
     kind?: BannerKind;
-    /**
-     * (DEPRECATED) Determines the edge style of the Banner.
-     *
-     * This prop is deprecated and will be removed in a future release.
-     * Currently, it has no effect on the component.
-     *
-     * @deprecated
-     */
-    layout?: BannerLayout;
     /**
      * Text on the banner or a node if you want something different. For the
      * best results, use the default styles provided by the Banner component and
@@ -204,11 +184,6 @@ const StyledDiv = addStyle("div");
  * It can be used as a way of informing the user of important changes.
  * Typically, it is displayed toward the top of the screen.
  *
- * There are two possible layouts for banners - floating and full-width.
- * The `floating` layout is intended to be used when there is whitespace
- * around the banner. The `full-width` layout is intended to be used when
- * the banner needs to be flush with surrounding elements.
- *
  * ### Usage
  * ```jsx
  * import Banner from "@khanacademy/wonder-blocks-banner";
@@ -216,7 +191,6 @@ const StyledDiv = addStyle("div");
  * <Banner
  *     text="Here is some example text."
  *     kind="success"
- *     layout="floating"
  *     actions={[
  *         {title: "Button 1", onClick: () => {}},
  *         {title: "Button 2", onClick: () => {}},


### PR DESCRIPTION
## Summary:

When we worked on supporting the Thunderblocks theme, we decided not to support different layouts in the Banner component anymore, so the layout prop is not currently used.

In this PR, we remove the `layout` prop and the use of the `layout` prop within WB.

This is a breaking change since the `layout` prop is removed from the API. 

Note: This PR should only be landed and released once the Perseus PR to remove the layout prop usage has been landed and deployed in `frontend` 

Issue: WB-1979

## Test plan:
1. Confirm the Banner layout prop is no longer used or documented

## Implementation plan:

1. Make the Banner `layout` prop optional https://github.com/Khan/wonder-blocks/pull/2792
2. Update WB in `frontend` and remove usage of `layout` prop 
  - update WB https://github.com/Khan/frontend/pull/3860
  - remove usage of `layout` prop https://github.com/Khan/frontend/pull/3828
3. Update WB in `perseus` and remove usage of `layout` prop https://github.com/Khan/frontend/pull/3828
4. (this PR) Remove `layout` prop in WB (breaking change)
5. Integrate WB into `frontend`