### PR TITLE
Introduce lint rule: no-invalid-bodytext-parent

### DIFF
--- a/.changeset/healthy-peas-push.md
+++ b/.changeset/healthy-peas-push.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin-wonder-blocks": minor
+---
+
+Add new Typography lint rule for no-invalid-bodytext-parent to avoid nested paragraphs

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,12 @@ module.exports = {
             },
         },
         {
+            files: ["bodytext-tag-eslint-rule/**/*.js"],
+            rules: {
+                "import/no-commonjs": "off",
+            },
+        },
+        {
             files: ["**/*.test.*"],
             rules: {
                 "max-lines": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,12 +48,6 @@ module.exports = {
             },
         },
         {
-            files: ["bodytext-tag-eslint-rule/**/*.js"],
-            rules: {
-                "import/no-commonjs": "off",
-            },
-        },
-        {
             files: ["**/*.test.*"],
             rules: {
                 "max-lines": "off",
@@ -222,7 +216,6 @@ module.exports = {
                 matchers: ["toHaveNoA11yViolations"],
             },
         ],
-
         /**
          * TypeScript rules
          */

--- a/__docs__/tools/eslint-plugin-wonder-blocks/no-invalid-bodytext-parent.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/no-invalid-bodytext-parent.mdx
@@ -1,0 +1,8 @@
+import {Meta, Markdown} from "@storybook/addon-docs/blocks";
+import lintRuleDocs from "../../../packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-parent.md?raw";
+
+<Meta
+    title="Tools / eslint-plugin-wonder-blocks / Rules / no-invalid-bodytext-parent"
+/>
+
+<Markdown>{lintRuleDocs}</Markdown>

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "8.17.0",
     "@typescript-eslint/parser": "8.17.0",
+    "@typescript-eslint/rule-tester": "^8.46.3",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/browser": "^4.0.15",
     "@vitest/browser-playwright": "^4.0.15",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "8.17.0",
     "@typescript-eslint/parser": "8.17.0",
-    "@typescript-eslint/rule-tester": "^8.46.3",
+    "@typescript-eslint/rule-tester": "^8.58.0",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/browser": "^4.0.15",
     "@vitest/browser-playwright": "^4.0.15",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "8.17.0",
     "@typescript-eslint/parser": "8.17.0",
-    "@typescript-eslint/rule-tester": "^8.58.0",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/browser": "^4.0.15",
     "@vitest/browser-playwright": "^4.0.15",

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -71,3 +71,4 @@ The following shows what rules are enabled in each config:
 | Rule | Enabled in `recommended`| Enabled in `strict` |
 |------|-------------------------|---------------------|
 | [`no-custom-tab-role`](docs/no-custom-tab-role.md)| |✅|
+| [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|

--- a/packages/eslint-plugin-wonder-blocks/demo/package.json
+++ b/packages/eslint-plugin-wonder-blocks/demo/package.json
@@ -16,7 +16,9 @@
         "@khanacademy/wonder-blocks-button": "workspace:*",
         "@khanacademy/wonder-blocks-clickable": "workspace:*",
         "@khanacademy/wonder-blocks-core": "workspace:*",
+        "@khanacademy/wonder-blocks-form": "workspace:*",
         "@khanacademy/wonder-blocks-link": "workspace:*",
+        "@khanacademy/wonder-blocks-typography": "workspace:*",
         "@types/react": "^18.2.6",
         "react": "^18.2.0"
     }

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-invalid-bodytext-parent-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-invalid-bodytext-parent-example.tsx
@@ -1,0 +1,131 @@
+/**
+ * This file demonstrates the wonder-blocks ESLint rule:
+ * `@khanacademy/wonder-blocks/no-invalid-bodytext-parent`
+ * Run `pnpm lint` in this directory to see the errors.
+ */
+
+import * as React from "react";
+
+import {Checkbox, Choice} from "@khanacademy/wonder-blocks-form";
+import {
+    Heading,
+    HeadingLarge,
+    BodyText,
+} from "@khanacademy/wonder-blocks-typography";
+import {addStyle} from "@khanacademy/wonder-blocks-core";
+
+const StyledButton = addStyle("button");
+const StyledP = addStyle("p");
+const StyledLabel = addStyle("label");
+const StyledH1 = addStyle("h1");
+
+// ✅ Valid: BodyText with an inline tag is safe anywhere
+export function ValidExamples() {
+    return (
+        <>
+            {/* Inline tag inside a heading */}
+            <h1>
+                Title <BodyText tag="sup">1</BodyText>
+            </h1>
+
+            {/* Inline tag inside a button */}
+            <button>
+                <BodyText tag="span">Click me</BodyText>
+            </button>
+
+            {/* Inline tag inside a form component prop */}
+            <Choice label={<BodyText tag="span">Option A</BodyText>} value="" />
+
+            {/* Standalone BodyText in a block container */}
+            <div>
+                <BodyText>Paragraph text</BodyText>
+            </div>
+        </>
+    );
+}
+
+// ❌ Invalid: BodyText (renders as <p>) inside WB form component props
+export function InvalidFormComponents() {
+    return (
+        <>
+            <Choice value="" label={<BodyText>Option A</BodyText>} />
+            <Choice value="" label="" description={<BodyText>More details</BodyText>} />
+            <Checkbox
+                checked={false}
+                onChange={() => {}}
+                label={<BodyText>Check me</BodyText>}
+            />
+        </>
+    );
+}
+
+// ❌ Invalid: BodyText inside button elements
+export function InvalidButtonElements() {
+    return (
+        <>
+            <button>
+                <BodyText>Click me</BodyText>
+            </button>
+            <StyledButton>
+                <BodyText>Click me</BodyText>
+            </StyledButton>
+        </>
+    );
+}
+
+// ❌ Invalid: BodyText inside paragraph elements
+export function InvalidParagraphElements() {
+    return (
+        <>
+            <p>
+                <BodyText>Nested paragraph</BodyText>
+            </p>
+            <StyledP>
+                <BodyText>Nested paragraph</BodyText>
+            </StyledP>
+        </>
+    );
+}
+
+// ❌ Invalid: BodyText inside label elements
+export function InvalidLabelElements() {
+    return (
+        <>
+            <label>
+                <BodyText>Label text</BodyText>
+            </label>
+            <StyledLabel>
+                <BodyText>Label text</BodyText>
+            </StyledLabel>
+        </>
+    );
+}
+
+// ❌ Invalid: BodyText inside heading elements
+export function InvalidHeadingElements() {
+    return (
+        <>
+            <Heading>
+                <BodyText>Sub text</BodyText>
+            </Heading>
+            <HeadingLarge>
+                <BodyText>Sub text</BodyText>
+            </HeadingLarge>
+            <h1>
+                <BodyText>Sub text</BodyText>
+            </h1>
+            <StyledH1>
+                <BodyText>Sub text</BodyText>
+            </StyledH1>
+        </>
+    );
+}
+
+// ❌ Invalid: BodyText nested inside another BodyText (both render as <p>)
+export function InvalidNestedBodyText() {
+    return (
+        <BodyText>
+            Outer <BodyText>inner</BodyText>
+        </BodyText>
+    );
+}

--- a/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-parent.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-parent.md
@@ -1,0 +1,105 @@
+# no-invalid-bodytext-parent
+
+Disallow `BodyText` with a block-level tag inside elements that cannot contain block-level content.
+
+## Rule Details
+
+`BodyText` renders as a `<p>` element by default. HTML does not allow block-level
+elements like `<p>` inside inline contexts such as `<button>`, `<label>`, `<p>`,
+or heading elements. Placing `BodyText` inside these elements produces invalid
+markup that browsers must silently repair, which can cause layout or accessibility
+issues.
+
+Add `tag="span"` (or another inline tag) to `BodyText` to make it render as an
+inline element that is valid in these contexts.
+
+This rule provides an auto-fix that adds `tag="span"` when the fix is
+unambiguous. Dynamic `tag` expressions (e.g. `tag={isLabel ? "span" : "p"}`) are
+not auto-fixed to avoid silently corrupting conditional logic.
+
+Examples of **incorrect** code:
+
+```tsx
+/* BodyText inside a <button> */
+<button>
+    <BodyText>Click me</BodyText>
+</button>
+
+/* BodyText inside a WB Button component */
+<Button onClick={handleClick}>
+    <BodyText>Click me</BodyText>
+</Button>
+
+/* BodyText inside a <label> */
+<label>
+    <BodyText>Email address</BodyText>
+    <input type="email" />
+</label>
+
+/* BodyText inside a WB form component */
+<Choice label={<BodyText>Option A</BodyText>} value="a" />
+<LabeledField label={<BodyText>Email</BodyText>} field={<input />} />
+<RadioGroup description={<BodyText>Choose one</BodyText>} />
+<CheckboxGroup description={<BodyText>Select all that apply</BodyText>} />
+
+/* BodyText nested inside another BodyText (both render as <p>) */
+<BodyText>
+    Outer text <BodyText>inner text</BodyText>
+</BodyText>
+
+/* BodyText inside a heading */
+<h2>
+    Section <BodyText>subtitle</BodyText>
+</h2>
+<StyledH2>
+    Section <BodyText>subtitle</BodyText>
+</StyledH2>
+<Heading>
+    Section <BodyText>subtitle</BodyText>
+</Heading>
+```
+
+Examples of **correct** code:
+
+```tsx
+/* Inline tag makes BodyText valid inside a button */
+<button>
+    <BodyText tag="span">Click me</BodyText>
+</button>
+
+/* Inline tag makes BodyText valid inside a WB Button */
+<Button onClick={handleClick}>
+    <BodyText tag="span">Click me</BodyText>
+</Button>
+
+/* Inline tag makes BodyText valid inside a label */
+<label>
+    <BodyText tag="span">Email address</BodyText>
+    <input type="email" />
+</label>
+
+/* Inline tag makes BodyText valid inside a WB form component */
+<Choice label={<BodyText tag="span">Option A</BodyText>} value="a" />
+
+/* Outer BodyText uses a block-container tag, allowing block children */
+<BodyText tag="div">
+    Outer text <BodyText>inner text</BodyText>
+</BodyText>
+
+/* Inline tag makes BodyText valid inside a heading */
+<h2>
+    Section <BodyText tag="sup">note</BodyText>
+</h2>
+
+/* BodyText is fine at the top level or inside block containers */
+<BodyText>Standalone paragraph</BodyText>
+<div>
+    <BodyText>Inside a div</BodyText>
+</div>
+```
+
+## When Not To Use It
+
+Disable this rule only if you are intentionally rendering invalid HTML and have a
+specific reason to do so. In most cases the auto-fix resolves the issue without
+any manual effort.

--- a/packages/eslint-plugin-wonder-blocks/package.json
+++ b/packages/eslint-plugin-wonder-blocks/package.json
@@ -22,14 +22,14 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^8.46.4"
+    "@typescript-eslint/utils": "^8.58.0"
   },
   "peerDependencies": {
     "eslint": "^8.57.0"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",
-    "@typescript-eslint/rule-tester": "^8.46.3",
+    "@typescript-eslint/typescript-estree": "^8.58.2",
     "eslint": "^8.57.0"
   }
 }

--- a/packages/eslint-plugin-wonder-blocks/package.json
+++ b/packages/eslint-plugin-wonder-blocks/package.json
@@ -22,14 +22,15 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^8.58.0"
+    "@typescript-eslint/utils": "^8.59.0"
   },
   "peerDependencies": {
     "eslint": "^8.57.0"
   },
   "devDependencies": {
     "@khanacademy/wb-dev-build-settings": "workspace:*",
-    "@typescript-eslint/typescript-estree": "^8.58.2",
+    "@typescript-eslint/typescript-estree": "^8.59.0",
+    "@typescript-eslint/rule-tester": "^8.59.0",
     "eslint": "^8.57.0"
   }
 }

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -5,5 +5,6 @@ export default {
     rules: {
         ...recommended.rules,
         "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+        "@khanacademy/wonder-blocks/no-invalid-bodytext-parent": "error",
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/jsx-utils.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/jsx-utils.test.ts
@@ -1,0 +1,82 @@
+import {parse} from "@typescript-eslint/typescript-estree";
+import {TSESTree} from "@typescript-eslint/utils";
+
+import {getAttributeStringValue} from "../jsx-utils";
+
+/**
+ * Parses a self-closing JSX element and returns its opening element node.
+ */
+function parseOpeningElement(code: string): TSESTree.JSXOpeningElement {
+    const ast = parse(code, {jsx: true});
+    const stmt = ast.body[0] as TSESTree.ExpressionStatement;
+    const element = stmt.expression as TSESTree.JSXElement;
+    return element.openingElement;
+}
+
+describe("getAttributeStringValue", () => {
+    it("returns the string value of a string-literal attribute", () => {
+        // Arrange
+        const node = parseOpeningElement(`<C tag="span" />`);
+
+        // Act
+        const result = getAttributeStringValue(node, "tag");
+
+        // Assert
+        expect(result).toBe("span");
+    });
+
+    it("returns the string value of an expression-container string literal", () => {
+        // Arrange
+        const node = parseOpeningElement(`<C tag={"div"} />`);
+
+        // Act
+        const result = getAttributeStringValue(node, "tag");
+
+        // Assert
+        expect(result).toBe("div");
+    });
+
+    it("returns null when the attribute has a dynamic expression", () => {
+        // Arrange
+        const node = parseOpeningElement(`<C tag={isLabel ? "span" : "p"} />`);
+
+        // Act
+        const result = getAttributeStringValue(node, "tag");
+
+        // Assert
+        expect(result).toBeNull();
+    });
+
+    it("returns null when the attribute is absent", () => {
+        // Arrange
+        const node = parseOpeningElement(`<C />`);
+
+        // Act
+        const result = getAttributeStringValue(node, "tag");
+
+        // Assert
+        expect(result).toBeNull();
+    });
+
+    it("returns null for a boolean (value-less) attribute", () => {
+        // Arrange
+        const node = parseOpeningElement(`<C tag />`);
+
+        // Act
+        const result = getAttributeStringValue(node, "tag");
+
+        // Assert
+        expect(result).toBeNull();
+    });
+
+    it("returns null when a different attribute name is queried", () => {
+        // Arrange
+        const node = parseOpeningElement(`<C size="small" />`);
+
+        // Act
+        const result = getAttributeStringValue(node, "tag");
+
+        // Assert
+        expect(result).toBeNull();
+    });
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for the no-invalid-bodytext-parent ESLint rule.
+ *
+ * Uses ESLint's RuleTester to verify that the rule correctly flags BodyText
+ * components nested inside elements that cannot contain block-level content,
+ * and that the auto-fix correctly adds tag="span".
+ */
+import {RuleTester} from "eslint";
+import {noInvalidBodyTextParent} from "../no-invalid-bodytext-parent";
+
+// @types/eslint@9 expects flat config but this project uses eslint@8 (eslintrc format).
+// The runtime API works correctly; the cast silences the version mismatch.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        ecmaFeatures: {jsx: true},
+        sourceType: "module",
+    },
+} as any);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ruleTester.run("no-invalid-bodytext-parent", noInvalidBodyTextParent as any, {
+    // ------------------------------------------------------------------ //
+    // VALID — BodyText with an inline tag is allowed everywhere;          //
+    //         BodyText without a tag is fine in non-restricted contexts.  //
+    // ------------------------------------------------------------------ //
+    valid: [
+        // Standalone BodyText — no parent context at all
+        {code: `<BodyText>Hello</BodyText>`},
+
+        // BodyText inside plain block containers
+        {code: `<div><BodyText>Hello</BodyText></div>`},
+        {code: `<section><BodyText>Hello</BodyText></section>`},
+        {code: `<article><BodyText>Hello</BodyText></article>`},
+
+        // BodyText with an inline tag inside WB form components
+        {
+            code: `<Choice label={<BodyText tag="span">Title</BodyText>} />`,
+        },
+        {
+            code: `<Checkbox label={<BodyText tag="span">Label</BodyText>} />`,
+        },
+        {
+            code: `<Radio label={<BodyText tag="span">Label</BodyText>} />`,
+        },
+
+        // BodyText with an inline tag inside WB Button
+        {code: `<Button><BodyText tag="span">Click</BodyText></Button>`},
+        {
+            code: `<ActivityButton><BodyText tag="span">Click</BodyText></ActivityButton>`,
+        },
+
+        // BodyText with an inline tag inside HTML button / StyledButton
+        {code: `<button><BodyText tag="span">Click</BodyText></button>`},
+        {
+            code: `<StyledButton><BodyText tag="span">Click</BodyText></StyledButton>`,
+        },
+
+        // BodyText with an inline tag inside HTML p / StyledP
+        {code: `<p><BodyText tag="span">Inline text</BodyText></p>`},
+        {
+            code: `<StyledP><BodyText tag="span">Inline text</BodyText></StyledP>`,
+        },
+
+        // BodyText with an inline tag inside HTML label / StyledLabel
+        {code: `<label><BodyText tag="span">Label text</BodyText></label>`},
+        {
+            code: `<StyledLabel><BodyText tag="span">Label text</BodyText></StyledLabel>`,
+        },
+
+        // BodyText with an inline tag inside another BodyText
+        {
+            code: `<BodyText><BodyText tag="span">Inline nested</BodyText></BodyText>`,
+        },
+
+        // Inner BodyText (no inline tag) inside outer BodyText with a
+        // block-container tag — the outer renders as a div, which can
+        // contain <p> elements.
+        {
+            code: `<BodyText tag="div"><BodyText>Nested para</BodyText></BodyText>`,
+        },
+        {
+            code: `<BodyText tag="section"><BodyText>Nested para</BodyText></BodyText>`,
+        },
+        {
+            code: `<BodyText tag="article"><BodyText>Nested para</BodyText></BodyText>`,
+        },
+
+        // BodyText with an inline tag inside WB Heading components
+        {
+            code: `<Heading><BodyText tag="sup">Superscript</BodyText></Heading>`,
+        },
+        {
+            code: `<HeadingLarge><BodyText tag="span">Sub</BodyText></HeadingLarge>`,
+        },
+        {
+            code: `<HeadingMedium><BodyText tag="code">Code</BodyText></HeadingMedium>`,
+        },
+
+        // BodyText with an inline tag inside HTML heading elements
+        {code: `<h1><BodyText tag="sup">Sup</BodyText></h1>`},
+        {code: `<h2><BodyText tag="span">Sub</BodyText></h2>`},
+
+        // BodyText with other inline tag variants
+        {code: `<button><BodyText tag="code">Code</BodyText></button>`},
+        {code: `<label><BodyText tag="strong">Bold</BodyText></label>`},
+        {code: `<p><BodyText tag="em">Emphasis</BodyText></p>`},
+
+        // BodyText deeper inside a non-restricted wrapper that itself is
+        // inside a restricted element — only the direct parent is checked.
+        {
+            code: `<button><div><BodyText>Nested deeper</BodyText></div></button>`,
+        },
+
+        // BodyText with multiple props, including an inline tag
+        {
+            code: `<Choice label={<BodyText size="small" weight="bold" tag="span">Title</BodyText>} />`,
+        },
+    ],
+
+    // ------------------------------------------------------------------ //
+    // INVALID — BodyText without an inline tag inside restricted parents  //
+    // ------------------------------------------------------------------ //
+    invalid: [
+        // --- WB Form: Choice ---
+        {
+            code: `<Choice label={<BodyText>Title</BodyText>} />`,
+            errors: [
+                {
+                    messageId: "nestedInFormComponent",
+                    data: {componentName: "Choice"},
+                },
+            ],
+            output: `<Choice label={<BodyText tag="span">Title</BodyText>} />`,
+        },
+        {
+            code: `<Choice description={<BodyText>Description</BodyText>} />`,
+            errors: [
+                {
+                    messageId: "nestedInFormComponent",
+                    data: {componentName: "Choice"},
+                },
+            ],
+            output: `<Choice description={<BodyText tag="span">Description</BodyText>} />`,
+        },
+        // BodyText with other props but no tag inside Choice
+        {
+            code: `<Choice label={<BodyText size="small" weight="bold">Title</BodyText>} />`,
+            errors: [
+                {
+                    messageId: "nestedInFormComponent",
+                    data: {componentName: "Choice"},
+                },
+            ],
+            output: `<Choice label={<BodyText size="small" weight="bold" tag="span">Title</BodyText>} />`,
+        },
+        // Self-closing BodyText inside Choice
+        {
+            code: `<Choice label={<BodyText />} />`,
+            errors: [
+                {
+                    messageId: "nestedInFormComponent",
+                    data: {componentName: "Choice"},
+                },
+            ],
+            output: `<Choice label={<BodyText tag="span" />} />`,
+        },
+
+        // --- WB Form: Checkbox ---
+        {
+            code: `<Checkbox label={<BodyText>Label</BodyText>} />`,
+            errors: [
+                {
+                    messageId: "nestedInFormComponent",
+                    data: {componentName: "Checkbox"},
+                },
+            ],
+            output: `<Checkbox label={<BodyText tag="span">Label</BodyText>} />`,
+        },
+
+        // --- WB Form: Radio ---
+        {
+            code: `<Radio label={<BodyText>Label</BodyText>} />`,
+            errors: [
+                {
+                    messageId: "nestedInFormComponent",
+                    data: {componentName: "Radio"},
+                },
+            ],
+            output: `<Radio label={<BodyText tag="span">Label</BodyText>} />`,
+        },
+
+        // --- WB Button ---
+        {
+            code: `<Button><BodyText>Click me</BodyText></Button>`,
+            errors: [{messageId: "nestedInButton"}],
+            output: `<Button><BodyText tag="span">Click me</BodyText></Button>`,
+        },
+        {
+            code: `<ActivityButton><BodyText>Click me</BodyText></ActivityButton>`,
+            errors: [{messageId: "nestedInButton"}],
+            output: `<ActivityButton><BodyText tag="span">Click me</BodyText></ActivityButton>`,
+        },
+
+        // --- HTML <button> ---
+        {
+            code: `<button><BodyText>Click me</BodyText></button>`,
+            errors: [{messageId: "nestedInButton"}],
+            output: `<button><BodyText tag="span">Click me</BodyText></button>`,
+        },
+
+        // --- StyledButton ---
+        {
+            code: `<StyledButton><BodyText>Click me</BodyText></StyledButton>`,
+            errors: [{messageId: "nestedInButton"}],
+            output: `<StyledButton><BodyText tag="span">Click me</BodyText></StyledButton>`,
+        },
+
+        // --- HTML <p> ---
+        {
+            code: `<p><BodyText>Paragraph text</BodyText></p>`,
+            errors: [{messageId: "nestedInParagraph"}],
+            output: `<p><BodyText tag="span">Paragraph text</BodyText></p>`,
+        },
+
+        // --- StyledP ---
+        {
+            code: `<StyledP><BodyText>Paragraph text</BodyText></StyledP>`,
+            errors: [{messageId: "nestedInParagraph"}],
+            output: `<StyledP><BodyText tag="span">Paragraph text</BodyText></StyledP>`,
+        },
+
+        // --- HTML <label> ---
+        {
+            code: `<label><BodyText>Label text</BodyText></label>`,
+            errors: [{messageId: "nestedInLabel"}],
+            output: `<label><BodyText tag="span">Label text</BodyText></label>`,
+        },
+
+        // --- StyledLabel ---
+        {
+            code: `<StyledLabel><BodyText>Label text</BodyText></StyledLabel>`,
+            errors: [{messageId: "nestedInLabel"}],
+            output: `<StyledLabel><BodyText tag="span">Label text</BodyText></StyledLabel>`,
+        },
+
+        // --- BodyText nested in BodyText (both default to <p>) ---
+        {
+            code: `<BodyText><BodyText>Nested</BodyText></BodyText>`,
+            errors: [{messageId: "nestedInBodyText"}],
+            output: `<BodyText><BodyText tag="span">Nested</BodyText></BodyText>`,
+        },
+        // Outer has explicit tag="p"
+        {
+            code: `<BodyText tag="p"><BodyText>Nested</BodyText></BodyText>`,
+            errors: [{messageId: "nestedInBodyText"}],
+            output: `<BodyText tag="p"><BodyText tag="span">Nested</BodyText></BodyText>`,
+        },
+        // Outer has an inline tag — also invalid (inline element can't contain <p>)
+        {
+            code: `<BodyText tag="span"><BodyText>Nested</BodyText></BodyText>`,
+            errors: [{messageId: "nestedInBodyText"}],
+            output: `<BodyText tag="span"><BodyText tag="span">Nested</BodyText></BodyText>`,
+        },
+        // Inner BodyText with an explicit block tag is still a block element;
+        // the fix replaces the existing non-inline tag value.
+        {
+            code: `<BodyText><BodyText tag="div">Block</BodyText></BodyText>`,
+            errors: [{messageId: "nestedInBodyText"}],
+            output: `<BodyText><BodyText tag="span">Block</BodyText></BodyText>`,
+        },
+
+        // --- WB Heading ---
+        {
+            code: `<Heading><BodyText>Sub text</BodyText></Heading>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<Heading><BodyText tag="span">Sub text</BodyText></Heading>`,
+        },
+        {
+            code: `<HeadingLarge><BodyText>Sub text</BodyText></HeadingLarge>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<HeadingLarge><BodyText tag="span">Sub text</BodyText></HeadingLarge>`,
+        },
+        {
+            code: `<HeadingMedium><BodyText>Sub text</BodyText></HeadingMedium>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<HeadingMedium><BodyText tag="span">Sub text</BodyText></HeadingMedium>`,
+        },
+        {
+            code: `<HeadingSmall><BodyText>Sub text</BodyText></HeadingSmall>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<HeadingSmall><BodyText tag="span">Sub text</BodyText></HeadingSmall>`,
+        },
+        {
+            code: `<HeadingXSmall><BodyText>Sub text</BodyText></HeadingXSmall>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<HeadingXSmall><BodyText tag="span">Sub text</BodyText></HeadingXSmall>`,
+        },
+
+        // --- HTML heading elements ---
+        {
+            code: `<h1><BodyText>Sub text</BodyText></h1>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<h1><BodyText tag="span">Sub text</BodyText></h1>`,
+        },
+        {
+            code: `<h2><BodyText>Sub text</BodyText></h2>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<h2><BodyText tag="span">Sub text</BodyText></h2>`,
+        },
+        {
+            code: `<h6><BodyText>Sub text</BodyText></h6>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<h6><BodyText tag="span">Sub text</BodyText></h6>`,
+        },
+
+        // --- BodyText with a non-inline tag is still invalid in restricted
+        //     parents; the fix replaces the existing tag value. ---
+        {
+            code: `<label><BodyText tag="p">Text</BodyText></label>`,
+            errors: [{messageId: "nestedInLabel"}],
+            output: `<label><BodyText tag="span">Text</BodyText></label>`,
+        },
+        {
+            code: `<Button><BodyText tag="div">Text</BodyText></Button>`,
+            errors: [{messageId: "nestedInButton"}],
+            output: `<Button><BodyText tag="span">Text</BodyText></Button>`,
+        },
+    ],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
@@ -6,7 +6,8 @@
  * and that the auto-fix correctly adds tag="span".
  */
 import {RuleTester} from "@typescript-eslint/rule-tester";
-import noInvalidBodyTextParent from "../no-invalid-bodytext-parent";
+
+import {rules} from "..";
 
 const ruleTester = new RuleTester({
     languageOptions: {
@@ -18,7 +19,10 @@ const ruleTester = new RuleTester({
     },
 });
 
-ruleTester.run("no-invalid-bodytext-parent", noInvalidBodyTextParent, {
+const ruleName = "no-invalid-bodytext-parent";
+const rule = rules[ruleName];
+
+ruleTester.run(ruleName, rule, {
     // ------------------------------------------------------------------ //
     // VALID — BodyText with an inline tag is allowed everywhere;          //
     //         BodyText without a tag is fine in non-restricted contexts.  //

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
@@ -325,5 +325,19 @@ ruleTester.run("no-invalid-bodytext-parent", noInvalidBodyTextParent, {
             errors: [{messageId: "nestedInButton"}],
             output: `<Button><BodyText tag="span">Text</BodyText></Button>`,
         },
+
+        // --- Dynamic tag expression: error is reported but no autofix is
+        //     applied, since replacing the expression would silently destroy
+        //     the developer's conditional logic. ---
+        {
+            code: `<label><BodyText tag={isLabel ? "span" : "code"}>Text</BodyText></label>`,
+            errors: [{messageId: "nestedInLabel"}],
+            output: null,
+        },
+        {
+            code: `<Button><BodyText tag={getTag()}>Click</BodyText></Button>`,
+            errors: [{messageId: "nestedInButton"}],
+            output: null,
+        },
     ],
 });

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
@@ -104,6 +104,10 @@ ruleTester.run(ruleName, rule, {
         {code: `<h1><BodyText tag="sup">Sup</BodyText></h1>`},
         {code: `<h2><BodyText tag="span">Sub</BodyText></h2>`},
 
+        // BodyText with an inline tag inside StyledH* elements
+        {code: `<StyledH1><BodyText tag="sup">Sup</BodyText></StyledH1>`},
+        {code: `<StyledH2><BodyText tag="span">Sub</BodyText></StyledH2>`},
+
         // BodyText with other inline tag variants
         {code: `<button><BodyText tag="code">Code</BodyText></button>`},
         {code: `<label><BodyText tag="strong">Bold</BodyText></label>`},
@@ -315,6 +319,23 @@ ruleTester.run(ruleName, rule, {
             code: `<h6><BodyText>Sub text</BodyText></h6>`,
             errors: [{messageId: "nestedInHeading"}],
             output: `<h6><BodyText tag="span">Sub text</BodyText></h6>`,
+        },
+
+        // --- StyledH* elements ---
+        {
+            code: `<StyledH1><BodyText>Sub text</BodyText></StyledH1>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<StyledH1><BodyText tag="span">Sub text</BodyText></StyledH1>`,
+        },
+        {
+            code: `<StyledH2><BodyText>Sub text</BodyText></StyledH2>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<StyledH2><BodyText tag="span">Sub text</BodyText></StyledH2>`,
+        },
+        {
+            code: `<StyledH6><BodyText>Sub text</BodyText></StyledH6>`,
+            errors: [{messageId: "nestedInHeading"}],
+            output: `<StyledH6><BodyText tag="span">Sub text</BodyText></StyledH6>`,
         },
 
         // --- BodyText with a non-inline tag is still invalid in restricted

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-parent.test.ts
@@ -5,22 +5,20 @@
  * components nested inside elements that cannot contain block-level content,
  * and that the auto-fix correctly adds tag="span".
  */
-import {RuleTester} from "eslint";
-import {noInvalidBodyTextParent} from "../no-invalid-bodytext-parent";
+import {RuleTester} from "@typescript-eslint/rule-tester";
+import noInvalidBodyTextParent from "../no-invalid-bodytext-parent";
 
-// @types/eslint@9 expects flat config but this project uses eslint@8 (eslintrc format).
-// The runtime API works correctly; the cast silences the version mismatch.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ruleTester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 2020,
-        ecmaFeatures: {jsx: true},
-        sourceType: "module",
+    languageOptions: {
+        parserOptions: {
+            ecmaVersion: 2020,
+            ecmaFeatures: {jsx: true},
+            sourceType: "module",
+        },
     },
-} as any);
+});
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-ruleTester.run("no-invalid-bodytext-parent", noInvalidBodyTextParent as any, {
+ruleTester.run("no-invalid-bodytext-parent", noInvalidBodyTextParent, {
     // ------------------------------------------------------------------ //
     // VALID — BodyText with an inline tag is allowed everywhere;          //
     //         BodyText without a tag is fine in non-restricted contexts.  //

--- a/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
@@ -1,7 +1,9 @@
 import noCustomTabRole from "./no-custom-tab-role";
+import noInvalidBodyTextParent from "./no-invalid-bodytext-parent";
 
 const rules = {
     "no-custom-tab-role": noCustomTabRole,
+    "no-invalid-bodytext-parent": noInvalidBodyTextParent,
 };
 
 export {rules};

--- a/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
@@ -1,7 +1,9 @@
+import {TSESLint} from "@typescript-eslint/utils";
+
 import noCustomTabRole from "./no-custom-tab-role";
 import noInvalidBodyTextParent from "./no-invalid-bodytext-parent";
 
-const rules = {
+const rules: Record<string, TSESLint.RuleModule<string, readonly unknown[]>> = {
     "no-custom-tab-role": noCustomTabRole,
     "no-invalid-bodytext-parent": noInvalidBodyTextParent,
 };

--- a/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
@@ -54,7 +54,14 @@ export const BLOCK_CONTAINER_TAGS = new Set([
  * Wonder Blocks form components that internally render a <label> or similar
  * inline-context element around their content.
  */
-export const WB_FORM_COMPONENTS = new Set(["Choice", "Checkbox", "Radio"]);
+export const WB_FORM_COMPONENTS = new Set([
+    "Choice",
+    "Checkbox",
+    "Radio",
+    "LabeledField",
+    "RadioGroup",
+    "CheckboxGroup",
+]);
 
 /**
  * Wonder Blocks Button component names. Buttons are inline contexts and
@@ -63,7 +70,7 @@ export const WB_FORM_COMPONENTS = new Set(["Choice", "Checkbox", "Radio"]);
 export const WB_BUTTON_COMPONENTS = new Set(["Button", "ActivityButton"]);
 
 /**
- * HTML heading element names.
+ * HTML heading element names and their styled-component equivalents.
  */
 export const HTML_HEADING_ELEMENTS = new Set([
     "h1",
@@ -72,6 +79,12 @@ export const HTML_HEADING_ELEMENTS = new Set([
     "h4",
     "h5",
     "h6",
+    "StyledH1",
+    "StyledH2",
+    "StyledH3",
+    "StyledH4",
+    "StyledH5",
+    "StyledH6",
 ]);
 
 /**
@@ -98,7 +111,7 @@ export function getAttributeStringValue(
         (a): a is TSESTree.JSXAttribute =>
             a.type === "JSXAttribute" &&
             a.name.type === "JSXIdentifier" &&
-            (a.name as TSESTree.JSXIdentifier).name === attributeName,
+            a.name.name === attributeName,
     );
 
     if (!attr?.value) {
@@ -113,7 +126,7 @@ export function getAttributeStringValue(
         attr.value.type === "JSXExpressionContainer" &&
         attr.value.expression.type === "Literal"
     ) {
-        return String((attr.value.expression as TSESTree.Literal).value);
+        return String(attr.value.expression.value);
     }
 
     return null;

--- a/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
@@ -1,0 +1,120 @@
+import {TSESTree} from "@typescript-eslint/utils";
+
+/**
+ * Inline/phrasing-content tags. When BodyText uses one of these it renders as
+ * an inline element rather than a block-level <p>.
+ */
+export const INLINE_BODY_TEXT_TAGS = new Set([
+    "span",
+    "sup",
+    "sub",
+    "em",
+    "strong",
+    "a",
+    "abbr",
+    "code",
+    "kbd",
+    "mark",
+    "cite",
+    "q",
+    "s",
+    "u",
+    "b",
+    "i",
+    "small",
+    "del",
+    "ins",
+    "time",
+    "var",
+    "samp",
+    "dfn",
+]);
+
+/**
+ * Block-level container tags. When BodyText uses one of these it renders as a
+ * block container rather than <p>, so it can legitimately hold block children.
+ */
+export const BLOCK_CONTAINER_TAGS = new Set([
+    "div",
+    "section",
+    "article",
+    "aside",
+    "main",
+    "header",
+    "footer",
+    "nav",
+    "blockquote",
+    "figure",
+    "figcaption",
+    "details",
+    "summary",
+]);
+
+/**
+ * Wonder Blocks form components that internally render a <label> or similar
+ * inline-context element around their content.
+ */
+export const WB_FORM_COMPONENTS = new Set(["Choice", "Checkbox", "Radio"]);
+
+/**
+ * Wonder Blocks Button component names. Buttons are inline contexts and
+ * cannot contain block-level elements like <p>.
+ */
+export const WB_BUTTON_COMPONENTS = new Set(["Button", "ActivityButton"]);
+
+/**
+ * HTML heading element names.
+ */
+export const HTML_HEADING_ELEMENTS = new Set([
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+]);
+
+/**
+ * Wonder Blocks Heading component names. These render as block-level heading
+ * elements (h1–h5) and cannot be children of a <p>.
+ */
+export const WB_HEADING_COMPONENTS = new Set([
+    "Heading",
+    "HeadingLarge",
+    "HeadingMedium",
+    "HeadingSmall",
+    "HeadingXSmall",
+]);
+
+/**
+ * Returns the string value of a JSX attribute if it is a simple string
+ * literal, otherwise null. Returns null for dynamic expressions.
+ */
+export function getAttributeStringValue(
+    openingElement: TSESTree.JSXOpeningElement,
+    attributeName: string,
+): string | null {
+    const attr = openingElement.attributes.find(
+        (a): a is TSESTree.JSXAttribute =>
+            a.type === "JSXAttribute" &&
+            a.name.type === "JSXIdentifier" &&
+            (a.name as TSESTree.JSXIdentifier).name === attributeName,
+    );
+
+    if (!attr?.value) {
+        return null;
+    }
+
+    if (attr.value.type === "Literal") {
+        return String(attr.value.value);
+    }
+
+    if (
+        attr.value.type === "JSXExpressionContainer" &&
+        attr.value.expression.type === "Literal"
+    ) {
+        return String((attr.value.expression as TSESTree.Literal).value);
+    }
+
+    return null;
+}

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
@@ -1,0 +1,427 @@
+// --- Self-contained rule types (avoids @types/eslint version conflicts) ---
+
+/** Minimal shape of an ESLint rule fix. */
+interface RuleFix {
+    range: [number, number];
+    text: string;
+}
+
+/** Minimal shape of an ESLint rule fixer. */
+interface RuleFixer {
+    replaceText(node: {range?: [number, number]}, text: string): RuleFix;
+    insertTextAfter(node: {range?: [number, number]}, text: string): RuleFix;
+}
+
+/** Minimal shape of an ESLint rule report descriptor. */
+interface ReportDescriptor {
+    node: unknown;
+    messageId: string;
+    data?: Record<string, string>;
+    fix?: (fixer: RuleFixer) => RuleFix;
+}
+
+/** Minimal shape of an ESLint rule context. */
+interface RuleContext {
+    report(descriptor: ReportDescriptor): void;
+}
+
+/** The shape of an exported ESLint rule module. */
+export interface RuleModule {
+    meta?: {
+        type?: string;
+        docs?: Record<string, unknown>;
+        fixable?: string;
+        schema?: unknown[];
+        messages?: Record<string, string>;
+    };
+    create(context: RuleContext): Record<string, (node: unknown) => void>;
+}
+
+// --- Minimal JSX AST types (not in ESTree spec) ---
+
+/** Base shape shared by all AST nodes as seen by ESLint rule visitors. */
+type ASTNode = {
+    type: string;
+    parent?: ASTNode;
+    range?: [number, number];
+};
+
+type JSXIdentifier = ASTNode & {
+    type: "JSXIdentifier";
+    name: string;
+};
+
+type JSXNamespacedName = ASTNode & {
+    type: "JSXNamespacedName";
+};
+
+type JSXMemberExpression = ASTNode & {
+    type: "JSXMemberExpression";
+};
+
+type Literal = ASTNode & {
+    type: "Literal";
+    value: string | number | boolean | null | bigint | RegExp;
+};
+
+type JSXEmptyExpression = ASTNode & {
+    type: "JSXEmptyExpression";
+};
+
+type JSXExpressionContainer = ASTNode & {
+    type: "JSXExpressionContainer";
+    expression: ASTNode | JSXEmptyExpression;
+};
+
+type JSXAttribute = ASTNode & {
+    type: "JSXAttribute";
+    name: JSXIdentifier | JSXNamespacedName;
+    value: Literal | JSXExpressionContainer | null;
+};
+
+type JSXSpreadAttribute = ASTNode & {
+    type: "JSXSpreadAttribute";
+};
+
+type JSXOpeningElement = ASTNode & {
+    type: "JSXOpeningElement";
+    name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
+    attributes: Array<JSXAttribute | JSXSpreadAttribute>;
+    parent: JSXElement;
+};
+
+type JSXElement = ASTNode & {
+    type: "JSXElement";
+    openingElement: JSXOpeningElement;
+    parent?: ASTNode;
+};
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Inline tags that make BodyText safe to nest inside inline/interactive
+ * contexts (e.g., inside a button, label, or paragraph element).
+ */
+const INLINE_BODY_TEXT_TAGS = new Set([
+    "span",
+    "sup",
+    "sub",
+    "em",
+    "strong",
+    "a",
+    "abbr",
+    "code",
+    "kbd",
+    "mark",
+    "cite",
+    "q",
+    "s",
+    "u",
+    "b",
+    "i",
+    "small",
+    "del",
+    "ins",
+    "time",
+    "var",
+    "samp",
+    "dfn",
+]);
+
+/**
+ * Block-level container tags. When an outer BodyText uses one of these, it
+ * can contain an inner BodyText that renders as <p> without creating invalid
+ * HTML nesting.
+ */
+const BLOCK_CONTAINER_TAGS = new Set([
+    "div",
+    "section",
+    "article",
+    "aside",
+    "main",
+    "header",
+    "footer",
+    "nav",
+    "blockquote",
+    "figure",
+    "figcaption",
+    "details",
+    "summary",
+]);
+
+/**
+ * Wonder Blocks form components that internally render a <label> or similar
+ * inline-context element around their content.
+ */
+const WB_FORM_COMPONENTS = new Set(["Choice", "Checkbox", "Radio"]);
+
+/**
+ * Wonder Blocks Button component names. Buttons are inline contexts and
+ * cannot contain block-level elements like <p>.
+ */
+const WB_BUTTON_COMPONENTS = new Set(["Button", "ActivityButton"]);
+
+/**
+ * Wonder Blocks Heading component names. Headings are block-level but
+ * cannot contain other block-level elements like <p>.
+ */
+const WB_HEADING_COMPONENTS = new Set([
+    "Heading",
+    "HeadingLarge",
+    "HeadingMedium",
+    "HeadingSmall",
+    "HeadingXSmall",
+]);
+
+/**
+ * HTML heading element names.
+ */
+const HTML_HEADING_ELEMENTS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
+
+/**
+ * Returns the string value of a JSX attribute if it's a simple string
+ * literal, otherwise null.
+ */
+function getAttributeStringValue(
+    openingElement: JSXOpeningElement,
+    attributeName: string,
+): string | null {
+    const attr = openingElement.attributes.find(
+        (a): a is JSXAttribute =>
+            a.type === "JSXAttribute" &&
+            a.name.type === "JSXIdentifier" &&
+            a.name.name === attributeName,
+    );
+
+    if (!attr?.value) {
+        return null;
+    }
+
+    if (attr.value.type === "Literal") {
+        return String(attr.value.value);
+    }
+
+    if (
+        attr.value.type === "JSXExpressionContainer" &&
+        attr.value.expression.type === "Literal"
+    ) {
+        return String((attr.value.expression as Literal).value);
+    }
+
+    return null;
+}
+
+/**
+ * Returns true if this BodyText uses an inline `tag` prop, making it safe
+ * to place inside any of the restricted parent elements.
+ */
+function hasInlineTag(openingElement: JSXOpeningElement): boolean {
+    const tag = getAttributeStringValue(openingElement, "tag");
+    return tag !== null && INLINE_BODY_TEXT_TAGS.has(tag);
+}
+
+/**
+ * Walks up the AST from a JSXOpeningElement to find the nearest *ancestor*
+ * JSXElement (i.e., skips the element's own JSXElement wrapper).
+ */
+function getNearestAncestorJSXElement(
+    openingElement: JSXOpeningElement,
+): JSXElement | null {
+    // openingElement.parent is the JSXElement for openingElement's own element.
+    // We need to go one level higher to start searching for an ancestor.
+    let current: ASTNode | undefined = openingElement.parent.parent;
+    while (current != null) {
+        if (current.type === "JSXElement") {
+            return current as JSXElement;
+        }
+        current = current.parent;
+    }
+    return null;
+}
+
+/**
+ * Builds the auto-fix that sets tag="span" on the BodyText element.
+ * If a `tag` prop already exists (with a non-inline value), its value is
+ * replaced. Otherwise, tag="span" is appended after the last attribute.
+ */
+function buildSpanTagFix(
+    fixer: RuleFixer,
+    openingElement: JSXOpeningElement,
+): RuleFix {
+    const existingTagAttr = openingElement.attributes.find(
+        (a): a is JSXAttribute =>
+            a.type === "JSXAttribute" &&
+            a.name.type === "JSXIdentifier" &&
+            (a.name as JSXIdentifier).name === "tag",
+    );
+
+    if (existingTagAttr?.value) {
+        return fixer.replaceText(existingTagAttr.value, '"span"');
+    }
+
+    const lastAttr =
+        openingElement.attributes[openingElement.attributes.length - 1];
+    return lastAttr
+        ? fixer.insertTextAfter(lastAttr, ' tag="span"')
+        : fixer.insertTextAfter(openingElement.name, ' tag="span"');
+}
+
+export const noInvalidBodyTextParent: RuleModule = {
+    meta: {
+        type: "problem",
+        docs: {
+            description:
+                "Disallow BodyText with a block-level tag (default <p>) inside elements that cannot contain block-level content",
+            category: "Possible Errors",
+            recommended: true,
+            url: "https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-parent.md",
+        },
+        fixable: "code",
+        schema: [],
+        messages: {
+            nestedInFormComponent:
+                'BodyText renders as <p> by default. Add tag="span" to use BodyText inside {{componentName}}.',
+            nestedInButton:
+                'BodyText renders as <p> by default. Add tag="span" to use BodyText inside a button element.',
+            nestedInParagraph:
+                'BodyText renders as <p> by default, which cannot be nested inside another <p>. Add tag="span" to use BodyText here.',
+            nestedInLabel:
+                'BodyText renders as <p> by default. Add tag="span" to use BodyText inside a label element.',
+            nestedInBodyText:
+                'BodyText renders as <p> by default, which cannot be nested inside another BodyText that also renders as <p>. Add tag="div" to the outer BodyText to allow block children, or add tag="span" to this BodyText to make it inline.',
+            nestedInHeading:
+                'BodyText renders as <p> by default, which cannot be nested inside a heading element. Add an inline tag (e.g., tag="sup" or tag="span") to use BodyText inside a heading.',
+        },
+    },
+
+    create(context: RuleContext) {
+        return {
+            JSXOpeningElement(rawNode: unknown) {
+                const node = rawNode as JSXOpeningElement;
+
+                // Only check BodyText components.
+                if (
+                    node.name.type !== "JSXIdentifier" ||
+                    node.name.name !== "BodyText"
+                ) {
+                    return;
+                }
+
+                // If BodyText explicitly uses an inline tag, it's safe
+                // in any of the restricted parent contexts.
+                if (hasInlineTag(node)) {
+                    return;
+                }
+
+                const ancestorJSXElement = getNearestAncestorJSXElement(node);
+                if (!ancestorJSXElement) {
+                    return;
+                }
+
+                const parentOpening = ancestorJSXElement.openingElement;
+                const parentName =
+                    parentOpening.name.type === "JSXIdentifier"
+                        ? parentOpening.name.name
+                        : null;
+
+                if (!parentName) {
+                    return;
+                }
+
+                const fix = (fixer: RuleFixer) => buildSpanTagFix(fixer, node);
+
+                // --- WB Form components (Choice, Checkbox, Radio) ---
+                if (WB_FORM_COMPONENTS.has(parentName)) {
+                    context.report({
+                        node: rawNode,
+                        messageId: "nestedInFormComponent",
+                        data: {componentName: parentName},
+                        fix,
+                    });
+                    return;
+                }
+
+                // --- WB Button components ---
+                if (WB_BUTTON_COMPONENTS.has(parentName)) {
+                    context.report({
+                        node: rawNode,
+                        messageId: "nestedInButton",
+                        fix,
+                    });
+                    return;
+                }
+
+                // --- HTML <button> or StyledButton ---
+                if (parentName === "button" || parentName === "StyledButton") {
+                    context.report({
+                        node: rawNode,
+                        messageId: "nestedInButton",
+                        fix,
+                    });
+                    return;
+                }
+
+                // --- HTML <p> or StyledP ---
+                if (parentName === "p" || parentName === "StyledP") {
+                    context.report({
+                        node: rawNode,
+                        messageId: "nestedInParagraph",
+                        fix,
+                    });
+                    return;
+                }
+
+                // --- HTML <label> or StyledLabel ---
+                if (parentName === "label" || parentName === "StyledLabel") {
+                    context.report({
+                        node: rawNode,
+                        messageId: "nestedInLabel",
+                        fix,
+                    });
+                    return;
+                }
+
+                // --- BodyText nested inside another BodyText ---
+                if (parentName === "BodyText") {
+                    // It's OK if the outer BodyText uses a block-container tag
+                    // like tag="div", which can contain <p> elements.
+                    const outerTag = getAttributeStringValue(
+                        parentOpening,
+                        "tag",
+                    );
+                    const outerIsBlockContainer =
+                        outerTag !== null && BLOCK_CONTAINER_TAGS.has(outerTag);
+
+                    if (!outerIsBlockContainer) {
+                        context.report({
+                            node: rawNode,
+                            messageId: "nestedInBodyText",
+                            fix,
+                        });
+                    }
+                    return;
+                }
+
+                // --- WB Heading components ---
+                if (WB_HEADING_COMPONENTS.has(parentName)) {
+                    context.report({
+                        node: rawNode,
+                        messageId: "nestedInHeading",
+                        fix,
+                    });
+                    return;
+                }
+
+                // --- HTML heading elements (h1–h6) ---
+                if (HTML_HEADING_ELEMENTS.has(parentName)) {
+                    context.report({
+                        node: rawNode,
+                        messageId: "nestedInHeading",
+                        fix,
+                    });
+                    return;
+                }
+            },
+        };
+    },
+};

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
@@ -46,7 +46,7 @@ function getNearestAncestorJSXElement(
     let current: TSESTree.Node | undefined = openingElement.parent?.parent;
     while (current != null) {
         if (current.type === "JSXElement") {
-            return current as TSESTree.JSXElement;
+            return current;
         }
         current = current.parent;
     }
@@ -70,7 +70,7 @@ function buildSpanTagFix(
         (a): a is TSESTree.JSXAttribute =>
             a.type === "JSXAttribute" &&
             a.name.type === "JSXIdentifier" &&
-            (a.name as TSESTree.JSXIdentifier).name === "tag",
+            a.name.name === "tag",
     );
 
     if (existingTagAttr) {
@@ -98,7 +98,7 @@ export default createRule<Options, MessageIds>({
         docs: {
             description:
                 "Disallow BodyText with a block-level tag (default <p>) inside elements that cannot contain block-level content",
-            recommended: true,
+            recommended: false,
         },
         fixable: "code",
         schema: [],

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
@@ -158,14 +158,18 @@ function getNearestAncestorJSXElement(
 }
 
 /**
- * Builds the auto-fix that sets tag="span" on the BodyText element.
- * If a `tag` prop already exists (with a non-inline value), its value is
- * replaced. Otherwise, tag="span" is appended after the last attribute.
+ * Build the auto-fix that sets tag="span" on the BodyText element.
+ *
+ * If a `tag` prop already exists with a static string value, its value is
+ * replaced. If the existing `tag` value is a dynamic expression (e.g.
+ * tag={condition ? 'span' : 'code'}), no fix is returned — replacing it
+ * would silently destroy the developer's conditional logic.
+ * Otherwise, tag="span" is appended after the last attribute.
  */
 function buildSpanTagFix(
     fixer: TSESLint.RuleFixer,
     openingElement: TSESTree.JSXOpeningElement,
-): TSESLint.RuleFix {
+): TSESLint.RuleFix | null {
     const existingTagAttr = openingElement.attributes.find(
         (a): a is TSESTree.JSXAttribute =>
             a.type === "JSXAttribute" &&
@@ -173,8 +177,15 @@ function buildSpanTagFix(
             (a.name as TSESTree.JSXIdentifier).name === "tag",
     );
 
-    if (existingTagAttr?.value) {
-        return fixer.replaceText(existingTagAttr.value, '"span"');
+    if (existingTagAttr) {
+        // Dynamic expression: don't autofix — we'd corrupt the developer's logic.
+        if (existingTagAttr.value?.type === "JSXExpressionContainer") {
+            return null;
+        }
+        // Static string literal: safe to replace.
+        if (existingTagAttr.value?.type === "Literal") {
+            return fixer.replaceText(existingTagAttr.value, '"span"');
+        }
     }
 
     const lastAttr =

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
@@ -1,6 +1,15 @@
 import {ESLintUtils, TSESLint, TSESTree} from "@typescript-eslint/utils";
 
 import type {WonderBlocksPluginDocs} from "../types";
+import {
+    getAttributeStringValue,
+    INLINE_BODY_TEXT_TAGS,
+    WB_BUTTON_COMPONENTS,
+    WB_FORM_COMPONENTS,
+    BLOCK_CONTAINER_TAGS,
+    WB_HEADING_COMPONENTS,
+    HTML_HEADING_ELEMENTS,
+} from "./jsx-utils";
 
 const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
     (name) =>
@@ -15,119 +24,6 @@ type MessageIds =
     | "nestedInLabel"
     | "nestedInBodyText"
     | "nestedInHeading";
-
-/**
- * Inline tags that make BodyText safe to nest inside inline/interactive
- * contexts (e.g., inside a button, label, or paragraph element).
- */
-const INLINE_BODY_TEXT_TAGS = new Set([
-    "span",
-    "sup",
-    "sub",
-    "em",
-    "strong",
-    "a",
-    "abbr",
-    "code",
-    "kbd",
-    "mark",
-    "cite",
-    "q",
-    "s",
-    "u",
-    "b",
-    "i",
-    "small",
-    "del",
-    "ins",
-    "time",
-    "var",
-    "samp",
-    "dfn",
-]);
-
-/**
- * Block-level container tags. When an outer BodyText uses one of these, it
- * can contain an inner BodyText that renders as <p> without creating invalid
- * HTML nesting.
- */
-const BLOCK_CONTAINER_TAGS = new Set([
-    "div",
-    "section",
-    "article",
-    "aside",
-    "main",
-    "header",
-    "footer",
-    "nav",
-    "blockquote",
-    "figure",
-    "figcaption",
-    "details",
-    "summary",
-]);
-
-/**
- * Wonder Blocks form components that internally render a <label> or similar
- * inline-context element around their content.
- */
-const WB_FORM_COMPONENTS = new Set(["Choice", "Checkbox", "Radio"]);
-
-/**
- * Wonder Blocks Button component names. Buttons are inline contexts and
- * cannot contain block-level elements like <p>.
- */
-const WB_BUTTON_COMPONENTS = new Set(["Button", "ActivityButton"]);
-
-/**
- * Wonder Blocks Heading component names. Headings are block-level but
- * cannot contain other block-level elements like <p>.
- */
-const WB_HEADING_COMPONENTS = new Set([
-    "Heading",
-    "HeadingLarge",
-    "HeadingMedium",
-    "HeadingSmall",
-    "HeadingXSmall",
-]);
-
-/**
- * HTML heading element names.
- */
-const HTML_HEADING_ELEMENTS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
-
-/**
- * Returns the string value of a JSX attribute if it's a simple string
- * literal, otherwise null.
- */
-function getAttributeStringValue(
-    openingElement: TSESTree.JSXOpeningElement,
-    attributeName: string,
-): string | null {
-    const attr = openingElement.attributes.find(
-        (a): a is TSESTree.JSXAttribute =>
-            a.type === "JSXAttribute" &&
-            a.name.type === "JSXIdentifier" &&
-            (a.name as TSESTree.JSXIdentifier).name === attributeName,
-    );
-
-    if (!attr?.value) {
-        return null;
-    }
-
-    if (attr.value.type === "Literal") {
-        return String(attr.value.value);
-    }
-
-    if (
-        attr.value.type === "JSXExpressionContainer" &&
-        attr.value.expression.type === "Literal"
-    ) {
-        return String((attr.value.expression as TSESTree.Literal).value);
-    }
-
-    return null;
-}
 
 /**
  * Returns true if this BodyText uses an inline `tag` prop, making it safe

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-parent.ts
@@ -1,102 +1,20 @@
-// --- Self-contained rule types (avoids @types/eslint version conflicts) ---
+import {ESLintUtils, TSESLint, TSESTree} from "@typescript-eslint/utils";
 
-/** Minimal shape of an ESLint rule fix. */
-interface RuleFix {
-    range: [number, number];
-    text: string;
-}
+import type {WonderBlocksPluginDocs} from "../types";
 
-/** Minimal shape of an ESLint rule fixer. */
-interface RuleFixer {
-    replaceText(node: {range?: [number, number]}, text: string): RuleFix;
-    insertTextAfter(node: {range?: [number, number]}, text: string): RuleFix;
-}
+const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
+    (name) =>
+        `https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/${name}.md`,
+);
 
-/** Minimal shape of an ESLint rule report descriptor. */
-interface ReportDescriptor {
-    node: unknown;
-    messageId: string;
-    data?: Record<string, string>;
-    fix?: (fixer: RuleFixer) => RuleFix;
-}
-
-/** Minimal shape of an ESLint rule context. */
-interface RuleContext {
-    report(descriptor: ReportDescriptor): void;
-}
-
-/** The shape of an exported ESLint rule module. */
-export interface RuleModule {
-    meta?: {
-        type?: string;
-        docs?: Record<string, unknown>;
-        fixable?: string;
-        schema?: unknown[];
-        messages?: Record<string, string>;
-    };
-    create(context: RuleContext): Record<string, (node: unknown) => void>;
-}
-
-// --- Minimal JSX AST types (not in ESTree spec) ---
-
-/** Base shape shared by all AST nodes as seen by ESLint rule visitors. */
-type ASTNode = {
-    type: string;
-    parent?: ASTNode;
-    range?: [number, number];
-};
-
-type JSXIdentifier = ASTNode & {
-    type: "JSXIdentifier";
-    name: string;
-};
-
-type JSXNamespacedName = ASTNode & {
-    type: "JSXNamespacedName";
-};
-
-type JSXMemberExpression = ASTNode & {
-    type: "JSXMemberExpression";
-};
-
-type Literal = ASTNode & {
-    type: "Literal";
-    value: string | number | boolean | null | bigint | RegExp;
-};
-
-type JSXEmptyExpression = ASTNode & {
-    type: "JSXEmptyExpression";
-};
-
-type JSXExpressionContainer = ASTNode & {
-    type: "JSXExpressionContainer";
-    expression: ASTNode | JSXEmptyExpression;
-};
-
-type JSXAttribute = ASTNode & {
-    type: "JSXAttribute";
-    name: JSXIdentifier | JSXNamespacedName;
-    value: Literal | JSXExpressionContainer | null;
-};
-
-type JSXSpreadAttribute = ASTNode & {
-    type: "JSXSpreadAttribute";
-};
-
-type JSXOpeningElement = ASTNode & {
-    type: "JSXOpeningElement";
-    name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
-    attributes: Array<JSXAttribute | JSXSpreadAttribute>;
-    parent: JSXElement;
-};
-
-type JSXElement = ASTNode & {
-    type: "JSXElement";
-    openingElement: JSXOpeningElement;
-    parent?: ASTNode;
-};
-
-// ---------------------------------------------------------------------------
+type Options = [];
+type MessageIds =
+    | "nestedInFormComponent"
+    | "nestedInButton"
+    | "nestedInParagraph"
+    | "nestedInLabel"
+    | "nestedInBodyText"
+    | "nestedInHeading";
 
 /**
  * Inline tags that make BodyText safe to nest inside inline/interactive
@@ -183,14 +101,14 @@ const HTML_HEADING_ELEMENTS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
  * literal, otherwise null.
  */
 function getAttributeStringValue(
-    openingElement: JSXOpeningElement,
+    openingElement: TSESTree.JSXOpeningElement,
     attributeName: string,
 ): string | null {
     const attr = openingElement.attributes.find(
-        (a): a is JSXAttribute =>
+        (a): a is TSESTree.JSXAttribute =>
             a.type === "JSXAttribute" &&
             a.name.type === "JSXIdentifier" &&
-            a.name.name === attributeName,
+            (a.name as TSESTree.JSXIdentifier).name === attributeName,
     );
 
     if (!attr?.value) {
@@ -205,7 +123,7 @@ function getAttributeStringValue(
         attr.value.type === "JSXExpressionContainer" &&
         attr.value.expression.type === "Literal"
     ) {
-        return String((attr.value.expression as Literal).value);
+        return String((attr.value.expression as TSESTree.Literal).value);
     }
 
     return null;
@@ -215,7 +133,7 @@ function getAttributeStringValue(
  * Returns true if this BodyText uses an inline `tag` prop, making it safe
  * to place inside any of the restricted parent elements.
  */
-function hasInlineTag(openingElement: JSXOpeningElement): boolean {
+function hasInlineTag(openingElement: TSESTree.JSXOpeningElement): boolean {
     const tag = getAttributeStringValue(openingElement, "tag");
     return tag !== null && INLINE_BODY_TEXT_TAGS.has(tag);
 }
@@ -225,14 +143,14 @@ function hasInlineTag(openingElement: JSXOpeningElement): boolean {
  * JSXElement (i.e., skips the element's own JSXElement wrapper).
  */
 function getNearestAncestorJSXElement(
-    openingElement: JSXOpeningElement,
-): JSXElement | null {
+    openingElement: TSESTree.JSXOpeningElement,
+): TSESTree.JSXElement | null {
     // openingElement.parent is the JSXElement for openingElement's own element.
     // We need to go one level higher to start searching for an ancestor.
-    let current: ASTNode | undefined = openingElement.parent.parent;
+    let current: TSESTree.Node | undefined = openingElement.parent?.parent;
     while (current != null) {
         if (current.type === "JSXElement") {
-            return current as JSXElement;
+            return current as TSESTree.JSXElement;
         }
         current = current.parent;
     }
@@ -245,14 +163,14 @@ function getNearestAncestorJSXElement(
  * replaced. Otherwise, tag="span" is appended after the last attribute.
  */
 function buildSpanTagFix(
-    fixer: RuleFixer,
-    openingElement: JSXOpeningElement,
-): RuleFix {
+    fixer: TSESLint.RuleFixer,
+    openingElement: TSESTree.JSXOpeningElement,
+): TSESLint.RuleFix {
     const existingTagAttr = openingElement.attributes.find(
-        (a): a is JSXAttribute =>
+        (a): a is TSESTree.JSXAttribute =>
             a.type === "JSXAttribute" &&
             a.name.type === "JSXIdentifier" &&
-            (a.name as JSXIdentifier).name === "tag",
+            (a.name as TSESTree.JSXIdentifier).name === "tag",
     );
 
     if (existingTagAttr?.value) {
@@ -266,15 +184,14 @@ function buildSpanTagFix(
         : fixer.insertTextAfter(openingElement.name, ' tag="span"');
 }
 
-export const noInvalidBodyTextParent: RuleModule = {
+export default createRule<Options, MessageIds>({
+    name: "no-invalid-bodytext-parent",
     meta: {
         type: "problem",
         docs: {
             description:
                 "Disallow BodyText with a block-level tag (default <p>) inside elements that cannot contain block-level content",
-            category: "Possible Errors",
             recommended: true,
-            url: "https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-parent.md",
         },
         fixable: "code",
         schema: [],
@@ -293,12 +210,9 @@ export const noInvalidBodyTextParent: RuleModule = {
                 'BodyText renders as <p> by default, which cannot be nested inside a heading element. Add an inline tag (e.g., tag="sup" or tag="span") to use BodyText inside a heading.',
         },
     },
-
-    create(context: RuleContext) {
+    create(context) {
         return {
-            JSXOpeningElement(rawNode: unknown) {
-                const node = rawNode as JSXOpeningElement;
-
+            JSXOpeningElement(node) {
                 // Only check BodyText components.
                 if (
                     node.name.type !== "JSXIdentifier" ||
@@ -328,12 +242,13 @@ export const noInvalidBodyTextParent: RuleModule = {
                     return;
                 }
 
-                const fix = (fixer: RuleFixer) => buildSpanTagFix(fixer, node);
+                const fix = (fixer: TSESLint.RuleFixer) =>
+                    buildSpanTagFix(fixer, node);
 
                 // --- WB Form components (Choice, Checkbox, Radio) ---
                 if (WB_FORM_COMPONENTS.has(parentName)) {
                     context.report({
-                        node: rawNode,
+                        node,
                         messageId: "nestedInFormComponent",
                         data: {componentName: parentName},
                         fix,
@@ -344,7 +259,7 @@ export const noInvalidBodyTextParent: RuleModule = {
                 // --- WB Button components ---
                 if (WB_BUTTON_COMPONENTS.has(parentName)) {
                     context.report({
-                        node: rawNode,
+                        node,
                         messageId: "nestedInButton",
                         fix,
                     });
@@ -354,7 +269,7 @@ export const noInvalidBodyTextParent: RuleModule = {
                 // --- HTML <button> or StyledButton ---
                 if (parentName === "button" || parentName === "StyledButton") {
                     context.report({
-                        node: rawNode,
+                        node,
                         messageId: "nestedInButton",
                         fix,
                     });
@@ -364,7 +279,7 @@ export const noInvalidBodyTextParent: RuleModule = {
                 // --- HTML <p> or StyledP ---
                 if (parentName === "p" || parentName === "StyledP") {
                     context.report({
-                        node: rawNode,
+                        node,
                         messageId: "nestedInParagraph",
                         fix,
                     });
@@ -374,7 +289,7 @@ export const noInvalidBodyTextParent: RuleModule = {
                 // --- HTML <label> or StyledLabel ---
                 if (parentName === "label" || parentName === "StyledLabel") {
                     context.report({
-                        node: rawNode,
+                        node,
                         messageId: "nestedInLabel",
                         fix,
                     });
@@ -394,7 +309,7 @@ export const noInvalidBodyTextParent: RuleModule = {
 
                     if (!outerIsBlockContainer) {
                         context.report({
-                            node: rawNode,
+                            node,
                             messageId: "nestedInBodyText",
                             fix,
                         });
@@ -405,7 +320,7 @@ export const noInvalidBodyTextParent: RuleModule = {
                 // --- WB Heading components ---
                 if (WB_HEADING_COMPONENTS.has(parentName)) {
                     context.report({
-                        node: rawNode,
+                        node,
                         messageId: "nestedInHeading",
                         fix,
                     });
@@ -415,7 +330,7 @@ export const noInvalidBodyTextParent: RuleModule = {
                 // --- HTML heading elements (h1–h6) ---
                 if (HTML_HEADING_ELEMENTS.has(parentName)) {
                     context.report({
-                        node: rawNode,
+                        node,
                         messageId: "nestedInHeading",
                         fix,
                     });
@@ -424,4 +339,5 @@ export const noInvalidBodyTextParent: RuleModule = {
             },
         };
     },
-};
+    defaultOptions: [],
+});

--- a/packages/eslint-plugin-wonder-blocks/tsconfig-build.json
+++ b/packages/eslint-plugin-wonder-blocks/tsconfig-build.json
@@ -1,5 +1,5 @@
 {
-    "exclude": ["dist", "demo"],
+    "exclude": ["dist", "demo", "src/**/__tests__"],
     "extends": "../tsconfig-shared.json",
     "compilerOptions": {
         "outDir": "./dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 8.17.0
         version: 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.46.3
+        version: 8.57.1(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
         version: 3.9.0(@swc/helpers@0.5.17)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
@@ -3482,6 +3485,13 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.57.1':
+    resolution: {integrity: sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/parser@8.58.0':
     resolution: {integrity: sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3489,11 +3499,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.57.1':
+    resolution: {integrity: sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/project-service@8.58.0':
     resolution: {integrity: sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/rule-tester@8.57.1':
+    resolution: {integrity: sha512-gk0q0rLa7a1uEB0iD2t1GZELK1z6HfudiKYeSVhjQ5gW5FdL0OcZ+8f09Lg7NbmHSBF3V+S9BDuw0qoCFkHR+w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
   '@typescript-eslint/rule-tester@8.58.0':
     resolution: {integrity: sha512-a/J72Cxeo5ug5sbey7+Dcna6tMBc4Z4eYwBEKM6MVuBqbxnROpLm8yn/j00lPZc75joPZJVR5oiTZxbK95zp+w==}
@@ -3509,9 +3531,19 @@ packages:
     resolution: {integrity: sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.57.1':
+    resolution: {integrity: sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/scope-manager@8.58.0':
     resolution: {integrity: sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.57.1':
+    resolution: {integrity: sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/tsconfig-utils@8.58.0':
     resolution: {integrity: sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==}
@@ -3537,6 +3569,10 @@ packages:
     resolution: {integrity: sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.57.1':
+    resolution: {integrity: sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/types@8.58.0':
     resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3555,6 +3591,12 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/typescript-estree@8.57.1':
+    resolution: {integrity: sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/typescript-estree@8.58.0':
     resolution: {integrity: sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==}
@@ -3579,6 +3621,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
+  '@typescript-eslint/utils@8.57.1':
+    resolution: {integrity: sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@8.58.0':
     resolution: {integrity: sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3592,6 +3641,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.22.0':
     resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.57.1':
+    resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.58.0':
@@ -3947,6 +4000,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -6176,6 +6233,10 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -7427,6 +7488,12 @@ packages:
 
   ts-api-utils@2.0.0:
     resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -10235,6 +10302,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.57.1
+      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.57.1
+      debug: 4.4.3
+      eslint: 8.57.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.58.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.0
@@ -10247,6 +10326,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.57.1(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.57.1
+      debug: 4.4.3
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.58.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.7.3)
@@ -10255,6 +10343,20 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/rule-tester@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/parser': 8.57.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@8.57.1)(typescript@5.7.3)
+      ajv: 6.12.6
+      eslint: 8.57.1
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@typescript-eslint/rule-tester@8.58.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
@@ -10280,10 +10382,19 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/visitor-keys': 8.22.0
 
+  '@typescript-eslint/scope-manager@8.57.1':
+    dependencies:
+      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/visitor-keys': 8.57.1
+
   '@typescript-eslint/scope-manager@8.58.0':
     dependencies:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/visitor-keys': 8.58.0
+
+  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@5.7.3)':
+    dependencies:
+      typescript: 5.7.3
 
   '@typescript-eslint/tsconfig-utils@8.58.0(typescript@5.7.3)':
     dependencies:
@@ -10304,6 +10415,8 @@ snapshots:
   '@typescript-eslint/types@8.17.0': {}
 
   '@typescript-eslint/types@8.22.0': {}
+
+  '@typescript-eslint/types@8.57.1': {}
 
   '@typescript-eslint/types@8.58.0': {}
 
@@ -10332,6 +10445,21 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.7.0
       ts-api-utils: 2.0.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.57.1(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/visitor-keys': 8.57.1
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -10374,6 +10502,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.57.1
+      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
+      eslint: 8.57.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.58.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
@@ -10394,6 +10533,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.22.0
       eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.57.1':
+    dependencies:
+      '@typescript-eslint/types': 8.57.1
+      eslint-visitor-keys: 5.0.1
 
   '@typescript-eslint/visitor-keys@8.58.0':
     dependencies:
@@ -10850,6 +10994,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   brace-expansion@5.0.5:
     dependencies:
@@ -12523,7 +12671,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.0
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -13139,7 +13287,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.0
+      semver: 7.7.4
 
   makeerror@1.0.12:
     dependencies:
@@ -13945,6 +14093,10 @@ snapshots:
   minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
+
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
 
   minimatch@10.2.5:
     dependencies:
@@ -15416,6 +15568,10 @@ snapshots:
       typescript: 5.7.3
 
   ts-api-utils@2.0.0(typescript@5.7.3):
+    dependencies:
+      typescript: 5.7.3
+
+  ts-api-utils@2.4.0(typescript@5.7.3):
     dependencies:
       typescript: 5.7.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,8 +316,8 @@ importers:
         specifier: 8.17.0
         version: 8.17.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/rule-tester':
-        specifier: ^8.46.3
-        version: 8.57.1(eslint@8.57.1)(typescript@5.7.3)
+        specifier: ^8.58.0
+        version: 8.58.2(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
         version: 3.9.0(@swc/helpers@0.5.17)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
@@ -465,15 +465,15 @@ importers:
   packages/eslint-plugin-wonder-blocks:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: ^8.46.4
-        version: 8.58.0(eslint@8.57.1)(typescript@5.7.3)
+        specifier: ^8.58.0
+        version: 8.58.2(eslint@8.57.1)(typescript@5.7.3)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
         version: link:../../build-settings
-      '@typescript-eslint/rule-tester':
-        specifier: ^8.46.3
-        version: 8.58.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree':
+        specifier: ^8.58.2
+        version: 8.58.2(typescript@5.7.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -3485,40 +3485,21 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.57.1':
-    resolution: {integrity: sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/parser@8.58.0':
-    resolution: {integrity: sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==}
+  '@typescript-eslint/parser@8.58.2':
+    resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.57.1':
-    resolution: {integrity: sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.58.0':
-    resolution: {integrity: sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==}
+  '@typescript-eslint/project-service@8.58.2':
+    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/rule-tester@8.57.1':
-    resolution: {integrity: sha512-gk0q0rLa7a1uEB0iD2t1GZELK1z6HfudiKYeSVhjQ5gW5FdL0OcZ+8f09Lg7NbmHSBF3V+S9BDuw0qoCFkHR+w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-
-  '@typescript-eslint/rule-tester@8.58.0':
-    resolution: {integrity: sha512-a/J72Cxeo5ug5sbey7+Dcna6tMBc4Z4eYwBEKM6MVuBqbxnROpLm8yn/j00lPZc75joPZJVR5oiTZxbK95zp+w==}
+  '@typescript-eslint/rule-tester@8.58.2':
+    resolution: {integrity: sha512-HF7ry5ZhQSLn4JAJfQCPX39D6BE5MhYXE743I0phrJw1BvB0adH8JpsEc4owCxEESQflodyhRWNUZY+m2EVenw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3531,22 +3512,12 @@ packages:
     resolution: {integrity: sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.57.1':
-    resolution: {integrity: sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==}
+  '@typescript-eslint/scope-manager@8.58.2':
+    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.58.0':
-    resolution: {integrity: sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.57.1':
-    resolution: {integrity: sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/tsconfig-utils@8.58.0':
-    resolution: {integrity: sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==}
+  '@typescript-eslint/tsconfig-utils@8.58.2':
+    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -3569,12 +3540,8 @@ packages:
     resolution: {integrity: sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.57.1':
-    resolution: {integrity: sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.58.0':
-    resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
+  '@typescript-eslint/types@8.58.2':
+    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.17.0':
@@ -3592,14 +3559,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/typescript-estree@8.57.1':
-    resolution: {integrity: sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/typescript-estree@8.58.0':
-    resolution: {integrity: sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==}
+  '@typescript-eslint/typescript-estree@8.58.2':
+    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -3621,15 +3582,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/utils@8.57.1':
-    resolution: {integrity: sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/utils@8.58.0':
-    resolution: {integrity: sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==}
+  '@typescript-eslint/utils@8.58.2':
+    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3643,12 +3597,8 @@ packages:
     resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.57.1':
-    resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.58.0':
-    resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
+  '@typescript-eslint/visitor-keys@8.58.2':
+    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -4000,10 +3950,6 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4979,12 +4925,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -6232,10 +6178,6 @@ packages:
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
-
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -7488,12 +7430,6 @@ packages:
 
   ts-api-utils@2.0.0:
     resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
-  ts-api-utils@2.4.0:
-    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -10302,67 +10238,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.58.2(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.58.0
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3
-      eslint: 8.57.1
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.57.1(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/types': 8.58.2
       debug: 4.4.3
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.0(typescript@5.7.3)':
+  '@typescript-eslint/rule-tester@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.7.3)
-      '@typescript-eslint/types': 8.58.0
-      debug: 4.4.3
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/rule-tester@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/parser': 8.57.1(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@8.57.1)(typescript@5.7.3)
-      ajv: 6.12.6
-      eslint: 8.57.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/rule-tester@8.58.0(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/parser': 8.58.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.58.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@8.57.1)(typescript@5.7.3)
       ajv: 6.12.6
       eslint: 8.57.1
       json-stable-stringify-without-jsonify: 1.0.1
@@ -10382,21 +10283,12 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/visitor-keys': 8.22.0
 
-  '@typescript-eslint/scope-manager@8.57.1':
+  '@typescript-eslint/scope-manager@8.58.2':
     dependencies:
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
 
-  '@typescript-eslint/scope-manager@8.58.0':
-    dependencies:
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/visitor-keys': 8.58.0
-
-  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@5.7.3)':
-    dependencies:
-      typescript: 5.7.3
-
-  '@typescript-eslint/tsconfig-utils@8.58.0(typescript@5.7.3)':
+  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.7.3)':
     dependencies:
       typescript: 5.7.3
 
@@ -10416,9 +10308,7 @@ snapshots:
 
   '@typescript-eslint/types@8.22.0': {}
 
-  '@typescript-eslint/types@8.57.1': {}
-
-  '@typescript-eslint/types@8.58.0': {}
+  '@typescript-eslint/types@8.58.2': {}
 
   '@typescript-eslint/typescript-estree@8.17.0(typescript@5.7.3)':
     dependencies:
@@ -10449,27 +10339,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.57.1(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/visitor-keys': 8.57.1
-      debug: 4.4.3
-      minimatch: 10.2.4
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.58.0(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.58.0(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.7.3)
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/visitor-keys': 8.58.0
+      '@typescript-eslint/project-service': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -10502,23 +10377,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
-      eslint: 8.57.1
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.58.0(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.58.0
-      '@typescript-eslint/types': 8.58.0
-      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -10534,14 +10398,9 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       eslint-visitor-keys: 4.2.0
 
-  '@typescript-eslint/visitor-keys@8.57.1':
+  '@typescript-eslint/visitor-keys@8.58.2':
     dependencies:
-      '@typescript-eslint/types': 8.57.1
-      eslint-visitor-keys: 5.0.1
-
-  '@typescript-eslint/visitor-keys@8.58.0':
-    dependencies:
-      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -10994,10 +10853,6 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.4:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.5:
     dependencies:
@@ -14094,10 +13949,6 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.4
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -15568,10 +15419,6 @@ snapshots:
       typescript: 5.7.3
 
   ts-api-utils@2.0.0(typescript@5.7.3):
-    dependencies:
-      typescript: 5.7.3
-
-  ts-api-utils@2.4.0(typescript@5.7.3):
     dependencies:
       typescript: 5.7.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,9 +315,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: 8.17.0
         version: 8.17.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/rule-tester':
-        specifier: ^8.58.0
-        version: 8.58.2(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
         version: 3.9.0(@swc/helpers@0.5.17)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
@@ -465,15 +462,18 @@ importers:
   packages/eslint-plugin-wonder-blocks:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: ^8.58.0
-        version: 8.58.2(eslint@8.57.1)(typescript@5.7.3)
+        specifier: ^8.59.0
+        version: 8.59.0(eslint@8.57.1)(typescript@5.7.3)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
         version: link:../../build-settings
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.59.0
+        version: 8.59.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree':
-        specifier: ^8.58.2
-        version: 8.58.2(typescript@5.7.3)
+        specifier: ^8.59.0
+        version: 8.59.0(typescript@5.7.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -489,9 +489,15 @@ importers:
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../../wonder-blocks-core
+      '@khanacademy/wonder-blocks-form':
+        specifier: workspace:*
+        version: link:../../wonder-blocks-form
       '@khanacademy/wonder-blocks-link':
         specifier: workspace:*
         version: link:../../wonder-blocks-link
+      '@khanacademy/wonder-blocks-typography':
+        specifier: workspace:*
+        version: link:../../wonder-blocks-typography
       '@types/react':
         specifier: '18'
         version: 18.3.18
@@ -3485,21 +3491,21 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.58.2':
-    resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.58.2':
-    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/rule-tester@8.58.2':
-    resolution: {integrity: sha512-HF7ry5ZhQSLn4JAJfQCPX39D6BE5MhYXE743I0phrJw1BvB0adH8JpsEc4owCxEESQflodyhRWNUZY+m2EVenw==}
+  '@typescript-eslint/rule-tester@8.59.0':
+    resolution: {integrity: sha512-2Ej6W28DqObFuEUQ+puEpDZFWFXAW7jIZ4TsgfLUCTNz1FID0NMfp1sXc+fQq8m5ysfPdhXAPjti6jYEu1oRcg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3512,12 +3518,12 @@ packages:
     resolution: {integrity: sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.58.2':
-    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.58.2':
-    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -3540,8 +3546,8 @@ packages:
     resolution: {integrity: sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.58.2':
-    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.17.0':
@@ -3559,8 +3565,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/typescript-estree@8.58.2':
-    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -3582,8 +3588,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/utils@8.58.2':
-    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
+  '@typescript-eslint/utils@8.59.0':
+    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3597,8 +3603,8 @@ packages:
     resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.58.2':
-    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -10238,32 +10244,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.2(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.59.0(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/rule-tester@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
       ajv: 6.12.6
       eslint: 8.57.1
       json-stable-stringify-without-jsonify: 1.0.1
@@ -10283,12 +10289,12 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/visitor-keys': 8.22.0
 
-  '@typescript-eslint/scope-manager@8.58.2':
+  '@typescript-eslint/scope-manager@8.59.0':
     dependencies:
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
 
-  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.7.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.7.3)':
     dependencies:
       typescript: 5.7.3
 
@@ -10308,7 +10314,7 @@ snapshots:
 
   '@typescript-eslint/types@8.22.0': {}
 
-  '@typescript-eslint/types@8.58.2': {}
+  '@typescript-eslint/types@8.59.0': {}
 
   '@typescript-eslint/typescript-estree@8.17.0(typescript@5.7.3)':
     dependencies:
@@ -10339,12 +10345,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/project-service': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -10377,12 +10383,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -10398,9 +10404,9 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       eslint-visitor-keys: 4.2.0
 
-  '@typescript-eslint/visitor-keys@8.58.2':
+  '@typescript-eslint/visitor-keys@8.59.0':
     dependencies:
-      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}


### PR DESCRIPTION
## Summary:
Adds new lint rule for the BodyText Typography component to disallow certain parents:

### WB Components

- `Choice`, `Checkbox`, `Radio` — render a `<label>` internally; `<p>` can't be inside a `<label>`
- `Button`, `ActivityButton` — inline/button context; `<p>` can't be inside `<button>`
- `Heading`, `HeadingLarge`, `HeadingMedium`, `HeadingSmall`, `HeadingXSmall` — heading elements can't contain block-level children (question: should we include the older components?)

### HTML Elements

- `<button>` — inline/interactive element
- `<p>` — block element, can't contain another block element
- `<label>` — inline element
- `<h1>`–`<h6>` — heading elements

### Styled/custom variants
- `StyledButton`
- `StyledP`
- `StyledLabel`

### BodyText itself

- `<BodyText>` nested inside another `<BodyText>` — both default to `<p>`, which would be `<p><p>` (invalid HTML). Exception: if the outer BodyText has a block-container `tag` prop (`div`, `section`, `article`, etc.), it's fine.

## Questions:
- Naming. Do we like the lint rule `no-invalid-bodytext-parent`?
- The test cases for the lint rule itself. Do we want to change/add/remove anything?

Issue: WB-2247

## Test plan:
1. Ensure tests pass
2. Run the lint rule in WB and frontend (In progress)