### PR TITLE
[WB-2101] Fix left-aligned dropdown components to be right-aligned

### DIFF
--- a/.changeset/fifty-bottles-happen.md
+++ b/.changeset/fifty-bottles-happen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+Updates styles to support RTL

--- a/.changeset/happy-trains-swim.md
+++ b/.changeset/happy-trains-swim.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-cell": patch
+---
+
+Updates styles to support RTL

--- a/__docs__/components/scenarios-layout.tsx
+++ b/__docs__/components/scenarios-layout.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import type {StrictArgs} from "@storybook/react-vite";
 import {StyleSheet} from "aphrodite";
 import {StyleType, View} from "@khanacademy/wonder-blocks-core";
@@ -6,7 +6,11 @@ import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 type Props = {
-    scenarios: {name: string; props: StrictArgs}[];
+    scenarios: {
+        name: string;
+        props: StrictArgs;
+        decorator?: React.ReactElement;
+    }[];
     children: (props: any, name: string) => React.ReactNode;
     styles?: {
         root?: StyleType;
@@ -23,10 +27,16 @@ export const ScenariosLayout = (props: Props) => {
     return (
         <View style={[styles.container, stylesProp?.root]}>
             {scenarios.map((scenario) => {
+                const renderer = children(scenario.props, scenario.name);
+                const {decorator: Decorator} = scenario;
                 return (
                     <View key={scenario.name} style={styles.scenario}>
                         <LabelLarge>{scenario.name}</LabelLarge>
-                        {children(scenario.props, scenario.name)}
+                        {Decorator
+                            ? React.cloneElement(Decorator, {
+                                  children: renderer,
+                              })
+                            : renderer}
                     </View>
                 );
             })}

--- a/__docs__/wonder-blocks-cell/compact-cell-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell-testing-snapshots.stories.tsx
@@ -138,6 +138,11 @@ export const Scenarios: Story = {
                     rightAccessory: undefined,
                 },
             },
+            {
+                name: "Right to Left",
+                props: {...defaultProps, title: longTextWithNoWordBreak},
+                decorator: <div dir="rtl" />,
+            },
         ];
 
         return (

--- a/__docs__/wonder-blocks-cell/detail-cell-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell-testing-snapshots.stories.tsx
@@ -179,6 +179,11 @@ export const Scenarios: Story = {
                     rightAccessory: undefined,
                 },
             },
+            {
+                name: "Right to Left",
+                props: {...defaultProps, title: longTextWithNoWordBreak},
+                decorator: <div dir="rtl" />,
+            },
         ];
 
         return (

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -820,6 +820,16 @@ export const CustomOpener: StoryComponentType = {
 };
 
 /**
+ * When in the right-to-left direction, the single select is mirrored.
+ */
+export const RightToLeft: StoryComponentType = {
+    ...ControlledOpened,
+    globals: {
+        direction: "rtl",
+    },
+};
+
+/**
  * Custom labels
  */
 const translatedItems = [

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -824,6 +824,7 @@ export const CustomOpener: StoryComponentType = {
  */
 export const RightToLeft: StoryComponentType = {
     ...ControlledOpened,
+    name: "Right to Left",
     globals: {
         direction: "rtl",
     },

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -238,7 +238,7 @@ const styles = StyleSheet.create({
         // Hide overflow so that if custom styling applies a border radius, the
         // left visual indicator for press/active states does not overflow
         overflow: "hidden",
-        textAlign: "left",
+        textAlign: "start",
         width: "100%",
         // layout
         // We need to specify flex as the wrapper can be a <View> or a


### PR DESCRIPTION
## Summary:

- Cell: Updates styles to support RTL.
- Tooling: Adds a `decorator` field to ScenariosLayout.
- Docs: adds RTL stories for Cell and SingleSelect.

Issue: https://khanacademy.atlassian.net/browse/WB-2101

## Test plan:

Navigate to the docs and verify that the new RTL stories render correctly.

- `/?path=/story/packages-dropdown-singleselect--right-to-left&globals=backgrounds.value:baseDefault;backgrounds.grid:!undefined;;direction:rtl`