### PR TITLE
CSS Modules:migrate wonder-blocks-button

### DIFF
--- a/packages/wonder-blocks-button/src/components/activity-button.module.css
+++ b/packages/wonder-blocks-button/src/components/activity-button.module.css
@@ -1,0 +1,159 @@
+/* ========================================
+ * ActivityButton outer wrapper
+ * ======================================== */
+.button {
+    /* Transparent background to allow chonky box to show through */
+    background: transparent;
+    border-radius: var(--wb-c-activity-button--border-radius);
+    color: var(--wb-c-activity-button--color);
+    /* Layout */
+    height: auto;
+    flex-direction: column;
+    gap: var(--wb-c-activity-button--gap);
+    align-self: flex-start;
+    justify-self: center;
+}
+
+/* ========================================
+ * Chonky box
+ * ======================================== */
+.chonky {
+    flex-direction: row;
+    gap: var(--wb-c-activity-button--chonky-gap);
+    border-radius: var(--wb-c-activity-button--chonky-border-radius);
+    margin-block-end: var(--wb-c-activity-button--chonky-margin-block-end);
+    max-width: 100%;
+    padding-block: var(--wb-c-activity-button--chonky-padding-block);
+    padding-inline: var(--wb-c-activity-button--chonky-padding-inline);
+    /* Theming */
+    background: var(--wb-c-activity-button--chonky-bg);
+    border: var(--wb-c-activity-button--chonky-border);
+    color: var(--wb-c-activity-button--chonky-color);
+    box-shadow: var(--wb-c-activity-button--chonky-shadow);
+    /* Motion */
+    transition: all 0.12s ease-out;
+}
+
+@media not (hover: hover) {
+    .chonky {
+        transition: none;
+    }
+}
+
+/* ========================================
+ * Hover state - descendant selectors on chonky
+ * ======================================== */
+@media (hover: hover) {
+    .button:hover .chonky {
+        background: var(--wb-c-activity-button--chonky-hover-bg);
+        border: var(--wb-c-activity-button--chonky-hover-border);
+        box-shadow: var(--wb-c-activity-button--chonky-hover-shadow);
+        color: var(--wb-c-activity-button--chonky-hover-color);
+        transform: var(--wb-c-activity-button--chonky-hover-transform);
+    }
+}
+
+/* ========================================
+ * Active/Press state
+ * ======================================== */
+.button:active .chonky {
+    background: var(--wb-c-activity-button--chonky-press-bg);
+    border: var(--wb-c-activity-button--chonky-press-border);
+    box-shadow: var(--wb-c-activity-button--chonky-press-shadow);
+    color: var(--wb-c-activity-button--chonky-press-color);
+    transform: var(--wb-c-activity-button--chonky-press-transform);
+}
+
+/* ========================================
+ * Focus state
+ * ======================================== */
+.button:focus-visible {
+    box-shadow: var(--wb-c-activity-button--focus-box-shadow);
+    outline: var(--wb-c-activity-button--focus-outline);
+    outline-offset: var(--wb-c-activity-button--focus-outline-offset);
+}
+
+/* ========================================
+ * Programmatic focus (via JS state)
+ * ======================================== */
+.focused {
+    box-shadow: var(--wb-c-activity-button--focus-box-shadow);
+    outline: var(--wb-c-activity-button--focus-outline);
+    outline-offset: var(--wb-c-activity-button--focus-outline-offset);
+}
+
+/* ========================================
+ * Programmatic press (via JS state)
+ * ======================================== */
+.pressed .chonky {
+    background: var(--wb-c-activity-button--chonky-press-bg);
+    border: var(--wb-c-activity-button--chonky-press-border);
+    box-shadow: var(--wb-c-activity-button--chonky-press-shadow);
+    color: var(--wb-c-activity-button--chonky-press-color);
+    transform: var(--wb-c-activity-button--chonky-press-transform);
+}
+
+/* ========================================
+ * Disabled state
+ * ======================================== */
+.disabled {
+    cursor: not-allowed;
+    color: var(--wb-c-activity-button--disabled-color);
+    outline: none;
+    transform: none;
+}
+
+@media (hover: hover) {
+    .disabled:hover {
+        outline: none;
+        transform: none;
+    }
+
+    .disabled:hover .chonky {
+        background: var(--wb-c-activity-button--chonky-disabled-bg);
+        border: var(--wb-c-activity-button--chonky-disabled-border);
+        color: var(--wb-c-activity-button--chonky-disabled-color);
+        box-shadow: var(--wb-c-activity-button--chonky-disabled-shadow);
+        transform: none;
+    }
+}
+
+.disabled:active {
+    outline: none;
+    transform: none;
+}
+
+.disabled:active .chonky {
+    background: var(--wb-c-activity-button--chonky-disabled-bg);
+    border: var(--wb-c-activity-button--chonky-disabled-border);
+    color: var(--wb-c-activity-button--chonky-disabled-color);
+    box-shadow: var(--wb-c-activity-button--chonky-disabled-shadow);
+    transform: none;
+}
+
+.disabled:focus-visible {
+    transform: none;
+}
+
+.disabled .chonky {
+    background: var(--wb-c-activity-button--chonky-disabled-bg);
+    border: var(--wb-c-activity-button--chonky-disabled-border);
+    color: var(--wb-c-activity-button--chonky-disabled-color);
+    box-shadow: var(--wb-c-activity-button--chonky-disabled-shadow);
+    transform: none;
+}
+
+/* ========================================
+ * Static styles
+ * ======================================== */
+.icon {
+    align-self: center;
+    width: 1.25rem; /* sizing.size_200 = 20px = 1.25rem */
+    height: 1.25rem;
+}
+
+.label {
+    line-height: 0.875rem; /* sizing.size_140 = 14px = 0.875rem */
+    padding-block-start: 0.25rem; /* sizing.size_040 */
+    padding-block-end: 0.375rem; /* sizing.size_060 */
+}

--- a/packages/wonder-blocks-button/src/components/activity-button.tsx
+++ b/packages/wonder-blocks-button/src/components/activity-button.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
-import {CSSProperties, StyleSheet} from "aphrodite";
 import {useInRouterContext} from "react-router-dom-v5-compat";
 
-import {View} from "@khanacademy/wonder-blocks-core";
+import {View, cx} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {focusStyles} from "@khanacademy/wonder-blocks-styles";
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {
@@ -13,14 +11,12 @@ import {
     ClickableState,
     getClickableBehavior,
 } from "@khanacademy/wonder-blocks-clickable";
-import type {
-    ActivityButtonActionType,
-    ButtonKind,
-    ActivityButtonProps,
-    ButtonRef,
-} from "../util/button.types";
+import type {ActivityButtonProps, ButtonRef} from "../util/button.types";
+import {getActivityButtonVars} from "../util/get-activity-button-vars";
 
 import {ButtonUnstyled} from "./button-unstyled";
+
+import actStyles from "./activity-button.module.css";
 
 type ButtonCoreProps = ActivityButtonProps & ChildrenProps & ClickableState;
 
@@ -46,35 +42,28 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
         ...restProps
     } = props;
 
-    const buttonStyles = _generateStyles(actionType, disabled, kind);
+    const cssVars = getActivityButtonVars(actionType, kind, disabled);
 
-    const sharedStyles = [
-        buttonStyles.button,
-        disabled && buttonStyles.disabled,
-        !disabled && pressed && buttonStyles.pressed,
-        // Enables programmatic focus.
-        !disabled && !pressed && focused && buttonStyles.focused,
-        stylesProp?.root,
-    ];
+    const buttonClassName = cx(
+        actStyles.button,
+        disabled && actStyles.disabled,
+        !disabled && pressed && actStyles.pressed,
+        !disabled && !pressed && focused && actStyles.focused,
+    );
 
-    const chonkyStyles = [
-        buttonStyles.chonky,
-        disabled && buttonStyles.chonkyDisabled,
-        !disabled && pressed && buttonStyles.chonkyPressed,
-        stylesProp?.box,
-    ];
+    const chonkyClassName = cx(actStyles.chonky, "chonky");
 
     return (
         <ButtonUnstyled
             {...restProps}
             disabled={disabled}
             ref={ref}
-            style={sharedStyles}
+            style={[buttonClassName, cssVars, stylesProp?.root]}
             type={type}
         >
             <>
                 {/* NOTE: Using a regular className to be able to use descendant selectors to account for the hover and press states */}
-                <View style={chonkyStyles} className="chonky">
+                <View style={stylesProp?.box} className={chonkyClassName}>
                     {/* If startIcon is a string, we use the `PhosphorIcon` component to render it. Otherwise, we render the element directly */}
                     {startIcon &&
                         (typeof startIcon === "string" ? (
@@ -84,13 +73,19 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
                                 size="medium"
                                 color="currentColor"
                                 icon={startIcon}
-                                style={[styles.icon, stylesProp?.startIcon]}
+                                style={[
+                                    staticStyles.icon,
+                                    stylesProp?.startIcon,
+                                ]}
                                 aria-hidden="true"
                             />
                         ) : (
                             React.cloneElement(startIcon, {
                                 "aria-hidden": true,
-                                style: [styles.icon, stylesProp?.startIcon],
+                                style: [
+                                    staticStyles.icon,
+                                    stylesProp?.startIcon,
+                                ],
                             })
                         ))}
 
@@ -98,7 +93,7 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
                         tag="span"
                         size="medium"
                         weight="semi"
-                        style={[styles.label, stylesProp?.label]}
+                        style={[staticStyles.label, stylesProp?.label]}
                     >
                         {children}
                     </BodyText>
@@ -111,13 +106,13 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
                                 size="medium"
                                 color="currentColor"
                                 icon={endIcon}
-                                style={[styles.icon, stylesProp?.endIcon]}
+                                style={[staticStyles.icon, stylesProp?.endIcon]}
                                 aria-hidden="true"
                             />
                         ) : (
                             React.cloneElement(endIcon, {
                                 "aria-hidden": true,
-                                style: [styles.icon, stylesProp?.endIcon],
+                                style: [staticStyles.icon, stylesProp?.endIcon],
                             })
                         ))}
                 </View>
@@ -224,215 +219,16 @@ export const ActivityButton = React.forwardRef(function ActivityButton(
     );
 });
 
-// NOTE: Theme is defined in the file directly to avoid generating CSS variables
-// as we are reusing the following tokens in all themes.
-const theme = {
-    root: {
-        border: {
-            width: {
-                primary: {
-                    rest: border.width.thin,
-                    hover: border.width.thin,
-                    press: border.width.thin,
-                },
-                secondary: {
-                    rest: border.width.thin,
-                    hover: border.width.thin,
-                    press: border.width.thin,
-                },
-                tertiary: {
-                    rest: border.width.thin,
-                    hover: border.width.thin,
-                    press: border.width.thin,
-                },
-            },
-            radius: border.radius.radius_120,
-        },
-        layout: {
-            padding: {
-                block: sizing.size_140,
-                inline: sizing.size_480,
-            },
-        },
-        shadow: {
-            y: {
-                // NOTE: We use px units to prevent a bug in Safari where the
-                // shadow animation flickers when using rem units.
-                rest: "6px",
-                hover: "8px",
-                press: sizing.size_0,
-            },
-        },
-    },
-    label: {
-        color: {
-            progressive: semanticColor.core.foreground.instructive.default,
-            neutral: semanticColor.core.foreground.neutral.default,
-            disabled: semanticColor.core.foreground.disabled.default,
-        },
-        font: {
-            // NOTE: This is intended by design to correctly align the text
-            // with the icon in the button.
-            lineHeight: sizing.size_140,
-        },
-        layout: {
-            padding: {
-                blockStart: sizing.size_040,
-                blockEnd: sizing.size_060,
-            },
-            width: sizing.size_640,
-        },
-    },
-    icon: {
-        sizing: {
-            height: sizing.size_200,
-            width: sizing.size_200,
-        },
-    },
-};
-
-// Static styles for the button.
-const styles = {
+// Static styles for icon and label that don't vary by variant.
+const staticStyles = {
     icon: {
         alignSelf: "center",
-        width: theme.icon.sizing.width,
-        height: theme.icon.sizing.height,
+        width: sizing.size_200,
+        height: sizing.size_200,
     },
     label: {
-        lineHeight: theme.label.font.lineHeight,
-        paddingBlockStart: theme.label.layout.padding.blockStart,
-        paddingBlockEnd: theme.label.layout.padding.blockEnd,
+        lineHeight: sizing.size_140,
+        paddingBlockStart: sizing.size_040,
+        paddingBlockEnd: sizing.size_060,
     },
-};
-
-const stateStyles: Record<string, any> = {};
-
-// Dynamically generate styles for the button based on the different variants.
-const _generateStyles = (
-    actionType: ActivityButtonActionType = "progressive",
-    disabled: boolean,
-    kind: ButtonKind,
-) => {
-    const buttonType = `${actionType}-d_${disabled}-${kind}`;
-    if (stateStyles[buttonType]) {
-        return stateStyles[buttonType];
-    }
-
-    const borderWidthKind = theme.root.border.width[kind];
-    const themeVariant = semanticColor.chonky[actionType];
-    const disabledState = semanticColor.chonky.disabled;
-
-    const disabledStatesStyles = {
-        outline: "none",
-        transform: "none",
-    };
-    const chonkyDisabled = {
-        background: disabledState.background[kind],
-        borderWidth: borderWidthKind.rest,
-        borderColor: disabledState.border[kind],
-        color: disabledState.foreground[kind],
-        boxShadow: `0 ${theme.root.shadow.y.rest} 0 0 ${disabledState.shadow[kind]}`,
-        transform: "none",
-    };
-
-    const chonkyPressed = {
-        // theming
-        background: themeVariant.background[kind].press,
-        border: `${borderWidthKind.press} solid ${themeVariant.border[kind].press}`,
-        boxShadow: `0 ${theme.root.shadow.y.press} 0 0 ${themeVariant.shadow[kind].press}`,
-        color: themeVariant.foreground[kind].press,
-        // motion
-        transform: `translateY(${theme.root.shadow.y.rest})`,
-    };
-
-    const newStyles: Record<string, CSSProperties> = {
-        button: {
-            // theming
-            // Applying a transparent background to allow the chonky box to show
-            // through.
-            background: "transparent",
-            // Used for the focus ring.
-            borderRadius: theme.root.border.radius,
-            color: theme.label.color[actionType],
-            // layout
-            height: "auto",
-            flexDirection: "column",
-            gap: sizing.size_020,
-            alignSelf: "flex-start",
-            justifySelf: "center",
-            /**
-             * States
-             *
-             * Defined in the following order: hover, active, focus.
-             *
-             * This is important as we want to give more priority to the
-             * :focus-visible styles.
-             */
-            [":is(:hover) .chonky" as any]: {
-                background: themeVariant.background[kind].hover,
-                border: `${borderWidthKind.hover} solid ${themeVariant.border[kind].hover}`,
-                boxShadow: `0 ${theme.root.shadow.y.hover} 0 0 ${themeVariant.shadow[kind].hover}`,
-                color: themeVariant.foreground[kind].hover,
-                // motion
-                transform: `translateY(calc((${theme.root.shadow.y.hover} - ${theme.root.shadow.y.rest}) * -1))`,
-            },
-
-            [":is(:active) .chonky" as any]: chonkyPressed,
-
-            // :focus-visible -> Provide focus styles for keyboard users only.
-            ...focusStyles.focus,
-        },
-        // To receive programmatic focus.
-        focused: focusStyles.focus[":focus-visible"],
-        disabled: {
-            cursor: "not-allowed",
-            color: theme.label.color.disabled,
-            ...disabledStatesStyles,
-            // Reset hover and active styles on disabled buttons.
-            ":hover": disabledStatesStyles,
-            ":active": disabledStatesStyles,
-            ":focus-visible": {
-                transform: "none",
-            },
-            // Reset hover and active styles on the chonky element.
-            [":is(:hover) .chonky" as any]: disabledStatesStyles,
-            [":is(:hover) .chonky" as any]: chonkyDisabled,
-            [":is(:active) .chonky" as any]: chonkyDisabled,
-        },
-        // Enable keyboard support for press styles.
-        pressed: {
-            [".chonky" as any]: chonkyPressed,
-        },
-
-        chonky: {
-            // layout
-            // Spacing between the icon(s) and the label.
-            flexDirection: "row",
-            gap: sizing.size_080,
-            // Used for the chonky box.
-            borderRadius: theme.root.border.radius,
-            marginBlockEnd: theme.root.shadow.y.rest,
-            maxWidth: "100%",
-            paddingBlock: theme.root.layout.padding.block,
-            paddingInline: theme.root.layout.padding.inline,
-            // theming
-            background: themeVariant.background[kind].rest,
-            border: `${borderWidthKind.rest} solid ${themeVariant.border[kind].rest}`,
-            color: themeVariant.foreground[kind].rest,
-
-            // Gives the button a "chonky" look and feel.
-            boxShadow: `0 ${theme.root.shadow.y.rest} 0 0 ${themeVariant.shadow[kind].rest}`,
-            // motion
-            transition: "all 0.12s ease-out",
-
-            ["@media not (hover: hover)" as any]: {
-                transition: "none",
-            },
-        },
-        chonkyPressed,
-        chonkyDisabled,
-    } as const;
-
-    stateStyles[buttonType] = StyleSheet.create(newStyles);
-    return stateStyles[buttonType];
 };

--- a/packages/wonder-blocks-button/src/components/button-core.module.css
+++ b/packages/wonder-blocks-button/src/components/button-core.module.css
@@ -1,0 +1,257 @@
+/* Shared structural styles */
+.shared {
+    height: var(--wb-c-button--height);
+    padding-block: 0;
+}
+
+.small {
+    height: var(--wb-c-button--height);
+}
+
+.large {
+    height: var(--wb-c-button--height);
+}
+
+/* Label text styles */
+.text {
+    align-items: center;
+    font-weight: var(--wb-c-button-root-font-weight-default);
+    white-space: nowrap;
+    overflow: hidden;
+    line-height: var(--wb-c-button-root-font-lineHeight-default);
+    text-overflow: ellipsis;
+    display: inline-block; /* allows the button text to truncate */
+    pointer-events: none; /* fix Safari bug where the browser was eating mouse events */
+}
+
+.smallText {
+    line-height: var(--wb-c-button-root-font-lineHeight-small);
+}
+
+.largeText {
+    font-size: var(--wb-c-button-root-font-size-large);
+    line-height: var(--wb-c-button-root-font-lineHeight-large);
+}
+
+.hiddenText {
+    visibility: hidden;
+}
+
+/* Spinner */
+.spinner {
+    position: absolute;
+}
+
+/* Icon styles */
+.startIcon {
+    margin-inline-start: var(--wb-c-button-icon-margin-inline-outer);
+    margin-inline-end: var(--wb-c-button-icon-margin-inline-inner);
+}
+
+.tertiaryStartIcon {
+    /* Undo the negative padding from startIcon since tertiary
+     * buttons don't have extra padding. */
+    margin-inline-start: 0;
+}
+
+.endIcon {
+    margin-inline-start: var(--wb-c-button-icon-margin-inline-inner);
+}
+
+.iconWrapper {
+    padding: var(--wb-c-button-icon-padding);
+    /* View has a default minWidth of 0, which causes the label text
+     * to encroach on the icon when it needs to truncate. We can fix
+     * this by setting the minWidth to auto. */
+    min-width: auto;
+}
+
+.endIconWrapper {
+    margin-inline-start: var(--wb-c-button-icon-margin-inline-inner);
+    margin-inline-end: var(--wb-c-button-icon-margin-inline-outer);
+}
+
+.endIconWrapperTertiary {
+    margin-inline-end: 0;
+}
+
+/* ========================================
+ * Base button variant styles
+ * ======================================== */
+.button {
+    border-radius: var(--wb-c-button--border-radius);
+    padding-inline: var(--wb-c-button--padding-inline);
+    border-style: var(--wb-c-button--border-style);
+    border-width: var(--wb-c-button--border-width);
+    border-color: var(--wb-c-button--border-color);
+    background: var(--wb-c-button--bg);
+    color: var(--wb-c-button--color);
+    transition: border-radius 0.1s ease-in-out;
+}
+
+/* ========================================
+ * Hover state - non-touch devices only
+ * ======================================== */
+@media (hover: hover) {
+    .button:hover {
+        background: var(--wb-c-button--hover-bg);
+        border-radius: var(--wb-c-button--hover-border-radius);
+        color: var(--wb-c-button--hover-color);
+    }
+
+    /* Primary: outline on hover */
+    .kindPrimary:hover {
+        outline: var(--wb-c-button--hover-outline);
+        outline-offset: var(--wb-c-button--hover-outline-offset);
+    }
+
+    /* Secondary: border-color + box-shadow on hover */
+    .kindSecondary:hover {
+        border-color: var(--wb-c-button--hover-border-color);
+        box-shadow: var(--wb-c-button--hover-box-shadow);
+    }
+
+    /* Tertiary: text-decoration on hover */
+    .kindTertiary:hover {
+        border-color: var(--wb-c-button--hover-border-color);
+        text-underline-offset: var(--wb-c-button--hover-text-underline-offset);
+        text-decoration: var(--wb-c-button--hover-text-decoration);
+    }
+}
+
+/* ========================================
+ * Active/Press state
+ * ======================================== */
+.button:active {
+    background: var(--wb-c-button--press-bg);
+    border-radius: var(--wb-c-button--press-border-radius);
+    color: var(--wb-c-button--press-color);
+}
+
+/* Primary: outline on press */
+.kindPrimary:active {
+    outline: var(--wb-c-button--press-outline);
+    outline-offset: var(--wb-c-button--press-outline-offset);
+}
+
+/* Secondary: border-color + box-shadow on press */
+.kindSecondary:active {
+    border-color: var(--wb-c-button--press-border-color);
+    box-shadow: var(--wb-c-button--press-box-shadow);
+}
+
+/* Tertiary: text-decoration on press */
+.kindTertiary:active {
+    border-color: var(--wb-c-button--press-border-color);
+    text-underline-offset: var(--wb-c-button--press-text-underline-offset);
+    text-decoration: var(--wb-c-button--press-text-decoration);
+}
+
+/* ========================================
+ * Focus state
+ * ======================================== */
+.button:focus-visible {
+    box-shadow: var(--wb-c-button--focus-box-shadow);
+    outline: var(--wb-c-button--focus-outline);
+    outline-offset: var(--wb-c-button--focus-outline-offset);
+}
+
+/* Secondary: combined focus + hover box-shadow */
+@media (hover: hover) {
+    .kindSecondary:focus-visible:hover {
+        box-shadow: var(--wb-c-button--focus-hover-box-shadow);
+        outline: var(--wb-c-button--focus-outline);
+        outline-offset: var(--wb-c-button--focus-outline-offset);
+    }
+}
+
+.kindSecondary:focus-visible:active {
+    box-shadow: var(--wb-c-button--focus-active-box-shadow);
+    outline: var(--wb-c-button--focus-outline);
+    outline-offset: var(--wb-c-button--focus-outline-offset);
+}
+
+/* ========================================
+ * Programmatic focus (via JS state)
+ * ======================================== */
+.focused {
+    box-shadow: var(--wb-c-button--focus-box-shadow);
+    outline: var(--wb-c-button--focus-outline);
+    outline-offset: var(--wb-c-button--focus-outline-offset);
+}
+
+/* ========================================
+ * Programmatic press (via JS state)
+ * ======================================== */
+.pressed {
+    background: var(--wb-c-button--press-bg);
+    border-radius: var(--wb-c-button--press-border-radius);
+    color: var(--wb-c-button--press-color);
+}
+
+.pressedPrimary {
+    outline: var(--wb-c-button--press-outline);
+    outline-offset: var(--wb-c-button--press-outline-offset);
+}
+
+.pressedSecondary {
+    border-color: var(--wb-c-button--press-border-color);
+    box-shadow: var(--wb-c-button--press-box-shadow);
+}
+
+.pressedTertiary {
+    border-color: var(--wb-c-button--press-border-color);
+    text-underline-offset: var(--wb-c-button--press-text-underline-offset);
+    text-decoration: var(--wb-c-button--press-text-decoration);
+}
+
+/* ========================================
+ * Disabled state
+ * ======================================== */
+.disabled {
+    cursor: not-allowed;
+    border-color: var(--wb-c-button--disabled-border-color);
+    border-width: var(--wb-c-button--disabled-border-width);
+    border-radius: var(--wb-c-button--disabled-border-radius);
+    background: var(--wb-c-button--disabled-bg);
+    color: var(--wb-c-button--disabled-color);
+}
+
+/* Override all pseudo-states when disabled */
+@media (hover: hover) {
+    .disabled:hover {
+        border-color: var(--wb-c-button--disabled-border-color);
+        border-width: var(--wb-c-button--disabled-border-width);
+        border-radius: var(--wb-c-button--disabled-border-radius);
+        background: var(--wb-c-button--disabled-bg);
+        color: var(--wb-c-button--disabled-color);
+        /* Reset kind-specific hover */
+        outline: none;
+        box-shadow: none;
+        text-decoration: none;
+        text-decoration-thickness: unset;
+        text-underline-offset: unset;
+    }
+}
+
+.disabled:active {
+    border-color: var(--wb-c-button--disabled-border-color);
+    border-width: var(--wb-c-button--disabled-border-width);
+    border-radius: var(--wb-c-button--disabled-border-radius);
+    background: var(--wb-c-button--disabled-bg);
+    color: var(--wb-c-button--disabled-color);
+    /* Reset kind-specific press */
+    outline: none;
+    box-shadow: none;
+    text-decoration: none;
+    text-decoration-thickness: unset;
+    text-underline-offset: unset;
+}
+
+.disabled:focus-visible {
+    border-color: var(--wb-c-button--disabled-border-color);
+    border-width: var(--wb-c-button--disabled-border-width);
+    border-radius: var(--wb-c-button--disabled-border-radius);
+    background: var(--wb-c-button--disabled-bg);
+    color: var(--wb-c-button--disabled-color);
+}

--- a/packages/wonder-blocks-button/src/components/button-unstyled.module.css
+++ b/packages/wonder-blocks-button/src/components/button-unstyled.module.css
@@ -1,0 +1,27 @@
+.reset {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    text-decoration: none;
+    box-sizing: border-box;
+    /* This removes the 300ms click delay on mobile browsers by indicating that
+     * "double-tap to zoom" shouldn't be used on this element. */
+    touch-action: manipulation;
+    user-select: none;
+}
+
+.reset:focus {
+    /* Mobile: Removes a blue highlight style shown when the user clicks a button */
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+/* Firefox adds an inner focus ring around text */
+.reset::-moz-focus-inner {
+    border: 0;
+}

--- a/packages/wonder-blocks-button/src/components/button-unstyled.tsx
+++ b/packages/wonder-blocks-button/src/components/button-unstyled.tsx
@@ -2,19 +2,33 @@ import * as React from "react";
 import {Link, useInRouterContext} from "react-router-dom-v5-compat";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
-import {StyleSheet} from "aphrodite";
 import {ButtonProps} from "../util/button.types";
+
+import resetStyles from "./button-unstyled.module.css";
 
 const StyledA = addStyle("a");
 const StyledButton = addStyle("button");
 const StyledLink = addStyle(Link);
 
-type Props = Omit<ButtonProps, "children"> & {
+// Widen style type to accept CSS module class name strings alongside
+// Aphrodite styles and inline style objects.
+type StyleTypeWithCSSModules =
+    | StyleType
+    | string
+    | ReadonlyArray<StyleType | string | false | null | undefined>;
+
+type Props = Omit<ButtonProps, "children" | "style"> & {
     /**
      * The button content.
      */
     children: React.ReactNode;
+    /**
+     * Custom styles. Accepts Aphrodite styles, inline style objects,
+     * and CSS module class name strings.
+     */
+    style?: StyleTypeWithCSSModules;
 };
 
 const ButtonUnstyled: React.ForwardRefExoticComponent<
@@ -40,7 +54,7 @@ const ButtonUnstyled: React.ForwardRefExoticComponent<
         "data-testid": testId,
         id: id,
         role: "button",
-        style: [styles.reset, style],
+        style: [resetStyles.reset, style],
         ...restProps,
     } as const;
 
@@ -76,30 +90,6 @@ const ButtonUnstyled: React.ForwardRefExoticComponent<
             </StyledButton>
         );
     }
-});
-
-const styles = StyleSheet.create({
-    reset: {
-        position: "relative",
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        margin: 0,
-        padding: 0,
-        border: "none",
-        cursor: "pointer",
-        outline: "none",
-        textDecoration: "none",
-        boxSizing: "border-box",
-        // This removes the 300ms click delay on mobile browsers by indicating that
-        // "double-tap to zoom" shouldn't be used on this element.
-        touchAction: "manipulation",
-        userSelect: "none",
-        ":focus": {
-            // Mobile: Removes a blue highlight style shown when the user clicks a button
-            WebkitTapHighlightColor: "rgba(0,0,0,0)",
-        },
-    },
 });
 
 export {ButtonUnstyled};

--- a/packages/wonder-blocks-button/src/util/get-activity-button-vars.ts
+++ b/packages/wonder-blocks-button/src/util/get-activity-button-vars.ts
@@ -1,0 +1,139 @@
+import * as React from "react";
+
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
+
+import type {ActivityButtonActionType, ButtonKind} from "./button.types";
+
+// NOTE: Theme is defined here directly to avoid generating CSS variables
+// as we are reusing the following tokens in all themes.
+const actTheme = {
+    root: {
+        border: {
+            width: {
+                primary: {
+                    rest: border.width.thin,
+                    hover: border.width.thin,
+                    press: border.width.thin,
+                },
+                secondary: {
+                    rest: border.width.thin,
+                    hover: border.width.thin,
+                    press: border.width.thin,
+                },
+                tertiary: {
+                    rest: border.width.thin,
+                    hover: border.width.thin,
+                    press: border.width.thin,
+                },
+            },
+            radius: border.radius.radius_120,
+        },
+        layout: {
+            padding: {
+                block: sizing.size_140,
+                inline: sizing.size_480,
+            },
+        },
+        shadow: {
+            y: {
+                // NOTE: We use px units to prevent a bug in Safari where the
+                // shadow animation flickers when using rem units.
+                rest: "6px",
+                hover: "8px",
+                press: sizing.size_0,
+            },
+        },
+    },
+    label: {
+        color: {
+            progressive: semanticColor.core.foreground.instructive.default,
+            neutral: semanticColor.core.foreground.neutral.default,
+            disabled: semanticColor.core.foreground.disabled.default,
+        },
+    },
+};
+
+const cache: Record<string, React.CSSProperties> = {};
+
+/**
+ * Returns CSS custom properties for an ActivityButton variant.
+ * These are set as inline styles and consumed by the CSS module via
+ * `var(--wb-c-activity-button--*)`.
+ */
+export function getActivityButtonVars(
+    actionType: ActivityButtonActionType = "progressive",
+    kind: ButtonKind,
+    disabled: boolean,
+): React.CSSProperties {
+    const cacheKey = `${actionType}-${kind}-${disabled}`;
+    if (cache[cacheKey]) {
+        return cache[cacheKey];
+    }
+
+    const borderWidthKind = actTheme.root.border.width[kind];
+    const themeVariant = semanticColor.chonky[actionType];
+    const disabledState = semanticColor.chonky.disabled;
+    const focusVisible = focusStyles.focus[":focus-visible"];
+
+    const vars = {
+        // Button (outer) colors
+        "--wb-c-activity-button--color": actTheme.label.color[actionType],
+        "--wb-c-activity-button--disabled-color": actTheme.label.color.disabled,
+        "--wb-c-activity-button--border-radius": actTheme.root.border.radius,
+
+        // Focus ring
+        "--wb-c-activity-button--focus-box-shadow": focusVisible.boxShadow,
+        "--wb-c-activity-button--focus-outline": focusVisible.outline,
+        "--wb-c-activity-button--focus-outline-offset":
+            focusVisible.outlineOffset,
+
+        // Gap between chonky and label
+        "--wb-c-activity-button--gap": sizing.size_020,
+
+        // Chonky box - rest state
+        "--wb-c-activity-button--chonky-bg": themeVariant.background[kind].rest,
+        "--wb-c-activity-button--chonky-border": `${borderWidthKind.rest} solid ${themeVariant.border[kind].rest}`,
+        "--wb-c-activity-button--chonky-border-radius":
+            actTheme.root.border.radius,
+        "--wb-c-activity-button--chonky-color":
+            themeVariant.foreground[kind].rest,
+        "--wb-c-activity-button--chonky-shadow": `0 ${actTheme.root.shadow.y.rest} 0 0 ${themeVariant.shadow[kind].rest}`,
+        "--wb-c-activity-button--chonky-margin-block-end":
+            actTheme.root.shadow.y.rest,
+        "--wb-c-activity-button--chonky-padding-block":
+            actTheme.root.layout.padding.block,
+        "--wb-c-activity-button--chonky-padding-inline":
+            actTheme.root.layout.padding.inline,
+        "--wb-c-activity-button--chonky-gap": sizing.size_080,
+
+        // Chonky box - hover state
+        "--wb-c-activity-button--chonky-hover-bg":
+            themeVariant.background[kind].hover,
+        "--wb-c-activity-button--chonky-hover-border": `${borderWidthKind.hover} solid ${themeVariant.border[kind].hover}`,
+        "--wb-c-activity-button--chonky-hover-shadow": `0 ${actTheme.root.shadow.y.hover} 0 0 ${themeVariant.shadow[kind].hover}`,
+        "--wb-c-activity-button--chonky-hover-color":
+            themeVariant.foreground[kind].hover,
+        "--wb-c-activity-button--chonky-hover-transform": `translateY(calc((${actTheme.root.shadow.y.hover} - ${actTheme.root.shadow.y.rest}) * -1))`,
+
+        // Chonky box - press state
+        "--wb-c-activity-button--chonky-press-bg":
+            themeVariant.background[kind].press,
+        "--wb-c-activity-button--chonky-press-border": `${borderWidthKind.press} solid ${themeVariant.border[kind].press}`,
+        "--wb-c-activity-button--chonky-press-shadow": `0 ${actTheme.root.shadow.y.press} 0 0 ${themeVariant.shadow[kind].press}`,
+        "--wb-c-activity-button--chonky-press-color":
+            themeVariant.foreground[kind].press,
+        "--wb-c-activity-button--chonky-press-transform": `translateY(${actTheme.root.shadow.y.rest})`,
+
+        // Chonky box - disabled state
+        "--wb-c-activity-button--chonky-disabled-bg":
+            disabledState.background[kind],
+        "--wb-c-activity-button--chonky-disabled-border": `${borderWidthKind.rest} solid ${disabledState.border[kind]}`,
+        "--wb-c-activity-button--chonky-disabled-color":
+            disabledState.foreground[kind],
+        "--wb-c-activity-button--chonky-disabled-shadow": `0 ${actTheme.root.shadow.y.rest} 0 0 ${disabledState.shadow[kind]}`,
+    };
+
+    cache[cacheKey] = vars as unknown as React.CSSProperties;
+    return cache[cacheKey];
+}

--- a/packages/wonder-blocks-button/src/util/get-button-vars.ts
+++ b/packages/wonder-blocks-button/src/util/get-button-vars.ts
@@ -1,0 +1,171 @@
+import * as React from "react";
+
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
+
+import theme from "../theme";
+import type {ButtonActionType, ButtonKind, ButtonSize} from "./button.types";
+
+type ButtonCSSVars = {
+    // Default state
+    "--wb-c-button--bg": string;
+    "--wb-c-button--color": string;
+    "--wb-c-button--border-color": string;
+    "--wb-c-button--border-width": string;
+    "--wb-c-button--border-radius": string;
+    "--wb-c-button--border-style": string;
+    "--wb-c-button--padding-inline": string;
+    "--wb-c-button--height": string;
+    // Hover state
+    "--wb-c-button--hover-bg": string;
+    "--wb-c-button--hover-color": string;
+    "--wb-c-button--hover-border-color": string;
+    "--wb-c-button--hover-border-radius": string;
+    // Primary hover outline
+    "--wb-c-button--hover-outline": string;
+    "--wb-c-button--hover-outline-offset": string | number;
+    // Secondary hover box-shadow
+    "--wb-c-button--hover-box-shadow": string;
+    // Tertiary hover text-decoration
+    "--wb-c-button--hover-text-underline-offset": string;
+    "--wb-c-button--hover-text-decoration": string;
+    // Press state
+    "--wb-c-button--press-bg": string;
+    "--wb-c-button--press-color": string;
+    "--wb-c-button--press-border-color": string;
+    "--wb-c-button--press-border-radius": string;
+    // Primary press outline
+    "--wb-c-button--press-outline": string;
+    "--wb-c-button--press-outline-offset": string | number;
+    // Secondary press box-shadow
+    "--wb-c-button--press-box-shadow": string;
+    // Tertiary press text-decoration
+    "--wb-c-button--press-text-underline-offset": string;
+    "--wb-c-button--press-text-decoration": string;
+    // Disabled state
+    "--wb-c-button--disabled-bg": string;
+    "--wb-c-button--disabled-color": string;
+    "--wb-c-button--disabled-border-color": string;
+    "--wb-c-button--disabled-border-width": string;
+    "--wb-c-button--disabled-border-radius": string;
+    // Focus state
+    "--wb-c-button--focus-box-shadow": string;
+    "--wb-c-button--focus-outline": string;
+    "--wb-c-button--focus-outline-offset": string;
+    // Secondary focus + hover/active combined
+    "--wb-c-button--focus-hover-box-shadow": string;
+    "--wb-c-button--focus-active-box-shadow": string;
+};
+
+const cache: Record<string, React.CSSProperties> = {};
+
+/**
+ * Returns CSS custom properties for a button variant.
+ * These are set as inline styles on the button element and consumed by
+ * the CSS module classes via `var(--wb-c-button--*)`.
+ */
+export function getButtonVars(
+    actionType: ButtonActionType = "progressive",
+    kind: ButtonKind,
+    size: ButtonSize,
+): React.CSSProperties {
+    const cacheKey = `${actionType}-${kind}-${size}`;
+    if (cache[cacheKey]) {
+        return cache[cacheKey];
+    }
+
+    const paddingInline = theme.root.layout.padding.inline[kind][size];
+    const borderWidthKind = theme.root.border.width[kind];
+    const outlineOffsetKind = theme.root.border.offset[kind];
+    const themeVariant = semanticColor.action[kind][actionType];
+    const disabledState = semanticColor.action[kind].disabled;
+    const focusVisible = focusStyles.focus[":focus-visible"];
+
+    const vars: ButtonCSSVars = {
+        // Default state
+        "--wb-c-button--bg": themeVariant.default.background,
+        "--wb-c-button--color": themeVariant.default.foreground,
+        "--wb-c-button--border-color": themeVariant.default.border,
+        "--wb-c-button--border-width": borderWidthKind.default,
+        "--wb-c-button--border-radius": theme.root.border.radius.default,
+        "--wb-c-button--border-style": "solid",
+        "--wb-c-button--padding-inline": paddingInline,
+        "--wb-c-button--height": theme.root.sizing.height[size],
+
+        // Hover state
+        "--wb-c-button--hover-bg": themeVariant.hover.background,
+        "--wb-c-button--hover-color": themeVariant.hover.foreground,
+        "--wb-c-button--hover-border-color": themeVariant.hover.border,
+        "--wb-c-button--hover-border-radius": theme.root.border.radius.hover,
+        // Primary hover outline
+        "--wb-c-button--hover-outline":
+            kind === "primary"
+                ? `${borderWidthKind.hover} solid ${themeVariant.hover.border}`
+                : "none",
+        "--wb-c-button--hover-outline-offset":
+            kind === "primary" ? outlineOffsetKind : 0,
+        // Secondary hover box-shadow
+        "--wb-c-button--hover-box-shadow":
+            kind !== "primary"
+                ? `inset 0 0 0 ${borderWidthKind.hover} ${themeVariant.hover.border}`
+                : "none",
+        // Tertiary hover text-decoration
+        "--wb-c-button--hover-text-underline-offset":
+            kind === "tertiary" ? theme.root.font.offset.default : "auto",
+        "--wb-c-button--hover-text-decoration":
+            kind === "tertiary"
+                ? `${theme.root.font.decoration.hover} ${theme.root.sizing.underline.hover}`
+                : "none",
+
+        // Press state
+        "--wb-c-button--press-bg": themeVariant.press.background,
+        "--wb-c-button--press-color": themeVariant.press.foreground,
+        "--wb-c-button--press-border-color": themeVariant.press.border,
+        "--wb-c-button--press-border-radius": theme.root.border.radius.press,
+        // Primary press outline
+        "--wb-c-button--press-outline":
+            kind === "primary"
+                ? `${borderWidthKind.press} solid ${themeVariant.press.border}`
+                : "none",
+        "--wb-c-button--press-outline-offset":
+            kind === "primary" ? outlineOffsetKind : 0,
+        // Secondary press box-shadow
+        "--wb-c-button--press-box-shadow":
+            kind !== "primary"
+                ? `inset 0 0 0 ${borderWidthKind.press} ${themeVariant.press.border}`
+                : "none",
+        // Tertiary press text-decoration
+        "--wb-c-button--press-text-underline-offset":
+            kind === "tertiary" ? theme.root.font.offset.default : "auto",
+        "--wb-c-button--press-text-decoration":
+            kind === "tertiary"
+                ? `${theme.root.font.decoration.press} ${theme.root.sizing.underline.press}`
+                : "none",
+
+        // Disabled state
+        "--wb-c-button--disabled-bg": disabledState.background,
+        "--wb-c-button--disabled-color": disabledState.foreground,
+        "--wb-c-button--disabled-border-color": disabledState.border,
+        "--wb-c-button--disabled-border-width": borderWidthKind.default,
+        "--wb-c-button--disabled-border-radius":
+            theme.root.border.radius.default,
+
+        // Focus state (from focusStyles)
+        "--wb-c-button--focus-box-shadow": focusVisible.boxShadow,
+        "--wb-c-button--focus-outline": focusVisible.outline,
+        "--wb-c-button--focus-outline-offset": focusVisible.outlineOffset,
+
+        // Secondary focus + hover/active combined box-shadow
+        "--wb-c-button--focus-hover-box-shadow":
+            kind === "secondary"
+                ? `inset 0 0 0 ${borderWidthKind.hover} ${themeVariant.hover.border}, ${focusVisible.boxShadow}`
+                : focusVisible.boxShadow,
+        "--wb-c-button--focus-active-box-shadow":
+            kind === "secondary"
+                ? `inset 0 0 0 ${borderWidthKind.press} ${themeVariant.press.border}, ${focusVisible.boxShadow}`
+                : focusVisible.boxShadow,
+    };
+
+    cache[cacheKey] = vars as unknown as React.CSSProperties;
+    return cache[cacheKey];
+}


### PR DESCRIPTION
## Summary:

- Replace Aphrodite StyleSheet.create with CSS Modules for Button, ButtonCore, ButtonUnstyled, and ActivityButton.
- Use CSS custom properties for dynamic variant values (colors, borders per actionType/kind/size).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Issue: WB-XXXX

## Test plan:

Verify that the button components are styled correctly with the new CSS Modules
and CSS custom properties.