### PR TITLE
FlexibleDialog: Fix positioning at middle breakpoint size

### DIFF
--- a/.changeset/brave-books-attend.md
+++ b/.changeset/brave-books-attend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Removes mobile media query in FlexibleDialog causing incorrect positioning

--- a/packages/wonder-blocks-modal/src/components/flexible-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/flexible-dialog.tsx
@@ -194,12 +194,6 @@ const componentStyles = StyleSheet.create({
         maxHeight: "100vh",
         maxWidth: 576,
         width: "93.75%",
-
-        [breakpoint.mediaQuery.sm]: {
-            height: "100vh",
-            maxHeight: "100vh",
-            width: "100%",
-        },
     },
 });
 

--- a/packages/wonder-blocks-modal/src/components/flexible-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/flexible-dialog.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import {breakpoint, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {Heading} from "@khanacademy/wonder-blocks-typography";
 import FlexiblePanel from "./flexible-panel";
 import theme from "../theme";


### PR DESCRIPTION
## Summary:
Removes a media query breakpoint that was causing positioning to be lost at in-between sizes

Before:
<img width="668" height="1012" alt="Modal dialog in Storybook positioned at top of screen" src="https://github.com/user-attachments/assets/4c118b24-4411-4e2f-825e-599de2df17ea" />

After:

<img width="840" height="1319" alt="Modal dialog in storybook positioned in middle of screen" src="https://github.com/user-attachments/assets/444fefa8-057b-4f96-996e-f0bb751a8295" />

Issue: WB-2105

## Test plan:
1. Review FlexibleDialog at various screen widths
2. Ensure dialog is positioned in the middle of the screen
3. Ensure DrawerLauncher / DrawerDialog aren't affected, since they are built on top of FlexibleDialog