### PR TITLE
Add Storybook docs for eslint-plugin-wonder-blocks

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -118,11 +118,8 @@ const parameters: Preview["parameters"] = {
     // https://storybook.js.org/docs/react/configure/story-layout
     layout: "padded",
     options: {
-        // Allowing stories to be sorted alphabetically. This means that we will
-        // display the stories (or examples first), then we will display all the
-        // mdx pages under __docs__.
         storySort: {
-            order: ["Components", "**/__docs__/**", "Overview"],
+            order: ["Foundations", "Packages", "Tools", "Catalog", "*"],
         },
     },
     docs: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -118,8 +118,11 @@ const parameters: Preview["parameters"] = {
     // https://storybook.js.org/docs/react/configure/story-layout
     layout: "padded",
     options: {
+        // Allowing stories to be sorted alphabetically. This means that we will
+        // display the stories (or examples first), then we will display all the
+        // mdx pages under __docs__.
         storySort: {
-            order: ["Foundations", "Packages", "Tools", "Catalog", "*"],
+            order: ["Foundations", "Packages", "Tools", "Catalog", "Components", "**/__docs__/**", "Overview"],
         },
     },
     docs: {

--- a/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
@@ -23,7 +23,7 @@ Wonder Blocks APIs.
 1. Install the package:
 
 ```sh
-pnpm install --save-dev @khanacademy/eslint-plugin-wonder-blocks
+pnpm add -D @khanacademy/eslint-plugin-wonder-blocks
 ```
 
 2. Add the plugin to your ESLint configuration and enable rules from the plugin:

--- a/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
@@ -8,12 +8,10 @@ import packageConfig from "../../../packages/eslint-plugin-wonder-blocks/package
 
 # eslint-plugin-wonder-blocks
 
-
 <ComponentInfo
     name={packageConfig.name}
     version={packageConfig.version}
 />
-
 
 `@khanacademy/eslint-plugin-wonder-blocks` is an ESLint plugin that includes
 lint rules that encourage correct usage of the Wonder Blocks design system.

--- a/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
@@ -1,0 +1,41 @@
+import {Meta} from "@storybook/addon-docs/blocks";
+import ComponentInfo from "../../components/component-info";
+import packageConfig from "../../../packages/eslint-plugin-wonder-blocks/package.json";
+
+<Meta
+    title="Tools / eslint-plugin-wonder-blocks"
+/>
+
+# eslint-plugin-wonder-blocks
+
+
+<ComponentInfo
+    name={packageConfig.name}
+    version={packageConfig.version}
+/>
+
+
+`@khanacademy/eslint-plugin-wonder-blocks` is an ESLint plugin that includes
+lint rules that encourage correct usage of the Wonder Blocks design system.
+It helps catch common mistakes and guides developers toward using the right
+Wonder Blocks APIs.
+
+## Installation
+
+1. Install the package:
+
+```sh
+pnpm install --save-dev @khanacademy/eslint-plugin-wonder-blocks
+```
+
+2. Add the plugin to your ESLint configuration and enable rules from the plugin:
+
+```js
+// .eslintrc.js
+module.exports = {
+    plugins: ["@khanacademy/wonder-blocks"],
+    rules: {
+        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+    },
+};
+```

--- a/__docs__/tools/eslint-plugin-wonder-blocks/no-custom-tab-role.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/no-custom-tab-role.mdx
@@ -1,0 +1,8 @@
+import {Meta, Markdown} from "@storybook/addon-docs/blocks";
+import lintRuleDocs from "../../../packages/eslint-plugin-wonder-blocks/docs/no-custom-tab-role.md?raw";
+
+<Meta
+    title="Tools / eslint-plugin-wonder-blocks / no-custom-tab-role"
+/>
+
+<Markdown>{lintRuleDocs}</Markdown>

--- a/__docs__/tools/eslint-plugin-wonder-blocks/no-custom-tab-role.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/no-custom-tab-role.mdx
@@ -2,7 +2,7 @@ import {Meta, Markdown} from "@storybook/addon-docs/blocks";
 import lintRuleDocs from "../../../packages/eslint-plugin-wonder-blocks/docs/no-custom-tab-role.md?raw";
 
 <Meta
-    title="Tools / eslint-plugin-wonder-blocks / no-custom-tab-role"
+    title="Tools / eslint-plugin-wonder-blocks / Rules / no-custom-tab-role"
 />
 
 <Markdown>{lintRuleDocs}</Markdown>


### PR DESCRIPTION
## Summary:

- Add docs for the eslint-plugin-wonder-blocks package
- Include the docs for the custom WB lint rule `no-custom-tag-role` in Storybook
  - We create a separate mdx for each lint rule so that the rule name shows up in the side navigation and can be found via the search bar 
- Specify order of root categories

Issue: WB-2304

## Test plan:

1. Review the docs for the eslint-plugin-wonder-blocks package

<img width="1718" height="884" alt="image" src="https://github.com/user-attachments/assets/0013b463-35f9-41ce-9fd7-bbf4316755ac" />

<img width="1723" height="930" alt="image" src="https://github.com/user-attachments/assets/79471d44-b269-49d3-ae13-6245a1f4e5b7" />
