### PR TITLE
Fix gh-pages.yml by stripping out symlinks from Storybook build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,6 +38,12 @@ jobs:
               # Generate a static version of storybook inside "storybook-static/"
               run: pnpm build:storybook
 
+            - name: Remove symlinks from Storybook output
+              # actions/upload-artifact does not preprocess the artifact like
+              # actions/upload-pages-artifact does. GitHub Pages deployment will
+              # fail if the artifact contains symlinks, so we remove them here.
+              run: find ./storybook-static -type l -delete
+
             - name: Upload Storybook artifact
               uses: actions/upload-artifact@v6
               with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,18 +38,26 @@ jobs:
               # Generate a static version of storybook inside "storybook-static/"
               run: pnpm build:storybook
 
-            - name: Remove symlinks from Storybook output
-              # actions/upload-artifact does not preprocess the artifact like
-              # actions/upload-pages-artifact does. GitHub Pages deployment will
-              # fail if the artifact contains symlinks, so we remove them here.
-              run: find ./storybook-static -type l -delete
+            - name: Archive Storybook artifact
+              # Replicates what actions/upload-pages-artifact does internally:
+              # --dereference and --hard-dereference resolve symlinks and hard
+              # links (the latter are created by pnpm's content-addressable
+              # store) so that the GitHub Pages deployment doesn't reject them.
+              shell: sh
+              run: |
+                  tar \
+                    --dereference --hard-dereference \
+                    --directory "./storybook-static" \
+                    -cvf "$RUNNER_TEMP/artifact.tar" \
+                    --exclude=.git \
+                    --exclude=.github \
+                    .
 
             - name: Upload Storybook artifact
               uses: actions/upload-artifact@v6
               with:
                   name: github-pages
-                  # Upload the generated static files
-                  path: "./storybook-static"
+                  path: "${{ runner.temp }}/artifact.tar"
 
     deploy:
         needs: build


### PR DESCRIPTION
## Summary:
One of the things the old actions/upload-pages-artifact was doing was stripping symlinks from the files before creating the tarball artifact and the rest of the GH Pages upload process requires there to be no symlinks.  This PR fixes the issue by stripping out the symlinks before packaging.

Issue: None

## Test plan:
- land, watch the logs for the gh-pages.yml workflow