### PR TITLE
WB-2067: Prevent premature announcements in SingleSelect and MultiSelect

### DIFF
--- a/.changeset/fluffy-glasses-rest.md
+++ b/.changeset/fluffy-glasses-rest.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Prevents announcements on initial render

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -187,6 +187,63 @@ export const Default: StoryComponentType = {
     },
 };
 
+const studentData = [
+    {kaid: "kaid_1", coachNickname: "Alice Smith"},
+    {kaid: "kaid_2", coachNickname: "Bob Jones"},
+    {kaid: "kaid_3", coachNickname: "Carol Wilson"},
+    {kaid: "kaid_4", coachNickname: "David Brown"},
+    {kaid: "kaid_5", coachNickname: "Eve Taylor"},
+];
+
+const studentLabels: LabelsValues = {
+    clearSearch: "Clear search",
+    filter: "Search",
+    noResults: "None found",
+    selectAllLabel: (count) =>
+        count === 1 ? "Select 1 student" : `Select all ${count} students`,
+    selectNoneLabel: "Clear selection",
+    noneSelected: "No students",
+    someSelected: (numSelected) =>
+        numSelected === 1 ? "1 student" : `${numSelected} students`,
+    allSelected: "All students",
+};
+
+/**
+ * This example demonstrates a StudentMultiSelect with all students initially selected.
+ * The screen reader will not announce the initial values on mount, but will
+ * announce when values change through user interaction.
+ */
+export const StudentMultiSelect: StoryComponentType = {
+    render: function Render() {
+        const [selectedValues, setSelectedValues] = React.useState(
+            studentData.map((student) => student.kaid),
+        );
+        const [opened, setOpened] = React.useState(false);
+
+        return (
+            <MultiSelect
+                aria-label="Students"
+                id="students-multiselect"
+                onChange={setSelectedValues}
+                selectedValues={selectedValues}
+                shortcuts={true}
+                isFilterable={true}
+                labels={studentLabels}
+                opened={opened}
+                onToggle={setOpened}
+            >
+                {studentData.map((student) => (
+                    <OptionItem
+                        key={student.kaid}
+                        label={student.coachNickname}
+                        value={student.kaid}
+                    />
+                ))}
+            </MultiSelect>
+        );
+    },
+};
+
 /**
  * The field can be used with the LabeledField component to provide a label,
  * description, required indicator, and/or error message for the field.

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -242,6 +242,12 @@ export const StudentMultiSelect: StoryComponentType = {
             </MultiSelect>
         );
     },
+    parameters: {
+        chromatic: {
+            // Disabling because this is for manual testing purposes
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -209,6 +209,18 @@ export const Default: StoryComponentType = {
 };
 
 /**
+ * This example demonstrates how SingleSelect behaves with an initial value.
+ * The screen reader will not announce the initial value on mount, but will
+ * announce when the value changes through user interaction.
+ */
+export const WithInitialValue: StoryComponentType = {
+    render: Template,
+    args: {
+        selectedValue: "banana",
+    },
+};
+
+/**
  * The field can be used with the LabeledField component to provide a label,
  * description, required indicator, and/or error message for the field.
  *

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -218,6 +218,12 @@ export const WithInitialValue: StoryComponentType = {
     args: {
         selectedValue: "banana",
     },
+    parameters: {
+        chromatic: {
+            // Disabling because this is for manual testing purposes
+            disableSnapshot: true,
+        },
+    },
 };
 
 /**

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -237,6 +237,7 @@ type Props = AriaProps &
  * ```
  */
 const MultiSelect = (props: Props) => {
+    const isInitialRender = React.useRef(true);
     const {
         id,
         opener,
@@ -569,6 +570,11 @@ const MultiSelect = (props: Props) => {
     );
 
     React.useEffect(() => {
+        if (isInitialRender.current) {
+            isInitialRender.current = false;
+            return;
+        }
+
         const optionItems = React.Children.toArray(
             children,
         ) as OptionItemComponentArray;

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -259,6 +259,7 @@ type Props = AriaProps &
  */
 const SingleSelect = (props: Props) => {
     const selectedIndex = React.useRef(0);
+    const isInitialRender = React.useRef(true);
     const {
         children,
         error = false,
@@ -437,8 +438,13 @@ const SingleSelect = (props: Props) => {
         });
     };
 
-    // Announce when selectedValue or children changes in the opener
+    // Announce when selectedValue or children changes in the opener, but skip initial render
     React.useEffect(() => {
+        if (isInitialRender.current) {
+            isInitialRender.current = false;
+            return;
+        }
+
         const optionItems = React.Children.toArray(
             children,
         ) as OptionItemComponentArray;


### PR DESCRIPTION
## Summary:
To work around combobox bugs in Safari and VoiceOver, SingleSelect and MultiSelect were augmented with an Announcer integration. In practice, when a default value is set (such as "All Students" in a filter), an announcement is made on page load. The announcement is pretty random and confusing when a user isn't interacting with a dropdown. It also runs the risk of conflicting with other announcements on the page, such as client-side routing announcements or skeleton loader techniques.

In this PR, I add a flag for initial rendering that prevents the initial announcement on page load. There should still be announcements when the dropdown is opened, items filtered, and item(s) selected.

Issue: WB-2067

## Test plan:
1. Review "initial render" stories with VoiceOver turned on, listening for no announcement on page load
2. Compare to a deployed version in prod, such as the students filter on `https://classroom.khanacademy.org/teacher/class/DHJ9MS88/reports/khanmigo-activity`
3. Ensure tests pass

## Screenshots

[Before] - Storybook: "All students" filter story on WB > main branch. Announcement happens on load

<img width="563" height="366" alt="Screenshot 2025-10-01 at 4 18 01 PM" src="https://github.com/user-attachments/assets/95a74467-aad3-4fe3-9750-1bfc56b63279" />

[After] - Storybook: "All students" filter story on WB > this branch. No announcement on load.

<img width="671" height="345" alt="Screenshot 2025-10-01 at 4 19 46 PM" src="https://github.com/user-attachments/assets/ea769dba-3603-4a26-b287-a6a6e48a1699" />

[Before] - Frontend: "All students" on TX experience with announcement on load, how I originally found this issue

<img width="2079" height="1312" alt="Screenshot 2025-10-01 at 4 13 27 PM" src="https://github.com/user-attachments/assets/e1047d73-8272-4e8f-8f89-9b60637c7784" />

Note: after story for Frontend will happen when I create a snapshot integration PR from this one