### PR TITLE
docs: Fix package name for Tabs docs

### DIFF
--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from "@storybook/react";
 import {action} from "@storybook/addon-actions";
 import {expect, within} from "@storybook/test";
 import ComponentInfo from "../components/component-info";
-import packageConfig from "../../packages/wonder-blocks-form/package.json";
+import packageConfig from "../../packages/wonder-blocks-tabs/package.json";
 import {
     Tab,
     TabItem,


### PR DESCRIPTION
## Summary:

Importing the correct `package.json` for the `Tabs` docs

Issue: WB-XXXX

## Test plan:
1. The Tabs docs should have information about the `@khanacademy/wonder-blocks-tabs` package name and version (`?path=/docs/packages-tabs-tabs--docs`)