### PR TITLE
Fix release workflow network sandboxing for sigstore

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,8 @@ jobs:
               timeout-minutes: 5
               with:
                   # registry.npmjs.org: npm package registry for pnpm install and npm publish
-                  extra-domains: registry.npmjs.org
+                  # fulcio.sigstore.dev,rekor.sigstore.dev: signing certificates are stored here
+                  extra-domains: registry.npmjs.org fulcio.sigstore.dev rekor.sigstore.dev
 
             - name: Install & cache node_modules
               uses: ./.github/actions/shared-node-cache


### PR DESCRIPTION
## Summary                    
  - Add `fulcio.sigstore.dev` and `rekor.sigstore.dev` to the release job's network allowlist so provenance signing can complete successfully                                                                                                                
  - The `publish_snapshot` job already had these domains but the release job was missing them                                   
  - Mirrors the same fix from Khan/perseus#3486 (and Khan/perseus#3487)
                                                                                                                            
  Issue: none                                                                                                                 
                                                                                                                              
  ## Test plan                                                                                                                
  - Once this lands, the next release should complete successfully with provenance signing                                    
  - Can also manually trigger with `gh workflow run publish.yml --ref main -f run_type=release`