### PR TITLE
Set up shared recommended and strict eslint config

### DIFF
--- a/.changeset/tender-dogs-sneeze.md
+++ b/.changeset/tender-dogs-sneeze.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-wonder-blocks-demo": minor
+"@khanacademy/eslint-plugin-wonder-blocks": minor
+---
+
+Create shared `recommended` and `strict` eslint config

--- a/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
@@ -1,39 +1,28 @@
-import {Meta} from "@storybook/addon-docs/blocks";
+import {Meta, Markdown, CodeOrSourceMdx} from "@storybook/addon-docs/blocks";
 import ComponentInfo from "../../components/component-info";
 import packageConfig from "../../../packages/eslint-plugin-wonder-blocks/package.json";
+import packageReadme from "../../../packages/eslint-plugin-wonder-blocks/README.md?raw";
+
 
 <Meta
     title="Tools / eslint-plugin-wonder-blocks"
 />
-
-# eslint-plugin-wonder-blocks
 
 <ComponentInfo
     name={packageConfig.name}
     version={packageConfig.version}
 />
 
-`@khanacademy/eslint-plugin-wonder-blocks` is an ESLint plugin that includes
-lint rules that encourage correct usage of the Wonder Blocks design system.
-It helps catch common mistakes and guides developers toward using the right
-Wonder Blocks APIs.
+<Markdown
+    options={{
+        overrides: {
+            // Override the default anchor behavior to prevent relative links in the original md file
+            a: ({children}) => <span>{children}</span>,
+            // Override the default code block behavior to include syntax highlighting
+            code: CodeOrSourceMdx,
+        },
+    }
+}>
+    {packageReadme}
+</Markdown>
 
-## Installation
-
-1. Install the package:
-
-```sh
-pnpm add -D @khanacademy/eslint-plugin-wonder-blocks
-```
-
-2. Add the plugin to your ESLint configuration and enable rules from the plugin:
-
-```js
-// .eslintrc.js
-module.exports = {
-    plugins: ["@khanacademy/wonder-blocks"],
-    rules: {
-        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
-    },
-};
-```

--- a/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/eslint-plugin-wonder-blocks.mdx
@@ -1,4 +1,5 @@
 import {Meta, Markdown, CodeOrSourceMdx} from "@storybook/addon-docs/blocks";
+import LinkTo from "@storybook/addon-links/react";
 import ComponentInfo from "../../components/component-info";
 import packageConfig from "../../../packages/eslint-plugin-wonder-blocks/package.json";
 import packageReadme from "../../../packages/eslint-plugin-wonder-blocks/README.md?raw";
@@ -16,8 +17,24 @@ import packageReadme from "../../../packages/eslint-plugin-wonder-blocks/README.
 <Markdown
     options={{
         overrides: {
-            // Override the default anchor behavior to prevent relative links in the original md file
-            a: ({children}) => <span>{children}</span>,
+            // Override the default anchor behavior to convert relative rule doc links to Storybook paths.
+            // Links inside <Markdown> are not intercepted by Storybook's router, so we use LinkTo
+            // from @storybook/addon-links to navigate within the Storybook manager.
+            a: ({children, href}) => {
+                const docsMatch = href?.match(/^docs\/(.+)\.md$/);
+                if (docsMatch) {
+                    const ruleName = docsMatch[1];
+                    return (
+                        <LinkTo
+                            title={`Tools / eslint-plugin-wonder-blocks / Rules / ${ruleName}`}
+                            story="docs"
+                        >
+                            {children}
+                        </LinkTo>
+                    );
+                }
+                return <a href={href}>{children}</a>;
+            },
             // Override the default code block behavior to include syntax highlighting
             code: CodeOrSourceMdx,
         },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@jest/globals": "^29.7.0",
     "@khanacademy/eslint-config": "^5.2.0",
     "@khanacademy/eslint-plugin": "^3.1.1",
+    "@khanacademy/eslint-plugin-wonder-blocks": "workspace:*",
     "@khanacademy/wonder-blocks-accordion": "workspace:*",
     "@khanacademy/wonder-blocks-announcer": "workspace:*",
     "@khanacademy/wonder-blocks-badge": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@rollup/plugin-swc": "^0.4.0",
     "@storybook/addon-a11y": "^10.1.10",
     "@storybook/addon-docs": "^10.1.10",
+    "@storybook/addon-links": "10.1.10",
     "@storybook/addon-mcp": "^0.4.1",
     "@storybook/addon-vitest": "10.1.10",
     "@storybook/builder-vite": "^10.1.10",

--- a/packages/eslint-plugin-wonder-blocks/CONTRIBUTING.md
+++ b/packages/eslint-plugin-wonder-blocks/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing to eslint-plugin-wonder-blocks
+
+## Creating a new lint rule
+
+Here are some helpful resources for setting up a new lint rule:
+
+- [TypeScript ESLint custom rules](https://typescript-eslint.io/developers/custom-rules/)
+- [AST Explorer](https://astexplorer.net/): A tool for showing what the abstract syntax tree (AST) looks like based on code
+- [ESTree Spec](https://github.com/estree/estree/tree/master): The spec for learning more about the AST node types
+
+## Demo
+
+The `demo/` directory contains a sample project for verifying that rules work
+as expected. See [`demo/README.md`](demo/README.md) for setup and usage instructions.

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -1,20 +1,30 @@
 # eslint-plugin-wonder-blocks
 
-An ESLint plugin for the Wonder Blocks design system.
+`@khanacademy/eslint-plugin-wonder-blocks` is an ESLint plugin that includes
+lint rules that encourage correct usage of the Wonder Blocks design system.
+It helps catch common mistakes and guides developers toward using the right
+Wonder Blocks APIs.
+
+## Installation
+
+1. Install the package:
+
+```sh
+pnpm add -D @khanacademy/eslint-plugin-wonder-blocks
+```
+
+2. Add the plugin to your ESLint configuration and enable rules from the plugin:
+
+```js
+// .eslintrc.js
+module.exports = {
+    plugins: ["@khanacademy/wonder-blocks"],
+    rules: {
+        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+    },
+};
+```
 
 ## Rules
 
 - [wonder-blocks/no-custom-tab-role](docs/no-custom-tab-role.md)
-
-## Creating a new lint rule
-
-Here are some helpful resources for setting up a new lint rule:
-
-- [TypeScript ESLint custom rules](https://typescript-eslint.io/developers/custom-rules/)
-- [AST Explorer](https://astexplorer.net/): A tool for showing what the abstract syntax tree (AST) looks like based on code
-- [ESTree Spec](https://github.com/estree/estree/tree/master): The spec for learning more about the AST node types
-
-## Demo
-
-The `demo/` directory contains a sample project for verifying that rules work
-as expected. See [`demo/README.md`](demo/README.md) for setup and usage instructions.

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -70,4 +70,4 @@ The following shows what rules are enabled in each config:
 
 | Rule | Enabled in `recommended`| Enabled in `strict` |
 |------|-------------------------|---------------------|
-| [`no-custom-tab-role`](docs/no-custom-tab-role.md)|✅|✅|
+| [`no-custom-tab-role`](docs/no-custom-tab-role.md)| |✅|

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -70,4 +70,4 @@ The following shows what rules are enabled in each config:
 
 | Rule | Enabled in `recommended`| Enabled in `strict` |
 |------|-------------------------|---------------------|
-| [`wonder-blocks/no-custom-tab-role`](docs/no-custom-tab-role.md)|✅|✅|
+| [`no-custom-tab-role`](docs/no-custom-tab-role.md)|✅|✅|

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -9,22 +9,65 @@ Wonder Blocks APIs.
 
 1. Install the package:
 
-```sh
-pnpm add -D @khanacademy/eslint-plugin-wonder-blocks
-```
+    ```sh
+    pnpm add -D @khanacademy/eslint-plugin-wonder-blocks
+    ```
 
-2. Add the plugin to your ESLint configuration and enable rules from the plugin:
+2. Add the plugin to your ESLint configuration and extend the `strict` or
+`recommended` config from the plugin:
+
+    ```js
+    // .eslintrc.js
+    module.exports = {
+        extends: ["plugin:@khanacademy/wonder-blocks/strict"],
+    };
+    ```
+
+    Or configure specific rules from the plugin:
+
+    ```js
+    // .eslintrc.js
+    module.exports = {
+        plugins: ["@khanacademy/wonder-blocks"],
+        rules: {
+            "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+        },
+    };
+    ```
+
+## Config
+
+The plugin provides two configs with different levels:
+
+### `recommended`
+
+Includes rules marked as `recommended`. This includes base rules for using
+Wonder Blocks.
 
 ```js
 // .eslintrc.js
 module.exports = {
-    plugins: ["@khanacademy/wonder-blocks"],
-    rules: {
-        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
-    },
+    extends: ["plugin:@khanacademy/wonder-blocks/recommended"],
+};
+```
+
+### `strict`
+
+Includes all `recommended` rules plus additional opinionated rules that enforce
+stricter Wonder Blocks usage patterns. Intended for projects that want to fully
+align with Wonder Blocks best practices.
+
+```js
+// .eslintrc.js
+module.exports = {
+    extends: ["plugin:@khanacademy/wonder-blocks/strict"],
 };
 ```
 
 ## Rules
 
-- [wonder-blocks/no-custom-tab-role](docs/no-custom-tab-role.md)
+The following shows what rules are enabled in each config:
+
+| Rule | Enabled in `recommended`| Enabled in `strict` |
+|------|-------------------------|---------------------|
+| [`wonder-blocks/no-custom-tab-role`](docs/no-custom-tab-role.md)|✅|✅|

--- a/packages/eslint-plugin-wonder-blocks/demo/.eslintrc.js
+++ b/packages/eslint-plugin-wonder-blocks/demo/.eslintrc.js
@@ -2,7 +2,5 @@ module.exports = {
     root: true,
     plugins: ["@khanacademy/wonder-blocks"],
     parser: "@typescript-eslint/parser",
-    rules: {
-        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
-    },
+    extends: ["plugin:@khanacademy/wonder-blocks/strict"],
 };

--- a/packages/eslint-plugin-wonder-blocks/demo/.eslintrc.js
+++ b/packages/eslint-plugin-wonder-blocks/demo/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
     root: true,
-    plugins: ["@khanacademy/wonder-blocks"],
     parser: "@typescript-eslint/parser",
     extends: ["plugin:@khanacademy/wonder-blocks/strict"],
 };

--- a/packages/eslint-plugin-wonder-blocks/demo/README.md
+++ b/packages/eslint-plugin-wonder-blocks/demo/README.md
@@ -1,7 +1,10 @@
 # eslint-plugin-wonder-blocks Demo
 
 This directory is a standalone project used to manually verify that the
-`eslint-plugin-wonder-blocks` rules work correctly end-to-end.
+`eslint-plugin-wonder-blocks` rules and config work correctly end-to-end.
+
+The demo project is configured with the `strict` eslint config from
+`eslint-plugin-wonder-blocks`.
 
 ## Why this exists
 

--- a/packages/eslint-plugin-wonder-blocks/src/configs/index.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/index.ts
@@ -1,0 +1,4 @@
+import recommended from "./recommended";
+import strict from "./strict";
+
+export const configs = {recommended, strict};

--- a/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
@@ -1,6 +1,4 @@
 export default {
     plugins: ["@khanacademy/wonder-blocks"],
-    rules: {
-        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
-    },
+    rules: {},
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
@@ -1,0 +1,6 @@
+export default {
+    plugins: ["@khanacademy/wonder-blocks"],
+    rules: {
+        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+    },
+};

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -1,7 +1,7 @@
 import recommended from "./recommended";
 
 export default {
-    plugins: ["@khanacademy/wonder-blocks"],
+    ...recommended,
     rules: {
         ...recommended.rules,
     },

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -4,5 +4,6 @@ export default {
     ...recommended,
     rules: {
         ...recommended.rules,
+        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -1,6 +1,8 @@
+import recommended from "./recommended";
+
 export default {
     plugins: ["@khanacademy/wonder-blocks"],
     rules: {
-        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+        ...recommended.rules,
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -1,0 +1,6 @@
+export default {
+    plugins: ["@khanacademy/wonder-blocks"],
+    rules: {
+        "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+    },
+};

--- a/packages/eslint-plugin-wonder-blocks/src/index.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/index.ts
@@ -1,3 +1,4 @@
 import {rules} from "./rules";
+import {configs} from "./configs";
 
-export {rules};
+export {rules, configs};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       '@storybook/addon-docs':
         specifier: ^10.1.10
         version: 10.1.10(@types/react@18.3.18)(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.1.10(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+      '@storybook/addon-links':
+        specifier: 10.1.10
+        version: 10.1.10(react@18.2.0)(storybook@10.1.10(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-mcp':
         specifier: ^0.4.1
         version: 0.4.1(@storybook/addon-vitest@10.1.10(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.1.10(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15))(storybook@10.1.10(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)
@@ -3020,6 +3023,15 @@ packages:
     peerDependencies:
       storybook: ^10.1.10
 
+  '@storybook/addon-links@10.1.10':
+    resolution: {integrity: sha512-SVKFDb14mne16QMGkmOEk+T4NLvCuFJJ1ecebQ01cPiG5gM72LhzYkAro717Aizd6owyMqcWs0Rsfwl09qi5zA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.1.10
+    peerDependenciesMeta:
+      react:
+        optional: true
+
   '@storybook/addon-mcp@0.4.1':
     resolution: {integrity: sha512-LJpzwFeS1Mw/k16T3NE1MuKa4EaJXGwt5kcVgupMnFa0Y3jbCCf2Hw9DjI6tQqc5w6hJG9DOA+YX9Qd+Pc2PZQ==}
     peerDependencies:
@@ -4904,12 +4916,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -9711,6 +9723,13 @@ snapshots:
       - rollup
       - vite
       - webpack
+
+  '@storybook/addon-links@10.1.10(react@18.2.0)(storybook@10.1.10(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      storybook: 10.1.10(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    optionalDependencies:
+      react: 18.2.0
 
   '@storybook/addon-mcp@0.4.1(@storybook/addon-vitest@10.1.10(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.1.10(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15))(storybook@10.1.10(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@khanacademy/eslint-plugin':
         specifier: ^3.1.1
         version: 3.1.1(eslint@8.57.1)(typescript@5.7.3)
+      '@khanacademy/eslint-plugin-wonder-blocks':
+        specifier: workspace:*
+        version: link:packages/eslint-plugin-wonder-blocks
       '@khanacademy/wonder-blocks-accordion':
         specifier: workspace:*
         version: link:packages/wonder-blocks-accordion

--- a/static/sb-styles/preview.css
+++ b/static/sb-styles/preview.css
@@ -97,8 +97,15 @@ html {
     line-height: var(--typography-heading-line-height-xs);
 }
 
+.sbdocs a>code {
+    /* Make sure code blocks inside links have link styling */
+    color: inherit;
+    text-decoration: underline;
+}
+
 /* Give the automatic TOC column more width instead of awkward scrolling */
-.sbdocs-toc--custom, .sbdocs-toc--custom nav {
+.sbdocs-toc--custom,
+.sbdocs-toc--custom nav {
     width: 22rem !important;
 }
 


### PR DESCRIPTION
## Summary:

Set up `strict` and `recommended` eslint configs. The `recommended` config will enable the base lint rules for WB usage, and the `strict` config includes the recommended rules + more specific rules intended for modern projects without legacy wb patterns.

We set up the `strict` config with the first wb lint rule `no-custom-tab-role`. As we add more lint rules, we can decide if it should only be enabled in recommended or strict cases. 


As part of this PR, I also updated the `eslint-plugin-wonder-blocks` README with information about the configs. This README is re-used for the SB docs. 

The demo project is also updated to use the `strict` config from the plugin. 

Issue: WB-2307

## Test plan:

1. Confirm that linting still works in the `demo` project
```sh
pnpm build
cd packages/eslint-plugin-wonder-blocks/demo
pnpm lint
```
You should see errors for the `no-custom-tab-role`. (To see this lint rules in the IDE, you can temporarily remove the `demo` dir from `.eslintignore` and restart the eslint server)

<img width="934" height="194" alt="Screenshot 2026-04-13 at 3 11 13 PM" src="https://github.com/user-attachments/assets/a45688a9-c851-44ba-95d4-85c00ee6b787" />

2. Confirm that the shared configs can be used in `frontend`. Here is the draft PR where I tested using the `strict` config for modern apps and the `recommended` config for the legacy app https://github.com/Khan/frontend/pull/10285

3. Review the docs in SB around installation steps and the configs `?path=/docs/tools-eslint-plugin-wonder-blocks--docs`