### PR TITLE
TextArea: Support dynamic content sizing

### DIFF
--- a/.changeset/spotty-balloons-swim.md
+++ b/.changeset/spotty-balloons-swim.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-form": minor
 ---
 
-TextArea: Add `autoResize` and `maxRows` props
+TextArea: Add `autoResize` and `maxRows` props. The `resizeType` prop is deprecated in favour of these new props.

--- a/.changeset/spotty-balloons-swim.md
+++ b/.changeset/spotty-balloons-swim.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+TextArea: Add `autoResize` and `maxRows` props

--- a/__docs__/components/text-for-testing.ts
+++ b/__docs__/components/text-for-testing.ts
@@ -8,6 +8,12 @@ export const reallyLongText =
 export const reallyLongTextWithNoWordBreak =
     "LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequatDuisauteiruredolorinreprehenderitinvoluptatevelitessecillumdoloreeufugiatnullapariaturExcepteursintoccaecatcupidatatnonproidentsuntinculpaquiofficiadeseruntmollitanimidestlaborum";
 
+/**
+ * A utility function to repeat text a given number of times.
+ * @param text - The text to repeat.
+ * @param times - The number of times to repeat the text.
+ * @returns The repeated text.
+ */
 export function repeatText(text: string, times: number) {
     return Array.from({length: times}, () => text).join(" ");
 }

--- a/__docs__/components/text-for-testing.ts
+++ b/__docs__/components/text-for-testing.ts
@@ -7,3 +7,7 @@ export const reallyLongText =
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 export const reallyLongTextWithNoWordBreak =
     "LoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequatDuisauteiruredolorinreprehenderitinvoluptatevelitessecillumdoloreeufugiatnullapariaturExcepteursintoccaecatcupidatatnonproidentsuntinculpaquiofficiadeseruntmollitanimidestlaborum";
+
+export function repeatText(text: string, times: number) {
+    return Array.from({length: times}, () => text).join(" ");
+}

--- a/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
@@ -13,6 +13,7 @@ import {
     repeatText,
 } from "../components/text-for-testing";
 import {AllVariants} from "../components/all-variants";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -247,7 +248,10 @@ export const Scenarios: Story = {
             },
         ];
         return (
-            <ScenariosLayout scenarios={scenarios}>
+            <ScenariosLayout
+                scenarios={scenarios}
+                styles={{root: {paddingBlockEnd: sizing.size_240}}}
+            >
                 {(props, name) => (
                     <LabeledField
                         label="Text Area"

--- a/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
@@ -189,10 +189,58 @@ export const Scenarios: Story = {
                 },
             },
             {
+                name: "Auto resize is true with rows = 10 and value is short",
+                props: {
+                    autoResize: true,
+                    value: longText,
+                    rows: 10,
+                },
+            },
+            {
                 name: "Auto-resize is true with rows = 4 and maxRows = 2 (rows > maxRows)",
                 props: {
                     autoResize: true,
                     value: repeatText(reallyLongText, 3),
+                    rows: 4,
+                    maxRows: 2,
+                },
+            },
+            {
+                name: "Using Placeholder: Auto resize is true with default maxRows of 6",
+                props: {
+                    autoResize: true,
+                    placeholder: repeatText(reallyLongText, 3),
+                },
+            },
+            {
+                name: "Using Placeholder: Auto resize is true with maxRows = 10",
+                props: {
+                    autoResize: true,
+                    placeholder: repeatText(reallyLongText, 3),
+                    maxRows: 10,
+                },
+            },
+            {
+                name: "Using Placeholder: Auto resize is true with rows = 30",
+                props: {
+                    autoResize: true,
+                    placeholder: repeatText(reallyLongText, 4),
+                    rows: 30,
+                },
+            },
+            {
+                name: "Auto resize is true with rows = 10 and placeholder is short",
+                props: {
+                    autoResize: true,
+                    placeholder: longText,
+                    rows: 10,
+                },
+            },
+            {
+                name: "Using Placeholder: Auto-resize is true with rows = 4 and maxRows = 2 (rows > maxRows)",
+                props: {
+                    autoResize: true,
+                    placeholder: repeatText(reallyLongText, 3),
                     rows: 4,
                     maxRows: 2,
                 },

--- a/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
 
+import {StyleSheet} from "aphrodite";
 import {TextArea} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {themeModes} from "../../.storybook/modes";
@@ -9,6 +10,8 @@ import {ScenariosLayout} from "../components/scenarios-layout";
 import {
     longText,
     longTextWithNoWordBreak,
+    reallyLongText,
+    repeatText,
 } from "../components/text-for-testing";
 import {AllVariants} from "../components/all-variants";
 
@@ -29,6 +32,12 @@ export default {
 type Story = StoryObj<typeof TextArea>;
 
 const rows = [{name: "Default", props: {}}];
+
+const styles = StyleSheet.create({
+    fixedWidth: {
+        width: "500px",
+    },
+});
 
 const columns = [
     {
@@ -143,6 +152,62 @@ export const Scenarios: Story = {
             {
                 name: "With Placeholder (long, no word breaks)",
                 props: {placeholder: longTextWithNoWordBreak},
+            },
+            {
+                name: "With rows = 10",
+                props: {rows: 10},
+            },
+            {
+                name: "With rows = 10 and value",
+                props: {rows: 10, value: repeatText(longText, 3)},
+            },
+            {
+                name: "Empty and auto resize is false",
+                props: {autoResize: false, style: styles.fixedWidth},
+            },
+            {
+                name: "With value and auto resize is false",
+                props: {
+                    autoResize: false,
+                    style: styles.fixedWidth,
+                    value: repeatText(longText, 3),
+                },
+            },
+            {
+                name: "Auto resize is true with default maxRows of 6",
+                props: {
+                    autoResize: true,
+                    value: repeatText(reallyLongText, 3),
+                    style: styles.fixedWidth,
+                },
+            },
+            {
+                name: "Auto resize is true with maxRows = 10",
+                props: {
+                    autoResize: true,
+                    value: repeatText(reallyLongText, 3),
+                    maxRows: 10,
+                    style: styles.fixedWidth,
+                },
+            },
+            {
+                name: "Auto resize is true with rows = 30",
+                props: {
+                    autoResize: true,
+                    value: repeatText(reallyLongText, 3),
+                    rows: 30,
+                    style: styles.fixedWidth,
+                },
+            },
+            {
+                name: "Auto-resize is true with rows = 4 and maxRows = 2 (rows > maxRows)",
+                props: {
+                    autoResize: true,
+                    value: repeatText(reallyLongText, 3),
+                    rows: 4,
+                    maxRows: 2,
+                    style: styles.fixedWidth,
+                },
             },
         ];
         return (

--- a/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react";
 
-import {StyleSheet} from "aphrodite";
 import {TextArea} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {themeModes} from "../../.storybook/modes";
@@ -32,12 +31,6 @@ export default {
 type Story = StoryObj<typeof TextArea>;
 
 const rows = [{name: "Default", props: {}}];
-
-const styles = StyleSheet.create({
-    fixedWidth: {
-        width: "500px",
-    },
-});
 
 const columns = [
     {
@@ -163,13 +156,12 @@ export const Scenarios: Story = {
             },
             {
                 name: "Empty and auto resize is false",
-                props: {autoResize: false, style: styles.fixedWidth},
+                props: {autoResize: false},
             },
             {
                 name: "With value and auto resize is false",
                 props: {
                     autoResize: false,
-                    style: styles.fixedWidth,
                     value: repeatText(longText, 3),
                 },
             },
@@ -178,7 +170,6 @@ export const Scenarios: Story = {
                 props: {
                     autoResize: true,
                     value: repeatText(reallyLongText, 3),
-                    style: styles.fixedWidth,
                 },
             },
             {
@@ -187,7 +178,6 @@ export const Scenarios: Story = {
                     autoResize: true,
                     value: repeatText(reallyLongText, 3),
                     maxRows: 10,
-                    style: styles.fixedWidth,
                 },
             },
             {
@@ -196,7 +186,6 @@ export const Scenarios: Story = {
                     autoResize: true,
                     value: repeatText(reallyLongText, 3),
                     rows: 30,
-                    style: styles.fixedWidth,
                 },
             },
             {
@@ -206,7 +195,6 @@ export const Scenarios: Story = {
                     value: repeatText(reallyLongText, 3),
                     rows: 4,
                     maxRows: 2,
-                    style: styles.fixedWidth,
                 },
             },
         ];

--- a/__docs__/wonder-blocks-form/text-area.argtypes.ts
+++ b/__docs__/wonder-blocks-form/text-area.argtypes.ts
@@ -26,6 +26,13 @@ export default {
             type: "text",
         },
     },
+    resizeType: {
+        table: {
+            type: {
+                summary: `"horizontal" | "vertical" | "both" | "none"`,
+            },
+        },
+    },
     /**
      * Visual Style
      */

--- a/__docs__/wonder-blocks-form/text-area.argtypes.ts
+++ b/__docs__/wonder-blocks-form/text-area.argtypes.ts
@@ -26,13 +26,6 @@ export default {
             type: "text",
         },
     },
-    resizeType: {
-        table: {
-            type: {
-                summary: `"horizontal" | "vertical" | "both" | "none"`,
-            },
-        },
-    },
     /**
      * Visual Style
      */

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -434,11 +434,6 @@ export const Required: StoryComponentType = {
 
 /**
  * The number of rows to use by default can be specified using the `rows` prop.
- * This will be ignored if:
- * - the height is set on the textarea using CSS
- *
- * It is often helpful to set the initial number of rows based on how much
- * content we expect from the user.
  */
 export const Rows: StoryComponentType = {
     args: {

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -173,15 +173,6 @@ export const WithValue: ControlledStoryComponentType = {
 };
 
 /**
- * The `rows` prop can be used to set the number of rows to show by default.
- */
-export const Rows: StoryComponentType = {
-    args: {
-        rows: 10,
-    },
-};
-
-/**
  * The `autoResize` prop can be used to automatically resize the textarea to fit
  * the content. By default, `autoResize` is `true`.
  *
@@ -496,6 +487,15 @@ export const Required: StoryComponentType = {
 };
 
 /**
+ * The `rows` prop can be used to set the number of rows to show by default.
+ */
+export const Rows: StoryComponentType = {
+    args: {
+        rows: 10,
+    },
+};
+
+/**
  * If the `autoComplete` prop is set, the browser can predict values for the
  * textarea. For more details, see the
  * [MDN docs for the textarea attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attributes).
@@ -692,6 +692,48 @@ export const MinMaxLength: StoryComponentType = {
             // Disabling because this doesn't test anything visual.
             disableSnapshot: true,
         },
+    },
+};
+
+/**
+ * The behaviour of the built-in resize control can be configured using the
+ * `resizeType` prop. Here are some tips:
+ * - The initial size of the TextArea can be configured using the `rows` prop.
+ * This size should be large enough for the expected user input.
+ * - Avoid having too small of a TextArea and having `resizeType=none`. This
+ * makes it difficult for users to scroll through their input.
+ */
+export const ResizeType: StoryComponentType = {
+    args: {},
+    render(args) {
+        return (
+            <div>
+                <LabeledField
+                    label="Resize Type: both"
+                    field={<TextArea {...args} resizeType="both" />}
+                />
+                <br />
+                <LabeledField
+                    label="Resize Type: vertical"
+                    field={<TextArea {...args} resizeType="vertical" />}
+                />
+                <br />
+                <LabeledField
+                    label="Resize Type: horizontal"
+                    field={<TextArea {...args} resizeType="horizontal" />}
+                />
+                <br />
+                <LabeledField
+                    label="Resize Type: none"
+                    field={<TextArea {...args} resizeType="none" />}
+                />
+                <br />
+                <LabeledField
+                    label="Resize Type: default (both)"
+                    field={<TextArea {...args} />}
+                />
+            </div>
+        );
     },
 };
 

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -15,7 +15,11 @@ import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 
 import TextAreaArgTypes from "./text-area.argtypes";
 import {validateEmail} from "./form-utilities";
-import {reallyLongText, repeatText} from "../components/text-for-testing";
+import {
+    longText,
+    reallyLongText,
+    repeatText,
+} from "../components/text-for-testing";
 
 /**
  * A TextArea is an element used to accept text from the user.
@@ -61,7 +65,6 @@ const styles = StyleSheet.create({
     customField: {
         backgroundColor: semanticColor.status.notice.background,
         color: semanticColor.status.notice.foreground,
-        border: "none",
         maxWidth: 250,
         "::placeholder": {
             color: semanticColor.core.foreground.neutral.default,
@@ -187,12 +190,18 @@ export const WithValue: ControlledStoryComponentType = {
 export const AutoResize: StoryComponentType = {
     render: (args) => {
         return (
-            <View style={{gap: spacing.large_24, width: "500px"}}>
+            <View style={{gap: spacing.large_24, maxWidth: "500px"}}>
                 <ControlledTextArea
                     {...args}
                     autoResize={false}
                     label="Auto resize is false"
                     value={repeatText(reallyLongText, 3)}
+                />
+                <ControlledTextArea
+                    {...args}
+                    autoResize={true}
+                    label="Auto resize is true"
+                    value={repeatText(longText, 2)}
                 />
                 <ControlledTextArea
                     {...args}

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -65,6 +65,7 @@ const styles = StyleSheet.create({
     customField: {
         backgroundColor: semanticColor.status.notice.background,
         color: semanticColor.status.notice.foreground,
+        border: "none",
         maxWidth: 250,
         "::placeholder": {
             color: semanticColor.core.foreground.neutral.default,

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -15,6 +15,7 @@ import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 
 import TextAreaArgTypes from "./text-area.argtypes";
 import {validateEmail} from "./form-utilities";
+import {reallyLongText, repeatText} from "../components/text-for-testing";
 
 /**
  * A TextArea is an element used to accept text from the user.
@@ -169,6 +170,62 @@ export const WithValue: ControlledStoryComponentType = {
         label: "With Value",
     },
     render: ControlledTextArea,
+};
+
+/**
+ * The `rows` prop can be used to set the number of rows to show by default.
+ */
+export const Rows: StoryComponentType = {
+    args: {
+        rows: 10,
+    },
+};
+
+/**
+ * The `autoResize` prop can be used to automatically resize the textarea to fit
+ * the content. By default, `autoResize` is `true`.
+ *
+ * There is also a `maxRows` prop that can be used to set the maximum number of
+ * rows to show when `autoResize` is enabled. If the content exceeds the max
+ * number of rows, the textarea will become scrollable. By default, `maxRows`
+ * is 6.
+ *
+ * When `autoResize` is enabled, the `rows` prop is used as the starting and
+ * minimum height. If `rows > maxRows`, `rows` will be used for `maxRows`.
+ */
+export const AutoResize: StoryComponentType = {
+    render: (args) => {
+        return (
+            <View style={{gap: spacing.large_24, width: "500px"}}>
+                <ControlledTextArea
+                    {...args}
+                    autoResize={false}
+                    label="Auto resize is false"
+                    value={repeatText(reallyLongText, 3)}
+                />
+                <ControlledTextArea
+                    {...args}
+                    autoResize={true}
+                    label="Auto resize is true with default maxRows"
+                    value={repeatText(reallyLongText, 3)}
+                />
+                <ControlledTextArea
+                    {...args}
+                    autoResize={true}
+                    label="Auto resize is true with maxRows = 30"
+                    value={repeatText(reallyLongText, 3)}
+                    maxRows={30}
+                />
+                <ControlledTextArea
+                    {...args}
+                    autoResize={true}
+                    label="Auto resize is true with rows = 30"
+                    value={repeatText(reallyLongText, 3)}
+                    rows={30}
+                />
+            </View>
+        );
+    },
 };
 
 /**
@@ -429,15 +486,6 @@ export const Required: StoryComponentType = {
             // Disabling because this doesn't test anything visual.
             disableSnapshot: true,
         },
-    },
-};
-
-/**
- * The number of rows to use by default can be specified using the `rows` prop.
- */
-export const Rows: StoryComponentType = {
-    args: {
-        rows: 10,
     },
 };
 

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -226,6 +226,12 @@ export const AutoResize: StoryComponentType = {
             </View>
         );
     },
+    parameters: {
+        chromatic: {
+            // Disabling because it is covered by scenarios
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -436,7 +436,6 @@ export const Required: StoryComponentType = {
  * The number of rows to use by default can be specified using the `rows` prop.
  * This will be ignored if:
  * - the height is set on the textarea using CSS
- * - the user resizes the textarea using the built-in resize control
  *
  * It is often helpful to set the initial number of rows based on how much
  * content we expect from the user.
@@ -644,48 +643,6 @@ export const MinMaxLength: StoryComponentType = {
             // Disabling because this doesn't test anything visual.
             disableSnapshot: true,
         },
-    },
-};
-
-/**
- * The behaviour of the built-in resize control can be configured using the
- * `resizeType` prop. Here are some tips:
- * - The initial size of the TextArea can be configured using the `rows` prop.
- * This size should be large enough for the expected user input.
- * - Avoid having too small of a TextArea and having `resizeType=none`. This
- * makes it difficult for users to scroll through their input.
- */
-export const ResizeType: StoryComponentType = {
-    args: {},
-    render(args) {
-        return (
-            <div>
-                <LabeledField
-                    label="Resize Type: both"
-                    field={<TextArea {...args} resizeType="both" />}
-                />
-                <br />
-                <LabeledField
-                    label="Resize Type: vertical"
-                    field={<TextArea {...args} resizeType="vertical" />}
-                />
-                <br />
-                <LabeledField
-                    label="Resize Type: horizontal"
-                    field={<TextArea {...args} resizeType="horizontal" />}
-                />
-                <br />
-                <LabeledField
-                    label="Resize Type: none"
-                    field={<TextArea {...args} resizeType="none" />}
-                />
-                <br />
-                <LabeledField
-                    label="Resize Type: default (both)"
-                    field={<TextArea {...args} />}
-                />
-            </div>
-        );
     },
 };
 

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -174,7 +174,7 @@ export const WithValue: ControlledStoryComponentType = {
 
 /**
  * The `autoResize` prop can be used to automatically resize the textarea to fit
- * the content. By default, `autoResize` is `true`.
+ * the content. By default, `autoResize` is `false`.
  *
  * There is also a `maxRows` prop that can be used to set the maximum number of
  * rows to show when `autoResize` is enabled. If the content exceeds the max

--- a/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/text-area.test.tsx
@@ -213,21 +213,6 @@ describe("TextArea", () => {
             expect(textArea).toHaveClass(className);
         });
 
-        it("should set the rows attribute when the rows prop is provided", async () => {
-            // Arrange
-            const rows = 10;
-            render(
-                <TextArea value="Text" onChange={() => {}} rows={rows} />,
-                defaultOptions,
-            );
-
-            // Act
-
-            // Assert
-            const textArea = await screen.findByRole("textbox");
-            expect(textArea).toHaveAttribute("rows", `${rows}`);
-        });
-
         it("should set the spellcheck attribute when spellCheck prop is set to true", async () => {
             // Arrange
             render(

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -331,7 +331,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                             : {
                                   // Dynamically set the height if field-sizing is
                                   // not supported
-                                  height: `${height}px`,
+                                  height: `calc(${height}px + 2px)`,
                               },
                         style,
                     ]}

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -212,7 +212,7 @@ const StyledTextarea = addStyle("textarea");
  * Height = (number of rows * line height) + (2 * vertical padding) + (2 * border width)
  */
 function getHeightForNumberOfRows(rows: number) {
-    return `calc(${rows}lh + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`;
+    return `calc((${rows} * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`;
 }
 
 /**

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -184,6 +184,7 @@ type TextAreaProps = AriaProps & {
      */
     required?: boolean | string;
     /**
+     * @deprecated This prop is deprecated in favour of the `autoResize` prop.
      * Specifies the resizing behaviour for the textarea. Defaults to both
      * behaviour. For more details, see the [CSS resize property values MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/resize#values)
      */

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -221,6 +221,33 @@ function getHeightForNumberOfRows(rows: number) {
 }
 
 /**
+ * Calculate the height of a textarea element.
+ * @param textArea - The textarea element.
+ * @returns The height of the textarea element.
+ */
+function getTextAreaHeight(textArea: HTMLTextAreaElement) {
+    // Save the original style properties
+    const originalHeight = textArea.style.height;
+    const originalOverflow = textArea.style.overflow;
+
+    // Force the textarea to shrink by setting height to 0 and hiding overflow
+    textArea.style.setProperty("height", "0px", "important");
+    textArea.style.setProperty("overflow", "hidden", "important");
+    // Now get the actual scrollHeight needed for the content
+    const newHeight = textArea.scrollHeight;
+
+    // Restore the original styles (remove !important)
+    textArea.style.removeProperty("height");
+    textArea.style.removeProperty("overflow");
+    if (originalHeight) {
+        textArea.style.height = originalHeight;
+    }
+    if (originalOverflow) {
+        textArea.style.overflow = originalOverflow;
+    }
+    return newHeight;
+}
+/**
  * A TextArea is an element used to accept text from the user.
  *
  * Make sure to provide a label for the field. This can be done by either:
@@ -291,29 +318,6 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
         const generatedUniqueId = useId();
         const uniqueId = id ?? generatedUniqueId;
-
-        const getTextAreaHeight = (textArea: HTMLTextAreaElement) => {
-            // Save the original style properties
-            const originalHeight = textArea.style.height;
-            const originalOverflow = textArea.style.overflow;
-
-            // Force the textarea to shrink by setting height to 0 and hiding overflow
-            textArea.style.setProperty("height", "0px", "important");
-            textArea.style.setProperty("overflow", "hidden", "important");
-            // Now get the actual scrollHeight needed for the content
-            const newHeight = textArea.scrollHeight;
-
-            // Restore the original styles (remove !important)
-            textArea.style.removeProperty("height");
-            textArea.style.removeProperty("overflow");
-            if (originalHeight) {
-                textArea.style.height = originalHeight;
-            }
-            if (originalOverflow) {
-                textArea.style.overflow = originalOverflow;
-            }
-            return newHeight;
-        };
 
         const handleChange = (
             event: React.ChangeEvent<HTMLTextAreaElement>,

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -227,7 +227,7 @@ function getHeightForNumberOfRows(rows: number) {
  * @returns The height to use for the textarea element.
  */
 function getTextAreaHeight(textArea: HTMLTextAreaElement): string {
-    // Save the original style properties. Note this is only gets the value from
+    // Save the original style properties. Note this only gets the value from
     // the style object, not the computed style which considers css classes
     const originalStyleHeightValue = textArea.style.getPropertyValue("height");
     const originalStyleHeightPriority =

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -73,6 +73,15 @@ type TextAreaProps = AriaProps & {
      */
     autoFocus?: boolean;
     /**
+     * The number of visible lines of text for the textarea. Defaults to 2.
+     *
+     * If `autoResize` is `true`, `rows` is the starting number of rows and more
+     * content increases the number of rows, up until the `maxRows` prop value
+     * is reached. If `autoResize` is `false`, the textarea will be scrollable
+     * with the number of rows set by the `rows` prop.
+     */
+    rows?: number;
+    /**
      * Determines if the textarea should be checked for spelling by the browser/OS.
      * By default, it is enabled. It will be checked for spelling when you try
      * to edit it (ie. once the textarea is focused). For more details, see the
@@ -175,14 +184,10 @@ type TextAreaProps = AriaProps & {
      */
     required?: boolean | string;
     /**
-     * The number of visible lines of text for the textarea. Defaults to 2.
-     *
-     * If `autoResize` is `true`, `rows` is the starting number of rows and more
-     * content increases the number of rows, up until the `maxRows` prop value
-     * is reached. If `autoResize` is `false`, the textarea will be scrollable
-     * with the number of rows set by the `rows` prop.
+     * Specifies the resizing behaviour for the textarea. Defaults to both
+     * behaviour. For more details, see the [CSS resize property values MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/resize#values)
      */
-    rows?: number;
+    resizeType?: "horizontal" | "vertical" | "both" | "none";
     /**
      * Whether the textarea should automatically resize to fit the content.
      * If `true`, the textarea will resize to fit the content. If `false`,
@@ -258,6 +263,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             validate,
             onValidate,
             required,
+            resizeType,
             rootStyle,
             error,
             autoResize = true,
@@ -352,21 +358,16 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             }
         });
 
-        const autoResizeStyles = autoResize
-            ? [
-                  {
-                      // Dynamically set the height. We account for the border
-                      // width so the scrollbar is not shown.
-                      height: `calc(${height}px + (2 * ${border.width.thin}))`,
-                  },
-                  {
-                      // Set the max height so the textarea can't grow infinitely
-                      maxHeight: getHeightForNumberOfRows(
-                          Math.max(maxRows, rows),
-                      ),
-                  },
-              ]
-            : [];
+        const autoResizeStyles = [
+            {
+                // Dynamically set the height. We account for the border
+                // width so the scrollbar is not shown.
+                height: `calc(${height}px + (2 * ${border.width.thin}))`,
+                // Set the max height so the textarea can't grow infinitely
+                maxHeight: getHeightForNumberOfRows(Math.max(maxRows, rows)),
+            },
+            styles.autoResize,
+        ];
 
         return (
             <View
@@ -381,6 +382,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     style={[
                         styles.textarea,
                         typographyStyles.BodyTextMediumMediumWeight,
+                        resizeType && resizeStyles[resizeType],
                         styles.default,
                         disabled && styles.disabled,
                         hasError && styles.error,
@@ -389,7 +391,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                             // Set the min height to the height of the number of rows
                             minHeight: getHeightForNumberOfRows(rows),
                         },
-                        ...autoResizeStyles,
+                        autoResize && autoResizeStyles,
                         style,
                     ]}
                     value={value}
@@ -426,6 +428,8 @@ const styles = StyleSheet.create({
         boxSizing: "border-box",
         paddingInline: theme.field.layout.paddingInline,
         paddingBlock: theme.field.layout.paddingBlock,
+    },
+    autoResize: {
         // Disable the resize control
         resize: "none",
     },
@@ -464,6 +468,21 @@ const styles = StyleSheet.create({
         "::placeholder": {
             color: semanticColor.input.default.placeholder,
         },
+    },
+});
+
+const resizeStyles = StyleSheet.create({
+    both: {
+        resize: "both",
+    },
+    none: {
+        resize: "none",
+    },
+    horizontal: {
+        resize: "horizontal",
+    },
+    vertical: {
+        resize: "vertical",
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -266,7 +266,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             resizeType,
             rootStyle,
             error,
-            autoResize = true,
+            autoResize = false,
             maxRows = 6,
             instantValidation = true,
             // Should only include aria related props

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -7,7 +7,7 @@ import {
     addStyle,
     View,
 } from "@khanacademy/wonder-blocks-core";
-import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {border, font, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {useId} from "react";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
@@ -213,7 +213,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             name,
             className,
             autoFocus,
-            rows,
+            rows = 2,
             spellCheck,
             wrap,
             minLength,
@@ -279,6 +279,14 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                         disabled && styles.disabled,
                         hasError && styles.error,
                         readOnly && styles.readOnly,
+                        rows && {
+                            // Calculate the size of x number of rows, including
+                            // padding and border. We do this because the `row`
+                            // attribute is not used when `field-sizing` is also
+                            // used.
+                            // Min height = (number of rows * line height) + (2 * vertical padding) + (2 * border width)
+                            minHeight: `calc((${rows} * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
+                        },
                         style,
                     ]}
                     value={value}
@@ -289,7 +297,6 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     autoComplete={autoComplete}
                     name={name}
                     autoFocus={autoFocus}
-                    rows={rows}
                     spellCheck={spellCheck}
                     wrap={wrap}
                     minLength={minLength}
@@ -316,8 +323,11 @@ const styles = StyleSheet.create({
         boxSizing: "border-box",
         paddingInline: theme.field.layout.paddingInline,
         paddingBlock: theme.field.layout.paddingBlock,
-        // This minHeight is equivalent to when the textarea has one row
-        minHeight: theme.field.sizing.height,
+        // Disable the resize control
+        resize: "none",
+        // For browsers that support field-sizing, set it to content so that
+        // the textarea can grow to fit the content
+        ["fieldSizing" as any]: "content",
     },
     readOnly: {
         background: semanticColor.input.readOnly.background,

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -206,6 +206,15 @@ type TextAreaProps = AriaProps & {
 const StyledTextarea = addStyle("textarea");
 
 /**
+ * Calculate the height of x number of rows, including padding and border.
+ *
+ * Height = (number of rows * line height) + (2 * vertical padding) + (2 * border width)
+ */
+function getHeightForNumberOfRows(rows: number) {
+    return `calc((${rows} * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`;
+}
+
+/**
  * A TextArea is an element used to accept text from the user.
  *
  * Make sure to provide a label for the field. This can be done by either:
@@ -354,11 +363,15 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                       ? styles.fieldSizing
                       : {
                             // Dynamically set the height if field-sizing is
-                            // not supported
-                            height: `calc(${height}px + 2px)`,
+                            // not supported. We account for the border width
+                            // so the scrollbar is not shown.
+                            height: `calc(${height}px + (2 * ${border.width.thin}))`,
                         },
                   {
-                      maxHeight: `calc(${Math.max(maxRows, rows)} * ${font.body.lineHeight.medium} + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
+                      // Set the max height so the textarea can't grow infinitely
+                      maxHeight: getHeightForNumberOfRows(
+                          Math.max(maxRows, rows),
+                      ),
                   },
               ]
             : [];
@@ -381,12 +394,9 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                         hasError && styles.error,
                         readOnly && styles.readOnly,
                         rows && {
-                            // Calculate the size of x number of rows, including
-                            // padding and border. We do this because the `row`
-                            // attribute is not used when `field-sizing` is also
-                            // used.
-                            // Min height = (number of rows * line height) + (2 * vertical padding) + (2 * border width)
-                            minHeight: `calc((${rows} * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
+                            // Set the min height to the height of the number of rows
+                            // This is because `rows` is not applied when `field-sizing` is also used.
+                            minHeight: getHeightForNumberOfRows(rows),
                         },
                         ...autoResizeStyles,
                         style,
@@ -432,10 +442,6 @@ const styles = StyleSheet.create({
         // For browsers that support field-sizing, set it to content so that
         // the textarea can grow to fit the content
         ["fieldSizing" as any]: "content",
-    },
-    sixRowsMaxHeight: {
-        // Set max height to 6 rows of text + padding + border
-        maxHeight: `calc((6 * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
     },
     readOnly: {
         background: semanticColor.input.readOnly.background,

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -278,12 +278,8 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             });
 
         const textAreaContainerRef = React.useRef<HTMLDivElement>(null);
-        // Keep track of the textarea height for browsers that don't support
-        // field-sizing.
+
         const [height, setHeight] = React.useState(0);
-        const [supportsFieldSizing] = React.useState(
-            CSS.supports("field-sizing", "content"),
-        );
 
         const hasError = error || !!errorMessage;
 
@@ -320,9 +316,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             onChangeValidation(newValue);
             onChange(newValue);
 
-            if (!supportsFieldSizing) {
-                setHeight(getTextAreaHeight(event.target));
-            }
+            setHeight(getTextAreaHeight(event.target));
         };
 
         const handleBlur = (event: React.FocusEvent<HTMLTextAreaElement>) => {
@@ -339,7 +333,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             // directly.
             const ref = textAreaContainerRef.current?.children[0];
 
-            if (!supportsFieldSizing && ref && window?.ResizeObserver) {
+            if (ref && window?.ResizeObserver) {
                 const observer = new window.ResizeObserver(([entry]) => {
                     if (entry) {
                         setHeight(
@@ -360,14 +354,11 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
         const autoResizeStyles = autoResize
             ? [
-                  supportsFieldSizing
-                      ? styles.fieldSizing
-                      : {
-                            // Dynamically set the height if field-sizing is
-                            // not supported. We account for the border width
-                            // so the scrollbar is not shown.
-                            height: `calc(${height}px + (2 * ${border.width.thin}))`,
-                        },
+                  {
+                      // Dynamically set the height. We account for the border
+                      // width so the scrollbar is not shown.
+                      height: `calc(${height}px + (2 * ${border.width.thin}))`,
+                  },
                   {
                       // Set the max height so the textarea can't grow infinitely
                       maxHeight: getHeightForNumberOfRows(
@@ -396,7 +387,6 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                         readOnly && styles.readOnly,
                         rows && {
                             // Set the min height to the height of the number of rows
-                            // This is because `rows` is not applied when `field-sizing` is also used.
                             minHeight: getHeightForNumberOfRows(rows),
                         },
                         ...autoResizeStyles,
@@ -438,12 +428,6 @@ const styles = StyleSheet.create({
         paddingBlock: theme.field.layout.paddingBlock,
         // Disable the resize control
         resize: "none",
-        minWidth: "28rem",
-    },
-    fieldSizing: {
-        // For browsers that support field-sizing, set it to content so that
-        // the textarea can grow to fit the content
-        ["fieldSizing" as any]: "content",
     },
     readOnly: {
         background: semanticColor.input.readOnly.background,

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -212,7 +212,7 @@ const StyledTextarea = addStyle("textarea");
  * Height = (number of rows * line height) + (2 * vertical padding) + (2 * border width)
  */
 function getHeightForNumberOfRows(rows: number) {
-    return `calc((${rows} * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`;
+    return `calc(${rows}lh + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`;
 }
 
 /**

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -73,10 +73,12 @@ type TextAreaProps = AriaProps & {
      */
     autoFocus?: boolean;
     /**
-     * The number of visible lines of text for the textarea.
-     * By default, 2 rows are shown.
-     * `rows` is ignored if a height is applied to the textarea using CSS.
-     * The number of rows can change if the resize control is used by the user.
+     * The number of visible lines of text for the textarea. Defaults to 2.
+     *
+     * If `autoResize` is `true`, `rows` is the starting number of rows and more
+     * content increases the number of rows, up until the `maxRows` prop value
+     * is reached. If `autoResize` is `false`, the textarea will be scrollable
+     * with the number of rows set by the `rows` prop.
      */
     rows?: number;
     /**

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -359,6 +359,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         });
 
         const autoResizeStyles = [
+            styles.autoResize,
             {
                 // Dynamically set the height. We account for the border
                 // width so the scrollbar is not shown.
@@ -366,7 +367,6 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                 // Set the max height so the textarea can't grow infinitely
                 maxHeight: getHeightForNumberOfRows(Math.max(maxRows, rows)),
             },
-            styles.autoResize,
         ];
 
         return (

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -227,10 +227,15 @@ function getHeightForNumberOfRows(rows: number) {
  * @returns The height to use for the textarea element.
  */
 function getTextAreaHeight(textArea: HTMLTextAreaElement): string {
-    // Save the original style properties
-    const style = getComputedStyle(textArea);
-    const originalHeight = style.height;
-    const originalOverflow = style.overflow;
+    // Save the original style properties. Note this is only gets the value from
+    // the style object, not the computed style which considers css classes
+    const originalStyleHeightValue = textArea.style.getPropertyValue("height");
+    const originalStyleHeightPriority =
+        textArea.style.getPropertyPriority("height");
+    const originalStyleOverflowValue =
+        textArea.style.getPropertyValue("overflow");
+    const originalStyleOverflowPriority =
+        textArea.style.getPropertyPriority("overflow");
 
     // Force the textarea to shrink by setting height to 0 and hiding overflow.
     textArea.style.setProperty("height", "0px", "important");
@@ -238,19 +243,32 @@ function getTextAreaHeight(textArea: HTMLTextAreaElement): string {
 
     // Get the scrollHeight needed for the content. We account for the border
     // width so the scrollbar is not shown.
-    const borderTop = style.borderTopWidth;
-    const borderBottom = style.borderBottomWidth;
+    const computedStyle = getComputedStyle(textArea);
+    const borderTop = computedStyle.borderTopWidth;
+    const borderBottom = computedStyle.borderBottomWidth;
     const newHeight = `calc(${textArea.scrollHeight}px + ${borderTop} + ${borderBottom})`;
 
-    // Restore the original styles (remove !important)
-    textArea.style.removeProperty("height");
-    textArea.style.removeProperty("overflow");
-    if (originalHeight) {
-        textArea.style.height = originalHeight;
+    // Restore the original style properties if they were set. Otherwise, remove
+    // the temporary properties used to calculate the content height.
+    if (originalStyleHeightValue) {
+        textArea.style.setProperty(
+            "height",
+            originalStyleHeightValue,
+            originalStyleHeightPriority,
+        );
+    } else {
+        textArea.style.removeProperty("height");
     }
-    if (originalOverflow) {
-        textArea.style.overflow = originalOverflow;
+    if (originalStyleOverflowValue) {
+        textArea.style.setProperty(
+            "overflow",
+            originalStyleOverflowValue,
+            originalStyleOverflowPriority,
+        );
+    } else {
+        textArea.style.removeProperty("overflow");
     }
+
     return newHeight;
 }
 /**

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -326,7 +326,11 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             onChangeValidation(newValue);
             onChange(newValue);
 
-            setHeight(getTextAreaHeight(event.target));
+            // When the textarea value is changed, we need to recalculate the
+            // height if autoResize is true
+            if (autoResize) {
+                setHeight(getTextAreaHeight(event.target));
+            }
         };
 
         const handleBlur = (event: React.FocusEvent<HTMLTextAreaElement>) => {
@@ -338,6 +342,10 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         };
 
         useOnMountEffect(() => {
+            // If autoResize is false, we don't need to set up the resize observer
+            if (!autoResize) {
+                return;
+            }
             // We use a ref to the container to get the child textarea element
             // so that consumers can pass in a ref to the textarea element
             // directly.
@@ -346,6 +354,9 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             if (ref && window?.ResizeObserver) {
                 const observer = new window.ResizeObserver(([entry]) => {
                     if (entry) {
+                        // When the resize observer is triggered from things like
+                        // a change in size or zoom level, we need to recalculate
+                        // the height
                         setHeight(
                             getTextAreaHeight(
                                 entry.target as HTMLTextAreaElement,

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -73,15 +73,6 @@ type TextAreaProps = AriaProps & {
      */
     autoFocus?: boolean;
     /**
-     * The number of visible lines of text for the textarea. Defaults to 2.
-     *
-     * If `autoResize` is `true`, `rows` is the starting number of rows and more
-     * content increases the number of rows, up until the `maxRows` prop value
-     * is reached. If `autoResize` is `false`, the textarea will be scrollable
-     * with the number of rows set by the `rows` prop.
-     */
-    rows?: number;
-    /**
      * Determines if the textarea should be checked for spelling by the browser/OS.
      * By default, it is enabled. It will be checked for spelling when you try
      * to edit it (ie. once the textarea is focused). For more details, see the
@@ -183,7 +174,15 @@ type TextAreaProps = AriaProps & {
      * will be used.
      */
     required?: boolean | string;
-
+    /**
+     * The number of visible lines of text for the textarea. Defaults to 2.
+     *
+     * If `autoResize` is `true`, `rows` is the starting number of rows and more
+     * content increases the number of rows, up until the `maxRows` prop value
+     * is reached. If `autoResize` is `false`, the textarea will be scrollable
+     * with the number of rows set by the `rows` prop.
+     */
+    rows?: number;
     /**
      * Whether the textarea should automatically resize to fit the content.
      * If `true`, the textarea will resize to fit the content. If `false`,

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -373,6 +373,8 @@ const styles = StyleSheet.create({
         paddingBlock: theme.field.layout.paddingBlock,
         // Disable the resize control
         resize: "none",
+        // Set max height to 6 rows of text + padding + border
+        maxHeight: `calc((6 * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
     },
     fieldSizing: {
         // For browsers that support field-sizing, set it to content so that

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -195,7 +195,7 @@ type TextAreaProps = AriaProps & {
      * the textarea will not change in size and the textarea will be scrollable if
      * content exceeds the height of the textarea.
      *
-     * Defaults to `true`.
+     * Defaults to `false`.
      *
      * See related `maxRows` prop for setting the max height for the textarea.
      */
@@ -222,7 +222,7 @@ function getHeightForNumberOfRows(rows: number) {
 }
 
 /**
- * Calculate the height of a textarea element.
+ * Calculate the height needed for a textarea element to fit the content
  * @param textArea - The textarea element.
  * @returns The height to use for the textarea element.
  */
@@ -232,11 +232,11 @@ function getTextAreaHeight(textArea: HTMLTextAreaElement): string {
     const originalHeight = style.height;
     const originalOverflow = style.overflow;
 
-    // Force the textarea to shrink by setting height to 0 and hiding overflow
+    // Force the textarea to shrink by setting height to 0 and hiding overflow.
     textArea.style.setProperty("height", "0px", "important");
     textArea.style.setProperty("overflow", "hidden", "important");
 
-    // Now get the actual scrollHeight needed for the content. We account for the border
+    // Get the scrollHeight needed for the content. We account for the border
     // width so the scrollbar is not shown.
     const borderTop = style.borderTopWidth;
     const borderBottom = style.borderBottomWidth;

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -181,6 +181,22 @@ type TextAreaProps = AriaProps & {
      * will be used.
      */
     required?: boolean | string;
+
+    /**
+     * Whether the textarea should automatically resize to fit the content.
+     * If `true`, the textarea will resize to fit the content. If `false`,
+     * the textarea will not change in size and the textarea will be scrollable if
+     * content exceeds the height of the textarea.
+     *
+     * Defaults to `true`.
+     *
+     * Note: When `autoResize` is `true` and `rows` is set to a value <= 6, the
+     * textarea will become scrollable after 6 rows. This is to prevent the
+     * textarea from becoming too tall by default. If `rows > 6`, the textarea
+     * will have no max height set. In both cases, the maxHeight can be
+     * overridden using the `style` prop.
+     */
+    autoResize?: boolean;
 };
 
 const StyledTextarea = addStyle("textarea");
@@ -230,6 +246,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             required,
             rootStyle,
             error,
+            autoResize = true,
             instantValidation = true,
             // Should only include aria related props
             ...otherProps
@@ -326,6 +343,20 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             }
         });
 
+        const autoResizeStyles = autoResize
+            ? [
+                  supportsFieldSizing
+                      ? styles.fieldSizing
+                      : {
+                            // Dynamically set the height if field-sizing is
+                            // not supported
+                            height: `calc(${height}px + 2px)`,
+                        },
+                  // If the number of rows is <= 6, set the max height to 6 rows. Otherwise, there is no max height set.
+                  rows <= 6 && styles.sixRowsMaxHeight,
+              ]
+            : [];
+
         return (
             <View
                 style={[{width: "100%"}, rootStyle]}
@@ -351,15 +382,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                             // Min height = (number of rows * line height) + (2 * vertical padding) + (2 * border width)
                             minHeight: `calc((${rows} * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
                         },
-                        supportsFieldSizing
-                            ? styles.fieldSizing
-                            : {
-                                  // Dynamically set the height if field-sizing is
-                                  // not supported
-                                  height: `calc(${height}px + 2px)`,
-                              },
-                        // If the number of rows is <= 6, set the max height to 6 rows. Otherwise, there is no max height set.
-                        rows <= 6 && styles.sixRowsMaxHeight,
+                        ...autoResizeStyles,
                         style,
                     ]}
                     value={value}

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -190,13 +190,17 @@ type TextAreaProps = AriaProps & {
      *
      * Defaults to `true`.
      *
-     * Note: When `autoResize` is `true` and `rows` is set to a value <= 6, the
-     * textarea will become scrollable after 6 rows. This is to prevent the
-     * textarea from becoming too tall by default. If `rows > 6`, the textarea
-     * will have no max height set. In both cases, the maxHeight can be
-     * overridden using the `style` prop.
+     * See related `maxRows` prop for setting the max height for the textarea.
      */
     autoResize?: boolean;
+    /**
+     * The maximum number of rows to show when `autoResize` is `true` to prevent
+     * the textarea from becoming too tall. The textarea will become scrollable
+     * if content exceeds the max number of rows.
+     *
+     * Defaults to 6. If `rows` > `maxRows`, `rows` will be used for `maxRows`.
+     */
+    maxRows?: number;
 };
 
 const StyledTextarea = addStyle("textarea");
@@ -247,6 +251,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             rootStyle,
             error,
             autoResize = true,
+            maxRows = 6,
             instantValidation = true,
             // Should only include aria related props
             ...otherProps
@@ -352,8 +357,9 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                             // not supported
                             height: `calc(${height}px + 2px)`,
                         },
-                  // If the number of rows is <= 6, set the max height to 6 rows. Otherwise, there is no max height set.
-                  rows <= 6 && styles.sixRowsMaxHeight,
+                  {
+                      maxHeight: `calc(${Math.max(maxRows, rows)} * ${font.body.lineHeight.medium} + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
+                  },
               ]
             : [];
 

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -180,11 +180,6 @@ type TextAreaProps = AriaProps & {
      * will be used.
      */
     required?: boolean | string;
-    /**
-     * Specifies the resizing behaviour for the textarea. Defaults to both
-     * behaviour. For more details, see the [CSS resize property values MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/resize#values)
-     */
-    resizeType?: "horizontal" | "vertical" | "both" | "none";
 };
 
 const StyledTextarea = addStyle("textarea");
@@ -232,7 +227,6 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             validate,
             onValidate,
             required,
-            resizeType,
             rootStyle,
             error,
             instantValidation = true,
@@ -281,7 +275,6 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     style={[
                         styles.textarea,
                         typographyStyles.BodyTextMediumMediumWeight,
-                        resizeType && resizeStyles[resizeType],
                         styles.default,
                         disabled && styles.disabled,
                         hasError && styles.error,
@@ -361,21 +354,6 @@ const styles = StyleSheet.create({
         "::placeholder": {
             color: semanticColor.input.default.placeholder,
         },
-    },
-});
-
-const resizeStyles = StyleSheet.create({
-    both: {
-        resize: "both",
-    },
-    none: {
-        resize: "none",
-    },
-    horizontal: {
-        resize: "horizontal",
-    },
-    vertical: {
-        resize: "vertical",
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -438,6 +438,7 @@ const styles = StyleSheet.create({
         paddingBlock: theme.field.layout.paddingBlock,
         // Disable the resize control
         resize: "none",
+        minWidth: "28rem",
     },
     fieldSizing: {
         // For browsers that support field-sizing, set it to content so that

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -332,8 +332,6 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                                   // Dynamically set the height if field-sizing is
                                   // not supported
                                   height: `${height}px`,
-                                  // Hide overflow to make sure scrollbar isn't shown
-                                  overflow: "hidden",
                               },
                         style,
                     ]}

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -332,6 +332,8 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                                   // Dynamically set the height if field-sizing is
                                   // not supported
                                   height: `${height}px`,
+                                  // Hide overflow to make sure scrollbar isn't shown
+                                  overflow: "hidden",
                               },
                         style,
                     ]}

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -408,6 +408,18 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
             },
         ];
 
+        React.useEffect(() => {
+            // If `autoResize` becomes `true`, we need to recalculate the height
+            if (autoResize) {
+                setHeight(
+                    getTextAreaHeight(
+                        textAreaContainerRef.current
+                            ?.children[0] as HTMLTextAreaElement,
+                    ),
+                );
+            }
+        }, [autoResize, ref]);
+
         return (
             <View
                 style={[{width: "100%"}, rootStyle]}

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -358,6 +358,8 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                                   // not supported
                                   height: `calc(${height}px + 2px)`,
                               },
+                        // If the number of rows is <= 6, set the max height to 6 rows. Otherwise, there is no max height set.
+                        rows <= 6 && styles.sixRowsMaxHeight,
                         style,
                     ]}
                     value={value}
@@ -396,13 +398,15 @@ const styles = StyleSheet.create({
         paddingBlock: theme.field.layout.paddingBlock,
         // Disable the resize control
         resize: "none",
-        // Set max height to 6 rows of text + padding + border
-        maxHeight: `calc((6 * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
     },
     fieldSizing: {
         // For browsers that support field-sizing, set it to content so that
         // the textarea can grow to fit the content
         ["fieldSizing" as any]: "content",
+    },
+    sixRowsMaxHeight: {
+        // Set max height to 6 rows of text + padding + border
+        maxHeight: `calc((6 * ${font.body.lineHeight.medium}) + (2 * ${theme.field.layout.paddingBlock}) + (2 * ${border.width.thin}))`,
     },
     readOnly: {
         background: semanticColor.input.readOnly.background,


### PR DESCRIPTION
## Summary:

Implements the following changes to the TextArea component:
- `autoResize (defaults to false)` (new) - enables the textarea element to grow/shrink based on the content 
- `maxRows` (new) - limits the number of rows shown before becoming scrollable. This prevents the textarea from infinitely expanding
- `resizeType` (deprecated) - we mark this prop as deprecated in favour of the `autoResize` prop. We don't remove this prop yet so that this change isn't a breaking change. It'll be removed in a future version

Context around decisions made for this implementation: 
- Using JS to calculate the needed content height when the content changes or a resize observer is triggered
  - Explored using [field-sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/field-sizing) for dynamic content sizing. The drawbacks were:
    - it is experimental still and not fully supported by all browsers. We would need the JS logic anyways as a fallback. It will be less maintenance for us to have one implementation for the behaviour, rather than switching implementations based on browser support!
    - `field-sizing` makes it so the width of an element is also dynamic, not just the height. This would be a more involved change since it would have an impact on the current TextArea usage. We only need dynamic content sizing vertically, which we can control with the custom implementation
- `autoResize` defaulting to `false`
  - I think long term, we want `autoResize` to default to `true`. I propose we let it be something opted into so that this initial release isn't a breaking change. Also, since we are manually updating the height when content changes, it is less performant than when the height is static and the TextArea becomes scrollable. Let me know though if anyone has any thoughts on this! 


Issue: WB-1843

## Test plan:
1. Confirm existing TextArea features work as expected `/?path=/docs/packages-form-textarea--docs`
2. Confirm TextArea auto-resizing works as expected (`/?path=/story/packages-form-textarea--auto-resize` and `?path=/story/packages-form-testing-snapshots-textarea--scenarios`). Some test cases:
  - adding text or new lines should cause the textarea to grow (up until the maxRows point)
  - if textarea has reached the max number of rows, the textarea should be scrollable
  - removing text should cause the textarea to shrink
  - pasting in text or removing a chunk of text should cause the textarea to grow/shrink accordingly
  - changing the zoom level or screen size should cause the textarea to grow/shrink accordingly
  - similar test cases for placeholder content, instead of the textarea value content