### PR TITLE
BodyText linting part 2: no-invalid-bodytext-children

### DIFF
--- a/.changeset/shy-ducks-collect.md
+++ b/.changeset/shy-ducks-collect.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-wonder-blocks-demo": minor
+"@khanacademy/eslint-plugin-wonder-blocks": minor
+---
+
+Add new Typography lint rule for no-invalid-bodytext-children to avoid invalid HTML nesting

--- a/.changeset/shy-ducks-collect.md
+++ b/.changeset/shy-ducks-collect.md
@@ -3,4 +3,7 @@
 "@khanacademy/eslint-plugin-wonder-blocks": minor
 ---
 
-Add new Typography lint rule for no-invalid-bodytext-children to avoid invalid HTML nesting
+Add two new ESLint rules for BodyText HTML validity and complexity
+
+- `no-invalid-bodytext-children` (recommended): flags block-level elements inside a phrasing-content BodyText. Accounts for BodyText's `tag` prop and View's `tag` prop — `<View tag="span">` is valid inside BodyText, `<BodyText tag="div">` allows block children.
+- `no-excessive-bodytext-children` (strict): flags BodyText with more direct JSX element children than a configurable threshold (default: 5). Separated from the validity rule so severity and options can be configured independently.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,12 @@ module.exports = {
             },
         },
         {
+            files: ["bodytext-tag-eslint-rule/**/*.js"],
+            rules: {
+                "import/no-commonjs": "off",
+            },
+        },
+        {
             files: ["**/*.test.*"],
             rules: {
                 "max-lines": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,12 +48,6 @@ module.exports = {
             },
         },
         {
-            files: ["bodytext-tag-eslint-rule/**/*.js"],
-            rules: {
-                "import/no-commonjs": "off",
-            },
-        },
-        {
             files: ["**/*.test.*"],
             rules: {
                 "max-lines": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -216,6 +216,7 @@ module.exports = {
                 matchers: ["toHaveNoA11yViolations"],
             },
         ],
+
         /**
          * TypeScript rules
          */

--- a/__docs__/tools/eslint-plugin-wonder-blocks/no-excessive-bodytext-children.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/no-excessive-bodytext-children.mdx
@@ -1,0 +1,8 @@
+import {Meta, Markdown} from "@storybook/addon-docs/blocks";
+import lintRuleDocs from "../../../packages/eslint-plugin-wonder-blocks/docs/no-excessive-bodytext-children.md?raw";
+
+<Meta
+    title="Tools / eslint-plugin-wonder-blocks / Rules / no-excessive-bodytext-children"
+/>
+
+<Markdown>{lintRuleDocs}</Markdown>

--- a/__docs__/tools/eslint-plugin-wonder-blocks/no-invalid-bodytext-children.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/no-invalid-bodytext-children.mdx
@@ -1,0 +1,8 @@
+import {Meta, Markdown} from "@storybook/addon-docs/blocks";
+import lintRuleDocs from "../../../packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md?raw";
+
+<Meta
+    title="Tools / eslint-plugin-wonder-blocks / Rules / no-invalid-bodytext-children"
+/>
+
+<Markdown>{lintRuleDocs}</Markdown>

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "8.17.0",
     "@typescript-eslint/parser": "8.17.0",
-    "@typescript-eslint/rule-tester": "^8.58.0",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/browser": "^4.0.15",
     "@vitest/browser-playwright": "^4.0.15",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "8.17.0",
     "@typescript-eslint/parser": "8.17.0",
+    "@typescript-eslint/rule-tester": "^8.46.3",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/browser": "^4.0.15",
     "@vitest/browser-playwright": "^4.0.15",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "8.17.0",
     "@typescript-eslint/parser": "8.17.0",
-    "@typescript-eslint/rule-tester": "^8.46.3",
+    "@typescript-eslint/rule-tester": "^8.58.0",
     "@vitejs/plugin-react-swc": "^3.9.0",
     "@vitest/browser": "^4.0.15",
     "@vitest/browser-playwright": "^4.0.15",

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -71,4 +71,5 @@ The following shows what rules are enabled in each config:
 | Rule | Enabled in `recommended`| Enabled in `strict` |
 |------|-------------------------|---------------------|
 | [`no-custom-tab-role`](docs/no-custom-tab-role.md)| |✅|
+| [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅| |
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -71,5 +71,5 @@ The following shows what rules are enabled in each config:
 | Rule | Enabled in `recommended`| Enabled in `strict` |
 |------|-------------------------|---------------------|
 | [`no-custom-tab-role`](docs/no-custom-tab-role.md)| |✅|
-| [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅| |
+| [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)| |✅|
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -71,5 +71,5 @@ The following shows what rules are enabled in each config:
 | Rule | Enabled in `recommended`| Enabled in `strict` |
 |------|-------------------------|---------------------|
 | [`no-custom-tab-role`](docs/no-custom-tab-role.md)| |✅|
-| [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)| |✅|
+| [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅|✅|
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -71,5 +71,6 @@ The following shows what rules are enabled in each config:
 | Rule | Enabled in `recommended`| Enabled in `strict` |
 |------|-------------------------|---------------------|
 | [`no-custom-tab-role`](docs/no-custom-tab-role.md)| |✅|
+| [`no-excessive-bodytext-children`](docs/no-excessive-bodytext-children.md)| |✅|
 | [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅|✅|
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-excessive-bodytext-children-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-excessive-bodytext-children-example.tsx
@@ -1,0 +1,47 @@
+/**
+ * This file demonstrates the wonder-blocks ESLint rule:
+ * `@khanacademy/wonder-blocks/no-excessive-bodytext-children`
+ * Run `pnpm lint` in this directory to see the errors.
+ */
+
+import * as React from "react";
+
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
+
+// ✅ Valid: five or fewer direct child elements
+export function ValidFewChildren() {
+    return (
+        <BodyText>
+            <span>one</span>
+            <span>two</span>
+            <span>three</span>
+            <span>four</span>
+            <span>five</span>
+        </BodyText>
+    );
+}
+
+// ✅ Valid: text nodes do not count toward the limit
+export function ValidTextNodes() {
+    return (
+        <BodyText>
+            Some text <strong>bold</strong> more text <em>emphasis</em> and
+            more text <span>inline</span> even more text <code>code</code> and
+            finally <a href="#">a link</a>.
+        </BodyText>
+    );
+}
+
+// ❌ Invalid: too many direct child elements (default max: 5)
+export function InvalidTooManyChildren() {
+    return (
+        <BodyText>
+            <span>one</span>
+            <span>two</span>
+            <span>three</span>
+            <span>four</span>
+            <span>five</span>
+            <span>six</span>
+        </BodyText>
+    );
+}

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-invalid-bodytext-children-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-invalid-bodytext-children-example.tsx
@@ -1,0 +1,102 @@
+/**
+ * This file demonstrates the wonder-blocks ESLint rule:
+ * `@khanacademy/wonder-blocks/no-invalid-bodytext-children`
+ * Run `pnpm lint` in this directory to see the errors.
+ */
+
+import * as React from "react";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import {
+    Heading,
+    HeadingLarge,
+    BodyText,
+} from "@khanacademy/wonder-blocks-typography";
+
+// ✅ Valid: inline/phrasing-content children
+export function ValidExamples() {
+    return (
+        <>
+            {/* Plain text */}
+            <BodyText>Hello world</BodyText>
+
+            {/* Inline HTML elements */}
+            <BodyText>
+                Text with <strong>bold</strong> and <em>emphasis</em>.
+            </BodyText>
+
+            {/* block-container tag allows block children */}
+            <BodyText tag="div">
+                <div>block content is fine here</div>
+            </BodyText>
+
+            {/* Inner BodyText with inline tag */}
+            <BodyText>
+                Outer <BodyText tag="span">inline nested</BodyText>
+            </BodyText>
+        </>
+    );
+}
+
+// ❌ Invalid: View is never valid inside BodyText
+export function InvalidViewChild() {
+    return (
+        <BodyText>
+            <View>layout</View>
+        </BodyText>
+    );
+}
+
+// ❌ Invalid: block-level HTML elements inside a default BodyText (<p>)
+export function InvalidBlockChildren() {
+    return (
+        <>
+            <BodyText>
+                <div>block content</div>
+            </BodyText>
+            <BodyText>
+                <p>nested paragraph</p>
+            </BodyText>
+            <BodyText>
+                <section>section content</section>
+            </BodyText>
+        </>
+    );
+}
+
+// ❌ Invalid: BodyText nested inside BodyText (both default to <p>)
+export function InvalidNestedBodyText() {
+    return (
+        <BodyText>
+            <BodyText>nested</BodyText>
+        </BodyText>
+    );
+}
+
+// ❌ Invalid: WB Heading components render as block-level headings
+export function InvalidHeadingChildren() {
+    return (
+        <>
+            <BodyText>
+                <Heading>Title</Heading>
+            </BodyText>
+            <BodyText>
+                <HeadingLarge>Title</HeadingLarge>
+            </BodyText>
+        </>
+    );
+}
+
+// ❌ Invalid: too many direct child elements (default max: 5)
+export function InvalidTooManyChildren() {
+    return (
+        <BodyText>
+            <span>one</span>
+            <span>two</span>
+            <span>three</span>
+            <span>four</span>
+            <span>five</span>
+            <span>six</span>
+        </BodyText>
+    );
+}

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-invalid-bodytext-children-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-invalid-bodytext-children-example.tsx
@@ -38,7 +38,16 @@ export function ValidExamples() {
     );
 }
 
-// ❌ Invalid: View is never valid inside BodyText
+// ✅ Valid: View with an inline tag is phrasing content
+export function ValidViewInlineTag() {
+    return (
+        <BodyText>
+            Read more <View tag="span">details here</View>.
+        </BodyText>
+    );
+}
+
+// ❌ Invalid: View defaults to <div> — block-level inside a <p>
 export function InvalidViewChild() {
     return (
         <BodyText>
@@ -79,16 +88,3 @@ export function InvalidHeadingChildren() {
     );
 }
 
-// ❌ Invalid: too many direct child elements (default max: 5)
-export function InvalidTooManyChildren() {
-    return (
-        <BodyText>
-            <span>one</span>
-            <span>two</span>
-            <span>three</span>
-            <span>four</span>
-            <span>five</span>
-            <span>six</span>
-        </BodyText>
-    );
-}

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-invalid-bodytext-children-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-invalid-bodytext-children-example.tsx
@@ -64,14 +64,6 @@ export function InvalidBlockChildren() {
     );
 }
 
-// ❌ Invalid: BodyText nested inside BodyText (both default to <p>)
-export function InvalidNestedBodyText() {
-    return (
-        <BodyText>
-            <BodyText>nested</BodyText>
-        </BodyText>
-    );
-}
 
 // ❌ Invalid: WB Heading components render as block-level headings
 export function InvalidHeadingChildren() {

--- a/packages/eslint-plugin-wonder-blocks/docs/no-excessive-bodytext-children.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-excessive-bodytext-children.md
@@ -1,0 +1,80 @@
+# no-excessive-bodytext-children
+
+Disallow `BodyText` with more direct JSX element children than a configurable
+threshold.
+
+## Rule Details
+
+`BodyText` is intended for text content, not complex layouts. When it contains
+many direct child elements, it is likely being used as a structural container —
+a role better served by `View` or another block-level element.
+
+There is also an accessibility concern: screen readers such as VoiceOver break
+up paragraph content at element boundaries. Each child element — even a `<span>`
+used purely for styling — interrupts the flow of content being read aloud.
+Keeping the number of child elements low reduces these interruptions and produces
+a more natural reading experience.
+
+Text nodes and expression containers (`{value}`) do not count toward the limit.
+
+Examples of **incorrect** code (with the default threshold of 5):
+
+```tsx
+<BodyText>
+    <span>one</span>
+    <span>two</span>
+    <span>three</span>
+    <span>four</span>
+    <span>five</span>
+    <span>six</span>
+</BodyText>
+```
+
+Examples of **correct** code:
+
+```tsx
+/* Five or fewer direct child elements */
+<BodyText>
+    <span>one</span>
+    <span>two</span>
+    <span>three</span>
+    <span>four</span>
+    <span>five</span>
+</BodyText>
+
+/* Text nodes do not count */
+<BodyText>
+    Some text <strong>bold</strong> more text <em>emphasis</em> and more.
+</BodyText>
+
+/* Use View for complex layouts */
+<View>
+    <BodyText>First paragraph</BodyText>
+    <BodyText>Second paragraph</BodyText>
+</View>
+```
+
+## Options
+
+```ts
+{
+    maxChildren?: number  // default: 5
+}
+```
+
+### `maxChildren`
+
+Sets the maximum number of direct JSX element children allowed in a single
+`BodyText`.
+
+```js
+// .eslintrc.js
+{
+    "@khanacademy/wonder-blocks/no-excessive-bodytext-children": ["error", { maxChildren: 3 }]
+}
+```
+
+## When Not To Use It
+
+Disable this rule if your team deliberately uses `BodyText` as a rich inline
+container and the child-count threshold is not a useful signal in your codebase.

--- a/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md
@@ -1,0 +1,117 @@
+# no-invalid-bodytext-children
+
+Disallow block-level elements and excessive direct children inside `BodyText`.
+
+## Rule Details
+
+`BodyText` renders as a `<p>` element by default. HTML does not allow block-level
+elements (e.g. `<div>`, `<section>`, headings) as children of `<p>`. Placing them
+inside a default `BodyText` produces invalid markup that browsers must silently
+repair, which can cause layout or accessibility issues.
+
+`View` always renders as `<div>` and is never valid as a child of `BodyText`,
+regardless of the `tag` prop.
+
+This rule also warns when `BodyText` has more than 5 direct JSX element children
+(configurable). `BodyText` is for text content — complex layouts with many child
+elements belong in a `View` or other block container.
+
+Add `tag="div"` (or another block-container tag) to `BodyText` to allow
+block-level children. Use `tag="span"` on a child `BodyText` to make it inline.
+
+Examples of **incorrect** code:
+
+```tsx
+/* <div> cannot be a child of <p> */
+<BodyText>
+    <div>some block content</div>
+</BodyText>
+
+/* <p> cannot be nested inside <p> */
+<BodyText>
+    <p>nested paragraph</p>
+</BodyText>
+
+/* BodyText defaults to <p> — two <p>s cannot nest */
+<BodyText>
+    <BodyText>nested</BodyText>
+</BodyText>
+
+/* Block-level HTML elements are not valid inside <p> */
+<BodyText>
+    <section>section content</section>
+</BodyText>
+<BodyText>
+    <h2>Subheading</h2>
+</BodyText>
+
+/* WB Heading components render as block-level elements */
+<BodyText>
+    <Heading>Title</Heading>
+</BodyText>
+
+/* View always renders as <div> — never valid inside BodyText */
+<BodyText>
+    <View>layout</View>
+</BodyText>
+
+/* Too many direct child elements (default max: 5) */
+<BodyText>
+    <span>one</span>
+    <span>two</span>
+    <span>three</span>
+    <span>four</span>
+    <span>five</span>
+    <span>six</span>
+</BodyText>
+```
+
+Examples of **correct** code:
+
+```tsx
+/* Inline/phrasing-content children are always valid */
+<BodyText>
+    Plain text with <strong>bold</strong> and <em>emphasis</em>.
+</BodyText>
+
+/* tag="div" allows block children */
+<BodyText tag="div">
+    <div>block content</div>
+</BodyText>
+
+/* tag="span" on inner BodyText makes it inline */
+<BodyText>
+    Outer text <BodyText tag="span">inline nested</BodyText>
+</BodyText>
+
+/* Use View for layouts that need block children */
+<View>
+    <BodyText>First paragraph</BodyText>
+    <BodyText>Second paragraph</BodyText>
+</View>
+```
+
+## Options
+
+```ts
+{
+    maxChildren?: number  // default: 5
+}
+```
+
+### `maxChildren`
+
+Sets the maximum number of direct JSX element children allowed in a single
+`BodyText`. Text nodes and expression containers do not count toward this limit.
+
+```js
+// .eslintrc.js
+{
+    "@khanacademy/wonder-blocks/no-invalid-bodytext-children": ["error", { maxChildren: 3 }]
+}
+```
+
+## When Not To Use It
+
+Disable this rule only if you are intentionally rendering HTML that deviates
+from the standard content model and have a specific reason to do so.

--- a/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md
@@ -49,7 +49,7 @@ Examples of **incorrect** code:
     <Heading>Title</Heading>
 </BodyText>
 
-/* View always renders as <div> — never valid inside BodyText */
+/* View defaults to <div> — invalid inside a paragraph BodyText */
 <BodyText>
     <View>layout</View>
 </BodyText>
@@ -81,6 +81,11 @@ Examples of **correct** code:
 /* tag="span" on inner BodyText makes it inline */
 <BodyText>
     Outer text <BodyText tag="span">inline nested</BodyText>
+</BodyText>
+
+/* tag="span" on View makes it inline — valid inside BodyText */
+<BodyText>
+    Read more <View tag="span">details here</View>.
 </BodyText>
 
 /* Use View for layouts that need block children */

--- a/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md
@@ -19,6 +19,10 @@ elements belong in a `View` or other block container.
 Add `tag="div"` (or another block-container tag) to `BodyText` to allow
 block-level children. Use `tag="span"` on a child `BodyText` to make it inline.
 
+`BodyText` nested inside another `BodyText` is handled by
+[`no-invalid-bodytext-parent`](./no-invalid-bodytext-parent.md), which also
+provides an auto-fix.
+
 Examples of **incorrect** code:
 
 ```tsx
@@ -30,11 +34,6 @@ Examples of **incorrect** code:
 /* <p> cannot be nested inside <p> */
 <BodyText>
     <p>nested paragraph</p>
-</BodyText>
-
-/* BodyText defaults to <p> — two <p>s cannot nest */
-<BodyText>
-    <BodyText>nested</BodyText>
 </BodyText>
 
 /* Block-level HTML elements are not valid inside <p> */

--- a/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-invalid-bodytext-children.md
@@ -1,6 +1,6 @@
 # no-invalid-bodytext-children
 
-Disallow block-level elements and excessive direct children inside `BodyText`.
+Disallow block-level elements inside `BodyText`.
 
 ## Rule Details
 
@@ -9,12 +9,8 @@ elements (e.g. `<div>`, `<section>`, headings) as children of `<p>`. Placing the
 inside a default `BodyText` produces invalid markup that browsers must silently
 repair, which can cause layout or accessibility issues.
 
-`View` always renders as `<div>` and is never valid as a child of `BodyText`,
-regardless of the `tag` prop.
-
-This rule also warns when `BodyText` has more than 5 direct JSX element children
-(configurable). `BodyText` is for text content — complex layouts with many child
-elements belong in a `View` or other block container.
+`View` defaults to `<div>` and is invalid as a child of a phrasing-content
+`BodyText` unless given an inline `tag` prop (e.g. `tag="span"`).
 
 Add `tag="div"` (or another block-container tag) to `BodyText` to allow
 block-level children. Use `tag="span"` on a child `BodyText` to make it inline.
@@ -49,19 +45,9 @@ Examples of **incorrect** code:
     <Heading>Title</Heading>
 </BodyText>
 
-/* View defaults to <div> — invalid inside a paragraph BodyText */
+/* View defaults to <div> — invalid inside a phrasing-content BodyText */
 <BodyText>
     <View>layout</View>
-</BodyText>
-
-/* Too many direct child elements (default max: 5) */
-<BodyText>
-    <span>one</span>
-    <span>two</span>
-    <span>three</span>
-    <span>four</span>
-    <span>five</span>
-    <span>six</span>
 </BodyText>
 ```
 
@@ -93,26 +79,6 @@ Examples of **correct** code:
     <BodyText>First paragraph</BodyText>
     <BodyText>Second paragraph</BodyText>
 </View>
-```
-
-## Options
-
-```ts
-{
-    maxChildren?: number  // default: 5
-}
-```
-
-### `maxChildren`
-
-Sets the maximum number of direct JSX element children allowed in a single
-`BodyText`. Text nodes and expression containers do not count toward this limit.
-
-```js
-// .eslintrc.js
-{
-    "@khanacademy/wonder-blocks/no-invalid-bodytext-children": ["error", { maxChildren: 3 }]
-}
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
@@ -1,4 +1,6 @@
 export default {
     plugins: ["@khanacademy/wonder-blocks"],
-    rules: {},
+    rules: {
+        "@khanacademy/wonder-blocks/no-invalid-bodytext-children": "error",
+    },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -5,6 +5,7 @@ export default {
     rules: {
         ...recommended.rules,
         "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+        "@khanacademy/wonder-blocks/no-invalid-bodytext-children": "error",
         "@khanacademy/wonder-blocks/no-invalid-bodytext-parent": "error",
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -5,6 +5,7 @@ export default {
     rules: {
         ...recommended.rules,
         "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
+        "@khanacademy/wonder-blocks/no-excessive-bodytext-children": "error",
         "@khanacademy/wonder-blocks/no-invalid-bodytext-parent": "error",
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -5,7 +5,6 @@ export default {
     rules: {
         ...recommended.rules,
         "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
-        "@khanacademy/wonder-blocks/no-invalid-bodytext-children": "error",
         "@khanacademy/wonder-blocks/no-invalid-bodytext-parent": "error",
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/jsx-utils.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/jsx-utils.test.ts
@@ -1,7 +1,7 @@
 import {parse} from "@typescript-eslint/typescript-estree";
 import {TSESTree} from "@typescript-eslint/utils";
 
-import {getAttributeStringValue} from "../jsx-utils";
+import {getAttributeStringValue, rendersAsParagraph} from "../jsx-utils";
 
 /**
  * Parses a self-closing JSX element and returns its opening element node.
@@ -78,5 +78,62 @@ describe("getAttributeStringValue", () => {
 
         // Assert
         expect(result).toBeNull();
+    });
+});
+
+describe("rendersAsParagraph", () => {
+    it("returns true when there is no tag prop", () => {
+        // Arrange
+        const node = parseOpeningElement(`<BodyText />`);
+
+        // Act
+        const result = rendersAsParagraph(node);
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("returns true when tag is explicitly set to 'p'", () => {
+        // Arrange
+        const node = parseOpeningElement(`<BodyText tag="p" />`);
+
+        // Act
+        const result = rendersAsParagraph(node);
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("returns false when tag is an inline tag", () => {
+        // Arrange
+        const node = parseOpeningElement(`<BodyText tag="span" />`);
+
+        // Act
+        const result = rendersAsParagraph(node);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+
+    it("returns false when tag is a block-container tag", () => {
+        // Arrange
+        const node = parseOpeningElement(`<BodyText tag="div" />`);
+
+        // Act
+        const result = rendersAsParagraph(node);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+
+    it("returns true when tag is a dynamic expression (unknown value treated as paragraph)", () => {
+        // Arrange
+        const node = parseOpeningElement(`<BodyText tag={getTag()} />`);
+
+        // Act
+        const result = rendersAsParagraph(node);
+
+        // Assert
+        expect(result).toBe(true);
     });
 });

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/jsx-utils.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/jsx-utils.test.ts
@@ -1,7 +1,10 @@
 import {parse} from "@typescript-eslint/typescript-estree";
 import {TSESTree} from "@typescript-eslint/utils";
 
-import {getAttributeStringValue, rendersAsParagraph} from "../jsx-utils";
+import {
+    getAttributeStringValue,
+    bodyTextRendersAsParagraph,
+} from "../jsx-utils";
 
 /**
  * Parses a self-closing JSX element and returns its opening element node.
@@ -81,13 +84,13 @@ describe("getAttributeStringValue", () => {
     });
 });
 
-describe("rendersAsParagraph", () => {
+describe("bodyTextRendersAsParagraph", () => {
     it("returns true when there is no tag prop", () => {
         // Arrange
         const node = parseOpeningElement(`<BodyText />`);
 
         // Act
-        const result = rendersAsParagraph(node);
+        const result = bodyTextRendersAsParagraph(node);
 
         // Assert
         expect(result).toBe(true);
@@ -98,7 +101,7 @@ describe("rendersAsParagraph", () => {
         const node = parseOpeningElement(`<BodyText tag="p" />`);
 
         // Act
-        const result = rendersAsParagraph(node);
+        const result = bodyTextRendersAsParagraph(node);
 
         // Assert
         expect(result).toBe(true);
@@ -109,7 +112,7 @@ describe("rendersAsParagraph", () => {
         const node = parseOpeningElement(`<BodyText tag="span" />`);
 
         // Act
-        const result = rendersAsParagraph(node);
+        const result = bodyTextRendersAsParagraph(node);
 
         // Assert
         expect(result).toBe(false);
@@ -120,7 +123,7 @@ describe("rendersAsParagraph", () => {
         const node = parseOpeningElement(`<BodyText tag="div" />`);
 
         // Act
-        const result = rendersAsParagraph(node);
+        const result = bodyTextRendersAsParagraph(node);
 
         // Assert
         expect(result).toBe(false);
@@ -131,7 +134,7 @@ describe("rendersAsParagraph", () => {
         const node = parseOpeningElement(`<BodyText tag={getTag()} />`);
 
         // Act
-        const result = rendersAsParagraph(node);
+        const result = bodyTextRendersAsParagraph(node);
 
         // Assert
         expect(result).toBe(true);

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-excessive-bodytext-children.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-excessive-bodytext-children.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the no-excessive-bodytext-children ESLint rule.
+ *
+ * Uses ESLint's RuleTester to verify that the rule correctly flags BodyText
+ * components with more direct JSX element children than the configured
+ * threshold.
+ */
+import {RuleTester} from "@typescript-eslint/rule-tester";
+
+import {rules} from "..";
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            ecmaVersion: 2020,
+            ecmaFeatures: {jsx: true},
+            sourceType: "module",
+        },
+    },
+});
+
+const ruleName = "no-excessive-bodytext-children";
+const rule = rules[ruleName];
+
+ruleTester.run(ruleName, rule, {
+    valid: [
+        // Non-BodyText components are not checked
+        {
+            code: `<View><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></View>`,
+        },
+
+        // At or below the default threshold of 5 element children
+        {
+            code: `<BodyText><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></BodyText>`,
+        },
+
+        // At or below a custom threshold
+        {
+            code: `<BodyText><span>1</span><span>2</span></BodyText>`,
+            options: [{maxChildren: 2}],
+        },
+
+        // Text nodes do not count toward the child-element limit
+        {
+            code: `<BodyText>text <span>one</span> text <span>two</span> text <span>three</span> text <span>four</span> text <span>five</span> text</BodyText>`,
+        },
+
+        // Expression containers do not count toward the child-element limit
+        {code: `<BodyText>{value}<span>label</span></BodyText>`},
+    ],
+
+    invalid: [
+        {
+            code: `<BodyText><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></BodyText>`,
+            errors: [
+                {
+                    messageId: "tooManyChildren",
+                    data: {count: "6", max: "5"},
+                },
+            ],
+        },
+        {
+            // Custom threshold
+            code: `<BodyText><span>1</span><span>2</span><span>3</span></BodyText>`,
+            options: [{maxChildren: 2}],
+            errors: [
+                {
+                    messageId: "tooManyChildren",
+                    data: {count: "3", max: "2"},
+                },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the no-invalid-bodytext-children ESLint rule.
+ *
+ * Uses RuleTester to verify that the rule correctly flags block-level elements
+ * and excessive children inside BodyText components.
+ */
+import {RuleTester} from "@typescript-eslint/rule-tester";
+import noInvalidBodyTextChildren from "../no-invalid-bodytext-children";
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            ecmaVersion: 2020,
+            ecmaFeatures: {jsx: true},
+            sourceType: "module",
+        },
+    },
+});
+
+ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
+    // ------------------------------------------------------------------ //
+    // VALID — BodyText with phrasing content or appropriate tag prop     //
+    // ------------------------------------------------------------------ //
+    valid: [
+        // Plain text is always fine
+        {code: `<BodyText>Hello world</BodyText>`},
+
+        // Inline HTML elements are phrasing content
+        {code: `<BodyText><span>inline</span></BodyText>`},
+        {code: `<BodyText><em>emphasis</em></BodyText>`},
+        {code: `<BodyText><strong>bold</strong></BodyText>`},
+        {code: `<BodyText><a href="#">link</a></BodyText>`},
+        {code: `<BodyText><code>code</code></BodyText>`},
+        {code: `<BodyText><sup>1</sup></BodyText>`},
+        {code: `<BodyText><sub>2</sub></BodyText>`},
+
+        // Block children are OK when BodyText uses a block container tag
+        {code: `<BodyText tag="div"><div>block</div></BodyText>`},
+        {code: `<BodyText tag="section"><p>paragraph</p></BodyText>`},
+        {code: `<BodyText tag="article"><div>block</div></BodyText>`},
+
+        // Children count at or below the default threshold of 5
+        {
+            code: `<BodyText><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></BodyText>`,
+        },
+
+        // Children count at or below a custom threshold
+        {
+            code: `<BodyText><span>1</span><span>2</span></BodyText>`,
+            options: [{maxChildren: 2}],
+        },
+
+        // Text nodes do not count toward the child element limit
+        {
+            code: `<BodyText>text <span>one</span> text <span>two</span> text <span>three</span> text <span>four</span> text <span>five</span> text</BodyText>`,
+        },
+
+        // Block elements are OK when BodyText has an inline tag
+        // (BodyText still renders inline, so HTML validity depends on context,
+        // but no block children to report here)
+        {code: `<BodyText tag="span"><em>fine</em></BodyText>`},
+
+        // Expression containers are not counted as element children
+        {
+            code: `<BodyText>{value}<span>label</span></BodyText>`,
+        },
+    ],
+
+    // ------------------------------------------------------------------ //
+    // INVALID — block-level children or too many children                //
+    // ------------------------------------------------------------------ //
+    invalid: [
+        // --- View is always a block-level child ---
+        {
+            code: `<BodyText><View>layout</View></BodyText>`,
+            errors: [{messageId: "viewChild"}],
+        },
+        {
+            code: `<BodyText tag="div"><View>layout</View></BodyText>`,
+            errors: [{messageId: "viewChild"}],
+        },
+        {
+            code: `<BodyText tag="span"><View>layout</View></BodyText>`,
+            errors: [{messageId: "viewChild"}],
+        },
+
+        // --- HTML block elements inside default BodyText (<p>) ---
+        {
+            code: `<BodyText><div>block</div></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "div"}}],
+        },
+        {
+            code: `<BodyText><p>paragraph</p></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "p"}}],
+        },
+        {
+            code: `<BodyText><section>section</section></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "section"}}],
+        },
+        {
+            code: `<BodyText><ul><li>item</li></ul></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "ul"}}],
+        },
+        {
+            code: `<BodyText><ol><li>item</li></ol></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "ol"}}],
+        },
+        {
+            code: `<BodyText><blockquote>quote</blockquote></BodyText>`,
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "blockquote"},
+                },
+            ],
+        },
+        {
+            code: `<BodyText><pre>code</pre></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "pre"}}],
+        },
+
+        // --- HTML heading elements inside default BodyText ---
+        {
+            code: `<BodyText><h1>Heading</h1></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "h1"}}],
+        },
+        {
+            code: `<BodyText><h2>Heading</h2></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "h2"}}],
+        },
+
+        // --- WB Heading components inside default BodyText ---
+        {
+            code: `<BodyText><Heading>Title</Heading></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "Heading"}}],
+        },
+        {
+            code: `<BodyText><HeadingLarge>Title</HeadingLarge></BodyText>`,
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "HeadingLarge"},
+                },
+            ],
+        },
+
+        // --- Block children also flagged when BodyText has tag="p" ---
+        {
+            code: `<BodyText tag="p"><div>block</div></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "div"}}],
+        },
+
+        // --- Block children also flagged when BodyText has an inline tag ---
+        {
+            code: `<BodyText tag="span"><div>block</div></BodyText>`,
+            errors: [{messageId: "blockChild", data: {childName: "div"}}],
+        },
+
+        // --- Multiple block children each reported ---
+        {
+            code: `<BodyText><div>a</div><p>b</p></BodyText>`,
+            errors: [
+                {messageId: "blockChild", data: {childName: "div"}},
+                {messageId: "blockChild", data: {childName: "p"}},
+            ],
+        },
+
+        // --- Too many direct element children (default threshold: 5) ---
+        {
+            code: `<BodyText><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></BodyText>`,
+            errors: [
+                {
+                    messageId: "tooManyChildren",
+                    data: {count: "6", max: "5"},
+                },
+            ],
+        },
+
+        // --- Custom threshold ---
+        {
+            code: `<BodyText><span>1</span><span>2</span><span>3</span></BodyText>`,
+            options: [{maxChildren: 2}],
+            errors: [
+                {
+                    messageId: "tooManyChildren",
+                    data: {count: "3", max: "2"},
+                },
+            ],
+        },
+
+        // --- Block child + too many children both reported ---
+        // tooManyChildren is on the BodyText opening element (earlier in
+        // source), so it sorts before blockChild (on the child element).
+        {
+            code: `<BodyText><div>a</div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></BodyText>`,
+            errors: [
+                {
+                    messageId: "tooManyChildren",
+                    data: {count: "6", max: "5"},
+                },
+                {messageId: "blockChild", data: {childName: "div"}},
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
@@ -1,11 +1,12 @@
 /**
  * Tests for the no-invalid-bodytext-children ESLint rule.
  *
- * Uses RuleTester to verify that the rule correctly flags block-level elements
- * and excessive children inside BodyText components.
+ * Uses ESLint's RuleTester to verify that the rule correctly flags block-level
+ * elements and excessive children inside BodyText components.
  */
 import {RuleTester} from "@typescript-eslint/rule-tester";
-import noInvalidBodyTextChildren from "../no-invalid-bodytext-children";
+
+import {rules} from "..";
 
 const ruleTester = new RuleTester({
     languageOptions: {
@@ -17,9 +18,13 @@ const ruleTester = new RuleTester({
     },
 });
 
-ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
+const ruleName = "no-invalid-bodytext-children";
+const rule = rules[ruleName];
+
+ruleTester.run(ruleName, rule, {
     // ------------------------------------------------------------------ //
-    // VALID                                                               //
+    // VALID — inline/phrasing-content children are always allowed;        //
+    //         block children are fine when BodyText uses a block tag.     //
     // ------------------------------------------------------------------ //
     valid: [
         // Plain text is always fine
@@ -71,7 +76,8 @@ ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
     ],
 
     // ------------------------------------------------------------------ //
-    // INVALID                                                             //
+    // INVALID — block-level children inside a paragraph-rendering         //
+    //           BodyText, or too many direct element children.            //
     // ------------------------------------------------------------------ //
     invalid: [
         // ---------------------------------------------------------------- //

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
@@ -19,13 +19,13 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
     // ------------------------------------------------------------------ //
-    // VALID — BodyText with phrasing content or appropriate tag prop     //
+    // VALID                                                               //
     // ------------------------------------------------------------------ //
     valid: [
         // Plain text is always fine
         {code: `<BodyText>Hello world</BodyText>`},
 
-        // Inline HTML elements are phrasing content
+        // Inline/phrasing-content HTML elements
         {code: `<BodyText><span>inline</span></BodyText>`},
         {code: `<BodyText><em>emphasis</em></BodyText>`},
         {code: `<BodyText><strong>bold</strong></BodyText>`},
@@ -34,65 +34,119 @@ ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
         {code: `<BodyText><sup>1</sup></BodyText>`},
         {code: `<BodyText><sub>2</sub></BodyText>`},
 
-        // Block children are OK when BodyText uses a block container tag
+        // Block HTML children are OK when BodyText uses a block-container tag
         {code: `<BodyText tag="div"><div>block</div></BodyText>`},
         {code: `<BodyText tag="section"><p>paragraph</p></BodyText>`},
         {code: `<BodyText tag="article"><div>block</div></BodyText>`},
 
-        // Children count at or below the default threshold of 5
+        // When BodyText has an inline tag the block-child checks do not apply
+        // (the outer BodyText renders inline; invalid nesting is a parent-rule
+        // concern, not a children concern).
+        {code: `<BodyText tag="span"><div>block</div></BodyText>`},
+        {code: `<BodyText tag="em"><p>paragraph</p></BodyText>`},
+
+        // Inner BodyText with an inline tag is safe inside a default BodyText
+        {
+            code: `<BodyText><BodyText tag="span">inline</BodyText></BodyText>`,
+        },
+
+        // Expression containers are not counted as element children
+        {code: `<BodyText>{value}<span>label</span></BodyText>`},
+
+        // At or below the default threshold of 5 element children
         {
             code: `<BodyText><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></BodyText>`,
         },
 
-        // Children count at or below a custom threshold
+        // At or below a custom threshold
         {
             code: `<BodyText><span>1</span><span>2</span></BodyText>`,
             options: [{maxChildren: 2}],
         },
 
-        // Text nodes do not count toward the child element limit
+        // Text nodes do not count toward the child-element limit
         {
             code: `<BodyText>text <span>one</span> text <span>two</span> text <span>three</span> text <span>four</span> text <span>five</span> text</BodyText>`,
-        },
-
-        // Block elements are OK when BodyText has an inline tag
-        // (BodyText still renders inline, so HTML validity depends on context,
-        // but no block children to report here)
-        {code: `<BodyText tag="span"><em>fine</em></BodyText>`},
-
-        // Expression containers are not counted as element children
-        {
-            code: `<BodyText>{value}<span>label</span></BodyText>`,
         },
     ],
 
     // ------------------------------------------------------------------ //
-    // INVALID — block-level children or too many children                //
+    // INVALID                                                             //
     // ------------------------------------------------------------------ //
     invalid: [
-        // --- View is always a block-level child ---
+        // ---------------------------------------------------------------- //
+        // View — always flagged regardless of the outer BodyText tag        //
+        // ---------------------------------------------------------------- //
         {
             code: `<BodyText><View>layout</View></BodyText>`,
             errors: [{messageId: "viewChild"}],
         },
         {
-            code: `<BodyText tag="div"><View>layout</View></BodyText>`,
-            errors: [{messageId: "viewChild"}],
-        },
-        {
+            // tag="span" does not exempt View
             code: `<BodyText tag="span"><View>layout</View></BodyText>`,
             errors: [{messageId: "viewChild"}],
         },
+        {
+            // tag="div" does not exempt View — BodyText is not a layout container
+            code: `<BodyText tag="div"><View>layout</View></BodyText>`,
+            errors: [{messageId: "viewChild"}],
+        },
 
-        // --- HTML block elements inside default BodyText (<p>) ---
+        // ---------------------------------------------------------------- //
+        // <div> — specific message for documentation clarity               //
+        // ---------------------------------------------------------------- //
         {
             code: `<BodyText><div>block</div></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "div"}}],
+            errors: [{messageId: "divChild"}],
         },
         {
-            code: `<BodyText><p>paragraph</p></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "p"}}],
+            // tag="p" also renders as <p>
+            code: `<BodyText tag="p"><div>block</div></BodyText>`,
+            errors: [{messageId: "divChild"}],
         },
+
+        // ---------------------------------------------------------------- //
+        // <p> and BodyText rendering as <p>                                //
+        // ---------------------------------------------------------------- //
+        {
+            code: `<BodyText><p>paragraph</p></BodyText>`,
+            errors: [
+                {
+                    messageId: "paragraphChild",
+                    data: {childName: "p", childNote: ""},
+                },
+            ],
+        },
+        {
+            // BodyText defaults to <p> — nesting two <p>s is invalid HTML
+            code: `<BodyText><BodyText>nested</BodyText></BodyText>`,
+            errors: [
+                {
+                    messageId: "paragraphChild",
+                    data: {
+                        childName: "BodyText",
+                        childNote: " (BodyText also renders as <p> by default)",
+                    },
+                },
+            ],
+        },
+        {
+            // Outer BodyText with tag="p" + inner default BodyText
+            code: `<BodyText tag="p"><BodyText>nested</BodyText></BodyText>`,
+            errors: [
+                {
+                    messageId: "paragraphChild",
+                    data: {
+                        childName: "BodyText",
+                        childNote: " (BodyText also renders as <p> by default)",
+                    },
+                },
+            ],
+        },
+
+        // ---------------------------------------------------------------- //
+        // Other block-level HTML elements                                  //
+        // ---------------------------------------------------------------- //
         {
             code: `<BodyText><section>section</section></BodyText>`,
             errors: [{messageId: "blockChild", data: {childName: "section"}}],
@@ -108,18 +162,13 @@ ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
         {
             code: `<BodyText><blockquote>quote</blockquote></BodyText>`,
             errors: [
-                {
-                    messageId: "blockChild",
-                    data: {childName: "blockquote"},
-                },
+                {messageId: "blockChild", data: {childName: "blockquote"}},
             ],
         },
         {
             code: `<BodyText><pre>code</pre></BodyText>`,
             errors: [{messageId: "blockChild", data: {childName: "pre"}}],
         },
-
-        // --- HTML heading elements inside default BodyText ---
         {
             code: `<BodyText><h1>Heading</h1></BodyText>`,
             errors: [{messageId: "blockChild", data: {childName: "h1"}}],
@@ -129,7 +178,9 @@ ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
             errors: [{messageId: "blockChild", data: {childName: "h2"}}],
         },
 
-        // --- WB Heading components inside default BodyText ---
+        // ---------------------------------------------------------------- //
+        // WB Heading components (render as block-level headings)           //
+        // ---------------------------------------------------------------- //
         {
             code: `<BodyText><Heading>Title</Heading></BodyText>`,
             errors: [{messageId: "blockChild", data: {childName: "Heading"}}],
@@ -137,35 +188,27 @@ ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
         {
             code: `<BodyText><HeadingLarge>Title</HeadingLarge></BodyText>`,
             errors: [
+                {messageId: "blockChild", data: {childName: "HeadingLarge"}},
+            ],
+        },
+
+        // ---------------------------------------------------------------- //
+        // Multiple block children — each reported independently            //
+        // ---------------------------------------------------------------- //
+        {
+            code: `<BodyText><div>a</div><p>b</p></BodyText>`,
+            errors: [
+                {messageId: "divChild"},
                 {
-                    messageId: "blockChild",
-                    data: {childName: "HeadingLarge"},
+                    messageId: "paragraphChild",
+                    data: {childName: "p", childNote: ""},
                 },
             ],
         },
 
-        // --- Block children also flagged when BodyText has tag="p" ---
-        {
-            code: `<BodyText tag="p"><div>block</div></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "div"}}],
-        },
-
-        // --- Block children also flagged when BodyText has an inline tag ---
-        {
-            code: `<BodyText tag="span"><div>block</div></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "div"}}],
-        },
-
-        // --- Multiple block children each reported ---
-        {
-            code: `<BodyText><div>a</div><p>b</p></BodyText>`,
-            errors: [
-                {messageId: "blockChild", data: {childName: "div"}},
-                {messageId: "blockChild", data: {childName: "p"}},
-            ],
-        },
-
-        // --- Too many direct element children (default threshold: 5) ---
+        // ---------------------------------------------------------------- //
+        // Too many direct element children                                 //
+        // ---------------------------------------------------------------- //
         {
             code: `<BodyText><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></BodyText>`,
             errors: [
@@ -175,9 +218,8 @@ ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
                 },
             ],
         },
-
-        // --- Custom threshold ---
         {
+            // Custom threshold
             code: `<BodyText><span>1</span><span>2</span><span>3</span></BodyText>`,
             options: [{maxChildren: 2}],
             errors: [
@@ -187,18 +229,17 @@ ruleTester.run("no-invalid-bodytext-children", noInvalidBodyTextChildren, {
                 },
             ],
         },
-
-        // --- Block child + too many children both reported ---
-        // tooManyChildren is on the BodyText opening element (earlier in
-        // source), so it sorts before blockChild (on the child element).
         {
+            // Block child + too many children both reported.
+            // tooManyChildren is on the BodyText opening element (earlier in
+            // source) so it sorts before divChild (on the <div> element).
             code: `<BodyText><div>a</div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></BodyText>`,
             errors: [
                 {
                     messageId: "tooManyChildren",
                     data: {count: "6", max: "5"},
                 },
-                {messageId: "blockChild", data: {childName: "div"}},
+                {messageId: "divChild"},
             ],
         },
     ],

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
@@ -50,6 +50,10 @@ ruleTester.run(ruleName, rule, {
         {code: `<BodyText tag="span"><div>block</div></BodyText>`},
         {code: `<BodyText tag="em"><p>paragraph</p></BodyText>`},
 
+        // BodyText-in-BodyText is handled entirely by no-invalid-bodytext-parent
+        // (which also provides an autofix). No error from this rule.
+        {code: `<BodyText><BodyText>nested</BodyText></BodyText>`},
+        {code: `<BodyText tag="p"><BodyText>nested</BodyText></BodyText>`},
         // Inner BodyText with an inline tag is safe inside a default BodyText
         {
             code: `<BodyText><BodyText tag="span">inline</BodyText></BodyText>`,
@@ -123,33 +127,6 @@ ruleTester.run(ruleName, rule, {
                 },
             ],
         },
-        {
-            // BodyText defaults to <p> — nesting two <p>s is invalid HTML
-            code: `<BodyText><BodyText>nested</BodyText></BodyText>`,
-            errors: [
-                {
-                    messageId: "paragraphChild",
-                    data: {
-                        childName: "BodyText",
-                        childNote: " (BodyText also renders as <p> by default)",
-                    },
-                },
-            ],
-        },
-        {
-            // Outer BodyText with tag="p" + inner default BodyText
-            code: `<BodyText tag="p"><BodyText>nested</BodyText></BodyText>`,
-            errors: [
-                {
-                    messageId: "paragraphChild",
-                    data: {
-                        childName: "BodyText",
-                        childNote: " (BodyText also renders as <p> by default)",
-                    },
-                },
-            ],
-        },
-
         // ---------------------------------------------------------------- //
         // Other block-level HTML elements                                  //
         // ---------------------------------------------------------------- //

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
@@ -44,11 +44,13 @@ ruleTester.run(ruleName, rule, {
         {code: `<BodyText tag="section"><p>paragraph</p></BodyText>`},
         {code: `<BodyText tag="article"><div>block</div></BodyText>`},
 
-        // When BodyText has an inline tag the block-child checks do not apply
-        // (the outer BodyText renders inline; invalid nesting is a parent-rule
-        // concern, not a children concern).
-        {code: `<BodyText tag="span"><div>block</div></BodyText>`},
-        {code: `<BodyText tag="em"><p>paragraph</p></BodyText>`},
+        // View with an inline tag is valid phrasing content inside <p>
+        {code: `<BodyText><View tag="span">inline</View></BodyText>`},
+        {code: `<BodyText><View tag="em">inline</View></BodyText>`},
+
+        // View inside a block-container BodyText is valid HTML
+        {code: `<BodyText tag="div"><View>layout</View></BodyText>`},
+        {code: `<BodyText tag="section"><View>layout</View></BodyText>`},
 
         // BodyText-in-BodyText is handled entirely by no-invalid-bodytext-parent
         // (which also provides an autofix). No error from this rule.
@@ -85,21 +87,29 @@ ruleTester.run(ruleName, rule, {
     // ------------------------------------------------------------------ //
     invalid: [
         // ---------------------------------------------------------------- //
-        // View — always flagged regardless of the outer BodyText tag        //
+        // View — flagged when it renders as a block element inside a       //
+        //        phrasing-content BodyText                                 //
         // ---------------------------------------------------------------- //
         {
+            // View defaults to <div> — invalid inside paragraph BodyText
             code: `<BodyText><View>layout</View></BodyText>`,
-            errors: [{messageId: "viewChild"}],
+            errors: [
+                {messageId: "viewChild", data: {tag: "div", outerTag: "p"}},
+            ],
         },
         {
-            // tag="span" does not exempt View
+            // Explicit tag="div" on View is also invalid
+            code: `<BodyText><View tag="div">layout</View></BodyText>`,
+            errors: [
+                {messageId: "viewChild", data: {tag: "div", outerTag: "p"}},
+            ],
+        },
+        {
+            // View with no tag is still invalid when outer BodyText renders as <span>
             code: `<BodyText tag="span"><View>layout</View></BodyText>`,
-            errors: [{messageId: "viewChild"}],
-        },
-        {
-            // tag="div" does not exempt View — BodyText is not a layout container
-            code: `<BodyText tag="div"><View>layout</View></BodyText>`,
-            errors: [{messageId: "viewChild"}],
+            errors: [
+                {messageId: "viewChild", data: {tag: "div", outerTag: "span"}},
+            ],
         },
 
         // ---------------------------------------------------------------- //
@@ -114,16 +124,31 @@ ruleTester.run(ruleName, rule, {
             code: `<BodyText tag="p"><div>block</div></BodyText>`,
             errors: [{messageId: "divChild"}],
         },
+        {
+            // Inline BodyText (span) also cannot contain <div>
+            code: `<BodyText tag="span"><div>block</div></BodyText>`,
+            errors: [{messageId: "divChild"}],
+        },
 
         // ---------------------------------------------------------------- //
-        // <p> and BodyText rendering as <p>                                //
+        // <p> nested inside a phrasing-content BodyText                    //
         // ---------------------------------------------------------------- //
         {
             code: `<BodyText><p>paragraph</p></BodyText>`,
             errors: [
                 {
                     messageId: "paragraphChild",
-                    data: {childName: "p", childNote: ""},
+                    data: {childName: "p", childNote: "", outerTag: "p"},
+                },
+            ],
+        },
+        {
+            // Inline BodyText (em) also cannot contain <p>
+            code: `<BodyText tag="em"><p>paragraph</p></BodyText>`,
+            errors: [
+                {
+                    messageId: "paragraphChild",
+                    data: {childName: "p", childNote: "", outerTag: "em"},
                 },
             ],
         },
@@ -132,33 +157,66 @@ ruleTester.run(ruleName, rule, {
         // ---------------------------------------------------------------- //
         {
             code: `<BodyText><section>section</section></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "section"}}],
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "section", outerTag: "p"},
+                },
+            ],
         },
         {
             code: `<BodyText><ul><li>item</li></ul></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "ul"}}],
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "ul", outerTag: "p"},
+                },
+            ],
         },
         {
             code: `<BodyText><ol><li>item</li></ol></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "ol"}}],
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "ol", outerTag: "p"},
+                },
+            ],
         },
         {
             code: `<BodyText><blockquote>quote</blockquote></BodyText>`,
             errors: [
-                {messageId: "blockChild", data: {childName: "blockquote"}},
+                {
+                    messageId: "blockChild",
+                    data: {childName: "blockquote", outerTag: "p"},
+                },
             ],
         },
         {
             code: `<BodyText><pre>code</pre></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "pre"}}],
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "pre", outerTag: "p"},
+                },
+            ],
         },
         {
             code: `<BodyText><h1>Heading</h1></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "h1"}}],
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "h1", outerTag: "p"},
+                },
+            ],
         },
         {
             code: `<BodyText><h2>Heading</h2></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "h2"}}],
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "h2", outerTag: "p"},
+                },
+            ],
         },
 
         // ---------------------------------------------------------------- //
@@ -166,12 +224,20 @@ ruleTester.run(ruleName, rule, {
         // ---------------------------------------------------------------- //
         {
             code: `<BodyText><Heading>Title</Heading></BodyText>`,
-            errors: [{messageId: "blockChild", data: {childName: "Heading"}}],
+            errors: [
+                {
+                    messageId: "blockChild",
+                    data: {childName: "Heading", outerTag: "p"},
+                },
+            ],
         },
         {
             code: `<BodyText><HeadingLarge>Title</HeadingLarge></BodyText>`,
             errors: [
-                {messageId: "blockChild", data: {childName: "HeadingLarge"}},
+                {
+                    messageId: "blockChild",
+                    data: {childName: "HeadingLarge", outerTag: "p"},
+                },
             ],
         },
 
@@ -184,7 +250,7 @@ ruleTester.run(ruleName, rule, {
                 {messageId: "divChild"},
                 {
                     messageId: "paragraphChild",
-                    data: {childName: "p", childNote: ""},
+                    data: {childName: "p", childNote: "", outerTag: "p"},
                 },
             ],
         },

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-invalid-bodytext-children.test.ts
@@ -69,12 +69,6 @@ ruleTester.run(ruleName, rule, {
             code: `<BodyText><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></BodyText>`,
         },
 
-        // At or below a custom threshold
-        {
-            code: `<BodyText><span>1</span><span>2</span></BodyText>`,
-            options: [{maxChildren: 2}],
-        },
-
         // Text nodes do not count toward the child-element limit
         {
             code: `<BodyText>text <span>one</span> text <span>two</span> text <span>three</span> text <span>four</span> text <span>five</span> text</BodyText>`,
@@ -252,43 +246,6 @@ ruleTester.run(ruleName, rule, {
                     messageId: "paragraphChild",
                     data: {childName: "p", childNote: "", outerTag: "p"},
                 },
-            ],
-        },
-
-        // ---------------------------------------------------------------- //
-        // Too many direct element children                                 //
-        // ---------------------------------------------------------------- //
-        {
-            code: `<BodyText><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span><span>6</span></BodyText>`,
-            errors: [
-                {
-                    messageId: "tooManyChildren",
-                    data: {count: "6", max: "5"},
-                },
-            ],
-        },
-        {
-            // Custom threshold
-            code: `<BodyText><span>1</span><span>2</span><span>3</span></BodyText>`,
-            options: [{maxChildren: 2}],
-            errors: [
-                {
-                    messageId: "tooManyChildren",
-                    data: {count: "3", max: "2"},
-                },
-            ],
-        },
-        {
-            // Block child + too many children both reported.
-            // tooManyChildren is on the BodyText opening element (earlier in
-            // source) so it sorts before divChild (on the <div> element).
-            code: `<BodyText><div>a</div><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span></BodyText>`,
-            errors: [
-                {
-                    messageId: "tooManyChildren",
-                    data: {count: "6", max: "5"},
-                },
-                {messageId: "divChild"},
             ],
         },
     ],

--- a/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
@@ -1,10 +1,12 @@
 import {TSESLint} from "@typescript-eslint/utils";
 
 import noCustomTabRole from "./no-custom-tab-role";
+import noInvalidBodyTextChildren from "./no-invalid-bodytext-children";
 import noInvalidBodyTextParent from "./no-invalid-bodytext-parent";
 
 const rules: Record<string, TSESLint.RuleModule<string, readonly unknown[]>> = {
     "no-custom-tab-role": noCustomTabRole,
+    "no-invalid-bodytext-children": noInvalidBodyTextChildren,
     "no-invalid-bodytext-parent": noInvalidBodyTextParent,
 };
 

--- a/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
@@ -1,11 +1,13 @@
 import {TSESLint} from "@typescript-eslint/utils";
 
 import noCustomTabRole from "./no-custom-tab-role";
+import noExcessiveBodyTextChildren from "./no-excessive-bodytext-children";
 import noInvalidBodyTextChildren from "./no-invalid-bodytext-children";
 import noInvalidBodyTextParent from "./no-invalid-bodytext-parent";
 
 const rules: Record<string, TSESLint.RuleModule<string, readonly unknown[]>> = {
     "no-custom-tab-role": noCustomTabRole,
+    "no-excessive-bodytext-children": noExcessiveBodyTextChildren,
     "no-invalid-bodytext-children": noInvalidBodyTextChildren,
     "no-invalid-bodytext-parent": noInvalidBodyTextParent,
 };

--- a/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
@@ -100,6 +100,46 @@ export const WB_HEADING_COMPONENTS = new Set([
 ]);
 
 /**
+ * HTML elements that are block-level and therefore cannot appear inside a <p>.
+ * Excludes <div> and <p> which have their own dedicated message IDs in the
+ * no-invalid-bodytext-children rule.
+ * https://html.spec.whatwg.org/#phrasing-content
+ */
+export const HTML_BLOCK_ELEMENTS = new Set([
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "dd",
+    "details",
+    "dl",
+    "dt",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hgroup",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "ol",
+    "pre",
+    "section",
+    "summary",
+    "table",
+    "ul",
+]);
+
+/**
  * Returns the string value of a JSX attribute if it is a simple string
  * literal, otherwise null. Returns null for dynamic expressions.
  */
@@ -130,4 +170,18 @@ export function getAttributeStringValue(
     }
 
     return null;
+}
+
+/**
+ * Returns true when the BodyText opening element has no tag prop or a tag prop
+ * of "p", meaning it will render as a <p> element.
+ *
+ * Block-container tags (div, section, …) and inline tags (span, …) both
+ * return false — only the default and explicit tag="p" cases return true.
+ */
+export function rendersAsParagraph(
+    openingElement: TSESTree.JSXOpeningElement,
+): boolean {
+    const tag = getAttributeStringValue(openingElement, "tag");
+    return tag === null || tag === "p";
 }

--- a/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
@@ -173,13 +173,21 @@ export function getAttributeStringValue(
 }
 
 /**
- * Returns true when the BodyText opening element has no tag prop or a tag prop
- * of "p", meaning it will render as a <p> element.
+ * Returns true when a BodyText opening element has no tag prop or tag="p",
+ * meaning it will render as a <p> element.
  *
  * Block-container tags (div, section, …) and inline tags (span, …) both
  * return false — only the default and explicit tag="p" cases return true.
+ *
+ * Dynamic tag expressions (e.g. tag={getTag()}) cannot be statically resolved,
+ * so they are treated conservatively as paragraph-rendering. This may produce
+ * false positives for dynamic tags that resolve to block-container values at
+ * runtime, but avoids silently missing invalid nesting.
+ *
+ * This function only reasons about the tag prop. It cannot determine the
+ * rendered element for arbitrary unknown components.
  */
-export function rendersAsParagraph(
+export function bodyTextRendersAsParagraph(
     openingElement: TSESTree.JSXOpeningElement,
 ): boolean {
     const tag = getAttributeStringValue(openingElement, "tag");

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-excessive-bodytext-children.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-excessive-bodytext-children.ts
@@ -1,0 +1,76 @@
+import {ESLintUtils, TSESTree} from "@typescript-eslint/utils";
+
+import type {WonderBlocksPluginDocs} from "../types";
+
+const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
+    (name) =>
+        `https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/${name}.md`,
+);
+
+type Options = [{maxChildren?: number}?];
+type MessageIds = "tooManyChildren";
+
+const DEFAULT_MAX_CHILDREN = 5;
+
+export default createRule<Options, MessageIds>({
+    name: "no-excessive-bodytext-children",
+    meta: {
+        type: "suggestion",
+        docs: {
+            description:
+                "Disallow BodyText with more direct JSX element children than a configurable threshold",
+            recommended: false,
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    maxChildren: {
+                        type: "number",
+                        minimum: 1,
+                        description: `Maximum number of direct JSX element children allowed in BodyText (default: ${DEFAULT_MAX_CHILDREN})`,
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        messages: {
+            tooManyChildren:
+                "BodyText has {{count}} direct child elements (max: {{max}}). BodyText is for text content — consider using View or a block container for complex layouts.",
+        },
+    },
+    create(context) {
+        const maxChildren =
+            context.options[0]?.maxChildren ?? DEFAULT_MAX_CHILDREN;
+
+        return {
+            JSXElement(node) {
+                const openingElement = node.openingElement;
+
+                if (
+                    openingElement.name.type !== "JSXIdentifier" ||
+                    openingElement.name.name !== "BodyText"
+                ) {
+                    return;
+                }
+
+                const elementChildren = node.children.filter(
+                    (child): child is TSESTree.JSXElement =>
+                        child.type === "JSXElement",
+                );
+
+                if (elementChildren.length > maxChildren) {
+                    context.report({
+                        node: openingElement,
+                        messageId: "tooManyChildren",
+                        data: {
+                            count: String(elementChildren.length),
+                            max: String(maxChildren),
+                        },
+                    });
+                }
+            },
+        };
+    },
+    defaultOptions: [],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
@@ -1,0 +1,243 @@
+import {ESLintUtils, TSESTree} from "@typescript-eslint/utils";
+
+import type {WonderBlocksPluginDocs} from "../types";
+
+const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
+    (name) =>
+        `https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/${name}.md`,
+);
+
+type Options = [{maxChildren?: number}?];
+type MessageIds = "viewChild" | "blockChild" | "tooManyChildren";
+
+const DEFAULT_MAX_CHILDREN = 5;
+
+/**
+ * Inline tags that make BodyText safe to use in inline/restricted contexts.
+ * When BodyText uses one of these, it renders as an inline element.
+ */
+const INLINE_BODY_TEXT_TAGS = new Set([
+    "span",
+    "sup",
+    "sub",
+    "em",
+    "strong",
+    "a",
+    "abbr",
+    "code",
+    "kbd",
+    "mark",
+    "cite",
+    "q",
+    "s",
+    "u",
+    "b",
+    "i",
+    "small",
+    "del",
+    "ins",
+    "time",
+    "var",
+    "samp",
+    "dfn",
+]);
+
+/**
+ * HTML elements that are block-level and cannot appear inside a <p>.
+ * https://html.spec.whatwg.org/#phrasing-content
+ */
+const HTML_BLOCK_ELEMENTS = new Set([
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "dd",
+    "details",
+    "div",
+    "dl",
+    "dt",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hgroup",
+    "hr",
+    "li",
+    "main",
+    "nav",
+    "ol",
+    "p",
+    "pre",
+    "section",
+    "summary",
+    "table",
+    "ul",
+]);
+
+/**
+ * Wonder Blocks components that render as block-level elements and therefore
+ * cannot be children of a <p>.
+ */
+const WB_BLOCK_COMPONENTS = new Set([
+    "Heading",
+    "HeadingLarge",
+    "HeadingMedium",
+    "HeadingSmall",
+    "HeadingXSmall",
+]);
+
+/**
+ * Returns the string value of a JSX attribute if it's a simple string
+ * literal, otherwise null.
+ */
+function getAttributeStringValue(
+    openingElement: TSESTree.JSXOpeningElement,
+    attributeName: string,
+): string | null {
+    const attr = openingElement.attributes.find(
+        (a): a is TSESTree.JSXAttribute =>
+            a.type === "JSXAttribute" &&
+            a.name.type === "JSXIdentifier" &&
+            (a.name as TSESTree.JSXIdentifier).name === attributeName,
+    );
+
+    if (!attr?.value) {
+        return null;
+    }
+
+    if (attr.value.type === "Literal") {
+        return String(attr.value.value);
+    }
+
+    if (
+        attr.value.type === "JSXExpressionContainer" &&
+        attr.value.expression.type === "Literal"
+    ) {
+        return String((attr.value.expression as TSESTree.Literal).value);
+    }
+
+    return null;
+}
+
+export default createRule<Options, MessageIds>({
+    name: "no-invalid-bodytext-children",
+    meta: {
+        type: "problem",
+        docs: {
+            description:
+                "Disallow block-level elements and excessive children inside BodyText",
+            recommended: true,
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    maxChildren: {
+                        type: "number",
+                        minimum: 1,
+                        description: `Maximum number of direct JSX element children allowed in BodyText (default: ${DEFAULT_MAX_CHILDREN})`,
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        messages: {
+            viewChild:
+                "BodyText should not wrap View. View renders as <div>, a block-level element that cannot be a child of <p>. Remove BodyText and use View directly for layout.",
+            blockChild:
+                'BodyText renders as <p> by default, which cannot contain {{childName}} (a block-level element). Add tag="div" to BodyText to allow block children, or restructure to remove the block element.',
+            tooManyChildren:
+                "BodyText has {{count}} direct child elements (max: {{max}}). BodyText is for text content — consider using View or a block container for complex layouts.",
+        },
+    },
+    create(context) {
+        const maxChildren =
+            context.options[0]?.maxChildren ?? DEFAULT_MAX_CHILDREN;
+
+        return {
+            JSXElement(node) {
+                const openingElement = node.openingElement;
+
+                // Only check BodyText components.
+                if (
+                    openingElement.name.type !== "JSXIdentifier" ||
+                    openingElement.name.name !== "BodyText"
+                ) {
+                    return;
+                }
+
+                const tagValue = getAttributeStringValue(openingElement, "tag");
+
+                // BodyText renders as <p> when no tag is set, or when tag="p".
+                // In that case, block-level children create invalid HTML.
+                const rendersAsParagraph =
+                    tagValue === null ||
+                    tagValue === "p" ||
+                    INLINE_BODY_TEXT_TAGS.has(tagValue);
+
+                // Direct JSXElement children only (excludes text nodes and
+                // expression containers).
+                const elementChildren = node.children.filter(
+                    (child): child is TSESTree.JSXElement =>
+                        child.type === "JSXElement",
+                );
+
+                for (const child of elementChildren) {
+                    const childOpening = child.openingElement;
+
+                    if (childOpening.name.type !== "JSXIdentifier") {
+                        continue;
+                    }
+
+                    const childName = childOpening.name.name;
+
+                    // View always renders as <div> — always a block-level child.
+                    if (childName === "View") {
+                        context.report({
+                            node: childOpening,
+                            messageId: "viewChild",
+                        });
+                        continue;
+                    }
+
+                    // When BodyText renders as <p>, block-level HTML elements
+                    // and block WB components are invalid children.
+                    if (rendersAsParagraph) {
+                        if (
+                            HTML_BLOCK_ELEMENTS.has(childName) ||
+                            WB_BLOCK_COMPONENTS.has(childName)
+                        ) {
+                            context.report({
+                                node: childOpening,
+                                messageId: "blockChild",
+                                data: {childName},
+                            });
+                        }
+                    }
+                }
+
+                // Warn when there are too many direct child elements — BodyText
+                // is for text content, not layout.
+                if (elementChildren.length > maxChildren) {
+                    context.report({
+                        node: openingElement,
+                        messageId: "tooManyChildren",
+                        data: {
+                            count: String(elementChildren.length),
+                            max: String(maxChildren),
+                        },
+                    });
+                }
+            },
+        };
+    },
+    defaultOptions: [],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
@@ -1,6 +1,11 @@
 import {ESLintUtils, TSESTree} from "@typescript-eslint/utils";
 
 import type {WonderBlocksPluginDocs} from "../types";
+import {
+    HTML_BLOCK_ELEMENTS,
+    WB_HEADING_COMPONENTS,
+    rendersAsParagraph,
+} from "./jsx-utils";
 
 const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
     (name) =>
@@ -16,107 +21,6 @@ type MessageIds =
     | "tooManyChildren";
 
 const DEFAULT_MAX_CHILDREN = 5;
-
-/**
- * HTML elements that are block-level and therefore cannot appear inside a <p>.
- * Excludes <div> and <p> which have their own dedicated message IDs.
- * https://html.spec.whatwg.org/#phrasing-content
- */
-const HTML_BLOCK_ELEMENTS = new Set([
-    "address",
-    "article",
-    "aside",
-    "blockquote",
-    "dd",
-    "details",
-    "dl",
-    "dt",
-    "fieldset",
-    "figcaption",
-    "figure",
-    "footer",
-    "form",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "header",
-    "hgroup",
-    "hr",
-    "li",
-    "main",
-    "nav",
-    "ol",
-    "pre",
-    "section",
-    "summary",
-    "table",
-    "ul",
-]);
-
-/**
- * Wonder Blocks components that render as block-level heading elements and
- * therefore cannot be children of a <p>.
- */
-const WB_HEADING_COMPONENTS = new Set([
-    "Heading",
-    "HeadingLarge",
-    "HeadingMedium",
-    "HeadingSmall",
-    "HeadingXSmall",
-]);
-
-/**
- * Returns the string value of a JSX attribute if it is a simple string
- * literal, otherwise null.
- */
-function getAttributeStringValue(
-    openingElement: TSESTree.JSXOpeningElement,
-    attributeName: string,
-): string | null {
-    const attr = openingElement.attributes.find(
-        (a): a is TSESTree.JSXAttribute =>
-            a.type === "JSXAttribute" &&
-            a.name.type === "JSXIdentifier" &&
-            (a.name as TSESTree.JSXIdentifier).name === attributeName,
-    );
-
-    if (!attr?.value) {
-        return null;
-    }
-
-    if (attr.value.type === "Literal") {
-        return String(attr.value.value);
-    }
-
-    if (
-        attr.value.type === "JSXExpressionContainer" &&
-        attr.value.expression.type === "Literal"
-    ) {
-        return String((attr.value.expression as TSESTree.Literal).value);
-    }
-
-    return null;
-}
-
-/**
- * Returns true when the BodyText opening element has no tag prop or a tag prop
- * that is not an inline/phrasing-content value, meaning it will render as <p>.
- *
- * Block-container tags (div, section, …) also return false here because a
- * block-level BodyText can legitimately contain block children.
- */
-function rendersAsParagraph(
-    openingElement: TSESTree.JSXOpeningElement,
-): boolean {
-    const tag = getAttributeStringValue(openingElement, "tag");
-    // No tag → defaults to <p>.
-    // tag="p" → explicitly <p>.
-    // Any inline or block-container tag → not a paragraph.
-    return tag === null || tag === "p";
-}
 
 export default createRule<Options, MessageIds>({
     name: "no-invalid-bodytext-children",

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
@@ -8,42 +8,18 @@ const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
 );
 
 type Options = [{maxChildren?: number}?];
-type MessageIds = "viewChild" | "blockChild" | "tooManyChildren";
+type MessageIds =
+    | "viewChild"
+    | "divChild"
+    | "paragraphChild"
+    | "blockChild"
+    | "tooManyChildren";
 
 const DEFAULT_MAX_CHILDREN = 5;
 
 /**
- * Inline tags that make BodyText safe to use in inline/restricted contexts.
- * When BodyText uses one of these, it renders as an inline element.
- */
-const INLINE_BODY_TEXT_TAGS = new Set([
-    "span",
-    "sup",
-    "sub",
-    "em",
-    "strong",
-    "a",
-    "abbr",
-    "code",
-    "kbd",
-    "mark",
-    "cite",
-    "q",
-    "s",
-    "u",
-    "b",
-    "i",
-    "small",
-    "del",
-    "ins",
-    "time",
-    "var",
-    "samp",
-    "dfn",
-]);
-
-/**
- * HTML elements that are block-level and cannot appear inside a <p>.
+ * HTML elements that are block-level and therefore cannot appear inside a <p>.
+ * Excludes <div> and <p> which have their own dedicated message IDs.
  * https://html.spec.whatwg.org/#phrasing-content
  */
 const HTML_BLOCK_ELEMENTS = new Set([
@@ -53,7 +29,6 @@ const HTML_BLOCK_ELEMENTS = new Set([
     "blockquote",
     "dd",
     "details",
-    "div",
     "dl",
     "dt",
     "fieldset",
@@ -74,7 +49,6 @@ const HTML_BLOCK_ELEMENTS = new Set([
     "main",
     "nav",
     "ol",
-    "p",
     "pre",
     "section",
     "summary",
@@ -83,10 +57,10 @@ const HTML_BLOCK_ELEMENTS = new Set([
 ]);
 
 /**
- * Wonder Blocks components that render as block-level elements and therefore
- * cannot be children of a <p>.
+ * Wonder Blocks components that render as block-level heading elements and
+ * therefore cannot be children of a <p>.
  */
-const WB_BLOCK_COMPONENTS = new Set([
+const WB_HEADING_COMPONENTS = new Set([
     "Heading",
     "HeadingLarge",
     "HeadingMedium",
@@ -95,7 +69,7 @@ const WB_BLOCK_COMPONENTS = new Set([
 ]);
 
 /**
- * Returns the string value of a JSX attribute if it's a simple string
+ * Returns the string value of a JSX attribute if it is a simple string
  * literal, otherwise null.
  */
 function getAttributeStringValue(
@@ -127,6 +101,23 @@ function getAttributeStringValue(
     return null;
 }
 
+/**
+ * Returns true when the BodyText opening element has no tag prop or a tag prop
+ * that is not an inline/phrasing-content value, meaning it will render as <p>.
+ *
+ * Block-container tags (div, section, …) also return false here because a
+ * block-level BodyText can legitimately contain block children.
+ */
+function rendersAsParagraph(
+    openingElement: TSESTree.JSXOpeningElement,
+): boolean {
+    const tag = getAttributeStringValue(openingElement, "tag");
+    // No tag → defaults to <p>.
+    // tag="p" → explicitly <p>.
+    // Any inline or block-container tag → not a paragraph.
+    return tag === null || tag === "p";
+}
+
 export default createRule<Options, MessageIds>({
     name: "no-invalid-bodytext-children",
     meta: {
@@ -151,9 +142,13 @@ export default createRule<Options, MessageIds>({
         ],
         messages: {
             viewChild:
-                "BodyText should not wrap View. View renders as <div>, a block-level element that cannot be a child of <p>. Remove BodyText and use View directly for layout.",
+                "BodyText should not wrap View. View renders as <div>, which is block-level and cannot be a child of <p>. Remove BodyText and use View directly for layout.",
+            divChild:
+                'BodyText renders as <p> by default, which cannot contain a <div>. Add tag="div" to the outer BodyText to allow block children, or remove the <div>.',
+            paragraphChild:
+                'BodyText renders as <p> by default. {{childName}} cannot be a child of <p>{{childNote}}. Add tag="span" to the inner element to make it inline, or tag="div" to the outer BodyText.',
             blockChild:
-                'BodyText renders as <p> by default, which cannot contain {{childName}} (a block-level element). Add tag="div" to BodyText to allow block children, or restructure to remove the block element.',
+                'BodyText renders as <p> by default, which cannot contain {{childName}} (a block-level element). Add tag="div" to BodyText to allow block children, or remove the block element.',
             tooManyChildren:
                 "BodyText has {{count}} direct child elements (max: {{max}}). BodyText is for text content — consider using View or a block container for complex layouts.",
         },
@@ -174,14 +169,8 @@ export default createRule<Options, MessageIds>({
                     return;
                 }
 
-                const tagValue = getAttributeStringValue(openingElement, "tag");
-
-                // BodyText renders as <p> when no tag is set, or when tag="p".
-                // In that case, block-level children create invalid HTML.
-                const rendersAsParagraph =
-                    tagValue === null ||
-                    tagValue === "p" ||
-                    INLINE_BODY_TEXT_TAGS.has(tagValue);
+                const outerRendersAsParagraph =
+                    rendersAsParagraph(openingElement);
 
                 // Direct JSXElement children only (excludes text nodes and
                 // expression containers).
@@ -199,7 +188,8 @@ export default createRule<Options, MessageIds>({
 
                     const childName = childOpening.name.name;
 
-                    // View always renders as <div> — always a block-level child.
+                    // View always renders as <div> — always warn regardless of
+                    // the outer BodyText's tag.
                     if (childName === "View") {
                         context.report({
                             node: childOpening,
@@ -208,19 +198,61 @@ export default createRule<Options, MessageIds>({
                         continue;
                     }
 
-                    // When BodyText renders as <p>, block-level HTML elements
-                    // and block WB components are invalid children.
-                    if (rendersAsParagraph) {
-                        if (
-                            HTML_BLOCK_ELEMENTS.has(childName) ||
-                            WB_BLOCK_COMPONENTS.has(childName)
-                        ) {
+                    // The remaining checks only apply when the outer BodyText
+                    // renders as <p> (no tag prop, or tag="p").
+                    if (!outerRendersAsParagraph) {
+                        continue;
+                    }
+
+                    // <div> gets its own message for documentation clarity.
+                    if (childName === "div") {
+                        context.report({
+                            node: childOpening,
+                            messageId: "divChild",
+                        });
+                        continue;
+                    }
+
+                    // <p> and BodyText that renders as <p> get their own
+                    // message because the source of the nested-<p> warning
+                    // can otherwise be unclear.
+                    if (childName === "p") {
+                        context.report({
+                            node: childOpening,
+                            messageId: "paragraphChild",
+                            data: {childName: "p", childNote: ""},
+                        });
+                        continue;
+                    }
+
+                    if (childName === "BodyText") {
+                        // Only warn if the inner BodyText also renders as <p>
+                        // (i.e. it doesn't have an inline tag set).
+                        if (rendersAsParagraph(childOpening)) {
                             context.report({
                                 node: childOpening,
-                                messageId: "blockChild",
-                                data: {childName},
+                                messageId: "paragraphChild",
+                                data: {
+                                    childName: "BodyText",
+                                    childNote:
+                                        " (BodyText also renders as <p> by default)",
+                                },
                             });
                         }
+                        continue;
+                    }
+
+                    // All other block-level HTML elements and WB heading
+                    // components.
+                    if (
+                        HTML_BLOCK_ELEMENTS.has(childName) ||
+                        WB_HEADING_COMPONENTS.has(childName)
+                    ) {
+                        context.report({
+                            node: childOpening,
+                            messageId: "blockChild",
+                            data: {childName},
+                        });
                     }
                 }
 

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
@@ -29,7 +29,7 @@ export default createRule<Options, MessageIds>({
         docs: {
             description:
                 "Disallow block-level elements and excessive children inside BodyText",
-            recommended: true,
+            recommended: false,
         },
         schema: [
             {

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
@@ -14,38 +14,18 @@ const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
         `https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/${name}.md`,
 );
 
-type Options = [{maxChildren?: number}?];
-type MessageIds =
-    | "viewChild"
-    | "divChild"
-    | "paragraphChild"
-    | "blockChild"
-    | "tooManyChildren";
-
-const DEFAULT_MAX_CHILDREN = 5;
+type Options = [];
+type MessageIds = "viewChild" | "divChild" | "paragraphChild" | "blockChild";
 
 export default createRule<Options, MessageIds>({
     name: "no-invalid-bodytext-children",
     meta: {
         type: "problem",
         docs: {
-            description:
-                "Disallow block-level elements and excessive children inside BodyText",
+            description: "Disallow block-level elements inside BodyText",
             recommended: false,
         },
-        schema: [
-            {
-                type: "object",
-                properties: {
-                    maxChildren: {
-                        type: "number",
-                        minimum: 1,
-                        description: `Maximum number of direct JSX element children allowed in BodyText (default: ${DEFAULT_MAX_CHILDREN})`,
-                    },
-                },
-                additionalProperties: false,
-            },
-        ],
+        schema: [],
         messages: {
             viewChild:
                 'View renders as <{{tag}}>, which is block-level and cannot be a child of <{{outerTag}}>. Add tag="span" to View to use it inline, or add tag="div" to the outer BodyText to allow block children.',
@@ -55,14 +35,9 @@ export default createRule<Options, MessageIds>({
                 'BodyText renders as <{{outerTag}}>. {{childName}} cannot be a child of <{{outerTag}}>{{childNote}}. Add tag="span" to the inner element to make it inline, or tag="div" to the outer BodyText.',
             blockChild:
                 'BodyText renders as <{{outerTag}}>, which cannot contain {{childName}} (a block-level element). Add tag="div" to BodyText to allow block children, or remove the block element.',
-            tooManyChildren:
-                "BodyText has {{count}} direct child elements (max: {{max}}). BodyText is for text content — consider using View or a block container for complex layouts.",
         },
     },
     create(context) {
-        const maxChildren =
-            context.options[0]?.maxChildren ?? DEFAULT_MAX_CHILDREN;
-
         return {
             JSXElement(node) {
                 const openingElement = node.openingElement;
@@ -170,19 +145,6 @@ export default createRule<Options, MessageIds>({
                             data: {childName, outerTag},
                         });
                     }
-                }
-
-                // Warn when there are too many direct child elements — BodyText
-                // is for text content, not layout.
-                if (elementChildren.length > maxChildren) {
-                    context.report({
-                        node: openingElement,
-                        messageId: "tooManyChildren",
-                        data: {
-                            count: String(elementChildren.length),
-                            max: String(maxChildren),
-                        },
-                    });
                 }
             },
         };

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
@@ -130,19 +130,9 @@ export default createRule<Options, MessageIds>({
                     }
 
                     if (childName === "BodyText") {
-                        // Only warn if the inner BodyText also renders as <p>
-                        // (i.e. it doesn't have an inline tag set).
-                        if (rendersAsParagraph(childOpening)) {
-                            context.report({
-                                node: childOpening,
-                                messageId: "paragraphChild",
-                                data: {
-                                    childName: "BodyText",
-                                    childNote:
-                                        " (BodyText also renders as <p> by default)",
-                                },
-                            });
-                        }
+                        // no-invalid-bodytext-parent already handles BodyText
+                        // nested in BodyText (with an autofix). Skip here to
+                        // avoid duplicate errors on the same node.
                         continue;
                     }
 

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-invalid-bodytext-children.ts
@@ -2,9 +2,11 @@ import {ESLintUtils, TSESTree} from "@typescript-eslint/utils";
 
 import type {WonderBlocksPluginDocs} from "../types";
 import {
+    BLOCK_CONTAINER_TAGS,
     HTML_BLOCK_ELEMENTS,
+    INLINE_BODY_TEXT_TAGS,
     WB_HEADING_COMPONENTS,
-    rendersAsParagraph,
+    getAttributeStringValue,
 } from "./jsx-utils";
 
 const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
@@ -46,13 +48,13 @@ export default createRule<Options, MessageIds>({
         ],
         messages: {
             viewChild:
-                "BodyText should not wrap View. View renders as <div>, which is block-level and cannot be a child of <p>. Remove BodyText and use View directly for layout.",
+                'View renders as <{{tag}}>, which is block-level and cannot be a child of <{{outerTag}}>. Add tag="span" to View to use it inline, or add tag="div" to the outer BodyText to allow block children.',
             divChild:
-                'BodyText renders as <p> by default, which cannot contain a <div>. Add tag="div" to the outer BodyText to allow block children, or remove the <div>.',
+                'BodyText renders as <{{outerTag}}>, which cannot contain a <div>. Add tag="div" to the outer BodyText to allow block children, or remove the <div>.',
             paragraphChild:
-                'BodyText renders as <p> by default. {{childName}} cannot be a child of <p>{{childNote}}. Add tag="span" to the inner element to make it inline, or tag="div" to the outer BodyText.',
+                'BodyText renders as <{{outerTag}}>. {{childName}} cannot be a child of <{{outerTag}}>{{childNote}}. Add tag="span" to the inner element to make it inline, or tag="div" to the outer BodyText.',
             blockChild:
-                'BodyText renders as <p> by default, which cannot contain {{childName}} (a block-level element). Add tag="div" to BodyText to allow block children, or remove the block element.',
+                'BodyText renders as <{{outerTag}}>, which cannot contain {{childName}} (a block-level element). Add tag="div" to BodyText to allow block children, or remove the block element.',
             tooManyChildren:
                 "BodyText has {{count}} direct child elements (max: {{max}}). BodyText is for text content — consider using View or a block container for complex layouts.",
         },
@@ -73,8 +75,15 @@ export default createRule<Options, MessageIds>({
                     return;
                 }
 
-                const outerRendersAsParagraph =
-                    rendersAsParagraph(openingElement);
+                // Determine the tag BodyText renders as. Absence of a tag prop
+                // means BodyText defaults to <p>.
+                const outerTag =
+                    getAttributeStringValue(openingElement, "tag") ?? "p";
+                // Block-container tags can hold flow content (including block
+                // children). Phrasing-content tags (<p>, <span>, <em>, …)
+                // cannot contain block-level elements.
+                const outerIsBlockContainer =
+                    BLOCK_CONTAINER_TAGS.has(outerTag);
 
                 // Direct JSXElement children only (excludes text nodes and
                 // expression containers).
@@ -92,19 +101,32 @@ export default createRule<Options, MessageIds>({
 
                     const childName = childOpening.name.name;
 
-                    // View always renders as <div> — always warn regardless of
-                    // the outer BodyText's tag.
-                    if (childName === "View") {
-                        context.report({
-                            node: childOpening,
-                            messageId: "viewChild",
-                        });
+                    // Block-level children are only invalid when the outer
+                    // BodyText is a phrasing-content element. Block containers
+                    // (div, section, …) can hold anything.
+                    if (outerIsBlockContainer) {
                         continue;
                     }
 
-                    // The remaining checks only apply when the outer BodyText
-                    // renders as <p> (no tag prop, or tag="p").
-                    if (!outerRendersAsParagraph) {
+                    // View has a tag prop that controls its rendered element.
+                    // If the tag is an inline element it's valid phrasing
+                    // content inside <p>; otherwise it defaults to <div>.
+                    if (childName === "View") {
+                        const viewTag = getAttributeStringValue(
+                            childOpening,
+                            "tag",
+                        );
+                        if (
+                            viewTag !== null &&
+                            INLINE_BODY_TEXT_TAGS.has(viewTag)
+                        ) {
+                            continue;
+                        }
+                        context.report({
+                            node: childOpening,
+                            messageId: "viewChild",
+                            data: {tag: viewTag ?? "div", outerTag},
+                        });
                         continue;
                     }
 
@@ -113,18 +135,18 @@ export default createRule<Options, MessageIds>({
                         context.report({
                             node: childOpening,
                             messageId: "divChild",
+                            data: {outerTag},
                         });
                         continue;
                     }
 
-                    // <p> and BodyText that renders as <p> get their own
-                    // message because the source of the nested-<p> warning
-                    // can otherwise be unclear.
+                    // <p> gets its own message because the source of the
+                    // nested-paragraph warning can otherwise be unclear.
                     if (childName === "p") {
                         context.report({
                             node: childOpening,
                             messageId: "paragraphChild",
-                            data: {childName: "p", childNote: ""},
+                            data: {childName: "p", childNote: "", outerTag},
                         });
                         continue;
                     }
@@ -145,7 +167,7 @@ export default createRule<Options, MessageIds>({
                         context.report({
                             node: childOpening,
                             messageId: "blockChild",
-                            data: {childName},
+                            data: {childName, outerTag},
                         });
                     }
                 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,9 +315,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: 8.17.0
         version: 8.17.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/rule-tester':
-        specifier: ^8.58.0
-        version: 8.58.2(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
         version: 3.9.0(@swc/helpers@0.5.17)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
@@ -466,17 +463,17 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^8.59.0
-        version: 8.59.1(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.59.0(eslint@8.57.1)(typescript@5.7.3)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
         version: link:../../build-settings
       '@typescript-eslint/rule-tester':
         specifier: ^8.59.0
-        version: 8.59.1(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.59.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree':
         specifier: ^8.59.0
-        version: 8.59.1(typescript@5.7.3)
+        version: 8.59.0(typescript@5.7.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -3490,40 +3487,21 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.58.2':
-    resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.59.1':
-    resolution: {integrity: sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.58.2':
-    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.59.1':
-    resolution: {integrity: sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/rule-tester@8.58.2':
-    resolution: {integrity: sha512-HF7ry5ZhQSLn4JAJfQCPX39D6BE5MhYXE743I0phrJw1BvB0adH8JpsEc4owCxEESQflodyhRWNUZY+m2EVenw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-
-  '@typescript-eslint/rule-tester@8.59.1':
-    resolution: {integrity: sha512-VAlTRylRP+zh2jepYylwEllQSI8yP0QWQqUKc3xcPbuSlnDeC0CjbpWAOp5CrqfGl9ZMGw74BjZnutb7mILOzA==}
+  '@typescript-eslint/rule-tester@8.59.0':
+    resolution: {integrity: sha512-2Ej6W28DqObFuEUQ+puEpDZFWFXAW7jIZ4TsgfLUCTNz1FID0NMfp1sXc+fQq8m5ysfPdhXAPjti6jYEu1oRcg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3536,22 +3514,12 @@ packages:
     resolution: {integrity: sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.58.2':
-    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.59.1':
-    resolution: {integrity: sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.58.2':
-    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/tsconfig-utils@8.59.1':
-    resolution: {integrity: sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==}
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -3574,12 +3542,8 @@ packages:
     resolution: {integrity: sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.58.2':
-    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.59.1':
-    resolution: {integrity: sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==}
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.17.0':
@@ -3597,14 +3561,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/typescript-estree@8.58.2':
-    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/typescript-estree@8.59.1':
-    resolution: {integrity: sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==}
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -3626,15 +3584,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/utils@8.58.2':
-    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/utils@8.59.1':
-    resolution: {integrity: sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==}
+  '@typescript-eslint/utils@8.59.0':
+    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3648,12 +3599,8 @@ packages:
     resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.58.2':
-    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.59.1':
-    resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -10276,67 +10223,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.59.0(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.59.1
-      debug: 4.4.3
-      eslint: 8.57.1
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.58.2(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.1(typescript@5.7.3)':
+  '@typescript-eslint/rule-tester@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/types': 8.59.1
-      debug: 4.4.3
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/rule-tester@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@8.57.1)(typescript@5.7.3)
-      ajv: 6.12.6
-      eslint: 8.57.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/rule-tester@8.59.1(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/parser': 8.59.1(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
       ajv: 6.12.6
       eslint: 8.57.1
       json-stable-stringify-without-jsonify: 1.0.1
@@ -10356,21 +10268,12 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/visitor-keys': 8.22.0
 
-  '@typescript-eslint/scope-manager@8.58.2':
+  '@typescript-eslint/scope-manager@8.59.0':
     dependencies:
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/visitor-keys': 8.58.2
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
 
-  '@typescript-eslint/scope-manager@8.59.1':
-    dependencies:
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/visitor-keys': 8.59.1
-
-  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.7.3)':
-    dependencies:
-      typescript: 5.7.3
-
-  '@typescript-eslint/tsconfig-utils@8.59.1(typescript@5.7.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.7.3)':
     dependencies:
       typescript: 5.7.3
 
@@ -10390,9 +10293,7 @@ snapshots:
 
   '@typescript-eslint/types@8.22.0': {}
 
-  '@typescript-eslint/types@8.58.2': {}
-
-  '@typescript-eslint/types@8.59.1': {}
+  '@typescript-eslint/types@8.59.0': {}
 
   '@typescript-eslint/typescript-estree@8.17.0(typescript@5.7.3)':
     dependencies:
@@ -10423,27 +10324,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.7.3)
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/visitor-keys': 8.58.2
-      debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.59.1(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.7.3)
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/visitor-keys': 8.59.1
+      '@typescript-eslint/project-service': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -10476,23 +10362,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/types': 8.58.2
-      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
-      eslint: 8.57.1
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.59.1(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -10508,14 +10383,9 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       eslint-visitor-keys: 4.2.0
 
-  '@typescript-eslint/visitor-keys@8.58.2':
+  '@typescript-eslint/visitor-keys@8.59.0':
     dependencies:
-      '@typescript-eslint/types': 8.58.2
-      eslint-visitor-keys: 5.0.1
-
-  '@typescript-eslint/visitor-keys@8.59.1':
-    dependencies:
-      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -11739,7 +11609,7 @@ snapshots:
 
   eslint-plugin-storybook@10.3.6(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/utils': 8.59.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,10 +233,10 @@ importers:
         version: 0.4.0(@swc/core@1.11.22(@swc/helpers@0.5.17))(rollup@2.79.2)
       '@storybook/addon-a11y':
         specifier: ^10.3.5
-        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 10.3.6(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-docs':
         specifier: ^10.3.5
-        version: 10.3.5(@types/react@18.3.18)(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+        version: 10.3.6(@types/react@18.3.18)(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@storybook/addon-links':
         specifier: 10.3.5
         version: 10.3.5(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -248,10 +248,10 @@ importers:
         version: 10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15)
       '@storybook/builder-vite':
         specifier: ^10.3.5
-        version: 10.3.5(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+        version: 10.3.6(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@storybook/react-vite':
         specifier: ^10.3.5
-        version: 10.3.5(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+        version: 10.3.6(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@swc-node/register':
         specifier: ^1.10.10
         version: 1.10.10(@swc/core@1.11.22(@swc/helpers@0.5.17))(@swc/types@0.1.21)(typescript@5.7.3)
@@ -316,8 +316,8 @@ importers:
         specifier: 8.17.0
         version: 8.17.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/rule-tester':
-        specifier: ^8.46.3
-        version: 8.57.1(eslint@8.57.1)(typescript@5.7.3)
+        specifier: ^8.58.0
+        version: 8.58.2(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
         version: 3.9.0(@swc/helpers@0.5.17)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
@@ -377,7 +377,7 @@ importers:
         version: 5.1.0(eslint@8.57.1)
       eslint-plugin-storybook:
         specifier: ^10.3.5
-        version: 10.3.5(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)
+        version: 10.3.6(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)
       eslint-plugin-testing-library:
         specifier: ^7.1.1
         version: 7.1.1(eslint@8.57.1)(typescript@5.7.3)
@@ -434,7 +434,7 @@ importers:
         version: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       storybook-addon-pseudo-states:
         specifier: ^10.3.5
-        version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 10.3.6(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       storybook-addon-tag-badges:
         specifier: ^3.1.0
         version: 3.1.0(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -466,17 +466,17 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^8.59.0
-        version: 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.59.1(eslint@8.57.1)(typescript@5.7.3)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
         version: link:../../build-settings
       '@typescript-eslint/rule-tester':
         specifier: ^8.59.0
-        version: 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.59.1(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree':
         specifier: ^8.59.0
-        version: 8.59.0(typescript@5.7.3)
+        version: 8.59.1(typescript@5.7.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -3023,15 +3023,15 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
-  '@storybook/addon-a11y@10.3.5':
-    resolution: {integrity: sha512-5k6lpgfIeLxvNhE8v3wEzdiu73ONKjF4gmH1AHvfqYd8kIVzQJai0KCDxgvqNncXHQhIWkaf1fg6+9hKaYJyaw==}
+  '@storybook/addon-a11y@10.3.6':
+    resolution: {integrity: sha512-cbwXIT5CeHZ9AFbTKQ6YB7Ct6TAl/kKOgALbvzzVtFfRvm51JYygGaiJaB7PbPWn9wgJP2olJcFt+erlEc6cRw==}
     peerDependencies:
-      storybook: ^10.3.5
+      storybook: ^10.3.6
 
-  '@storybook/addon-docs@10.3.5':
-    resolution: {integrity: sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==}
+  '@storybook/addon-docs@10.3.6':
+    resolution: {integrity: sha512-TvIdADVPtauxW0LzXIpIv7X6GxwetorhyNh+6+7MHC27XSBCWVxxRUwL63YeLlHTuXsIk0quG3b1xgwVRzWOJA==}
     peerDependencies:
-      storybook: ^10.3.5
+      storybook: ^10.3.6
 
   '@storybook/addon-links@10.3.5':
     resolution: {integrity: sha512-Xe2wCGZ+hpZ0cDqAIBHk+kPc8nODNbu585ghd5bLrlYJMDVXoNM/fIlkrLgjIDVbfpgeJLUEg7vldJrn+FyOLw==}
@@ -3069,18 +3069,18 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@10.3.5':
-    resolution: {integrity: sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw==}
+  '@storybook/builder-vite@10.3.6':
+    resolution: {integrity: sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==}
     peerDependencies:
-      storybook: ^10.3.5
+      storybook: ^10.3.6
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/csf-plugin@10.3.5':
-    resolution: {integrity: sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==}
+  '@storybook/csf-plugin@10.3.6':
+    resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.3.5
+      storybook: ^10.3.6
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -3105,27 +3105,27 @@ packages:
   '@storybook/mcp@0.7.0':
     resolution: {integrity: sha512-Pr4E61tM5e7aDzqgNOL/Ylw8CGdb+BIDGOf3vbmFfkR8ZnXjPxaV/vhTEsiXynnIpjQWCzySCxOU1icxZsgjrA==}
 
-  '@storybook/react-dom-shim@10.3.5':
-    resolution: {integrity: sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g==}
+  '@storybook/react-dom-shim@10.3.6':
+    resolution: {integrity: sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.5
+      storybook: ^10.3.6
 
-  '@storybook/react-vite@10.3.5':
-    resolution: {integrity: sha512-UB5sJHeh26bfd8sNMx2YPGYRYmErIdTRaLOT28m4bykQIa1l9IgVktsYg/geW7KsJU0lXd3oTbnUjLD+enpi3w==}
+  '@storybook/react-vite@10.3.6':
+    resolution: {integrity: sha512-tySQRc+8q7V2NkylQMNJjDV8zXy6tkxb8oDqw/DIhHhI9Xn77MTKVZ8Cihbo5NMm7HYTB6xDKr6wqdSMgdufYQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.5
+      storybook: ^10.3.6
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@storybook/react@10.3.5':
-    resolution: {integrity: sha512-tpLTLaVGoA6fLK3ReyGzZUricq7lyPaV2hLPpj5wqdXLV/LpRtAHClUpNoPDYSBjlnSjL81hMZijbkGC3mA+gw==}
+  '@storybook/react@10.3.6':
+    resolution: {integrity: sha512-oZQZ6xayWe5IdHmFUTL0TL8rX/gpNNh9gWhT2vzW5eeUvlkVG/RBKdsja6Ndrk2s1D9vcnwiI6r6CNXy3IEEmg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.5
+      storybook: ^10.3.6
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       typescript:
@@ -3490,40 +3490,40 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@8.57.1':
-    resolution: {integrity: sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/parser@8.59.0':
-    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
+  '@typescript-eslint/parser@8.58.2':
+    resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.57.1':
-    resolution: {integrity: sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==}
+  '@typescript-eslint/parser@8.59.1':
+    resolution: {integrity: sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.59.0':
-    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
+  '@typescript-eslint/project-service@8.58.2':
+    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/rule-tester@8.57.1':
-    resolution: {integrity: sha512-gk0q0rLa7a1uEB0iD2t1GZELK1z6HfudiKYeSVhjQ5gW5FdL0OcZ+8f09Lg7NbmHSBF3V+S9BDuw0qoCFkHR+w==}
+  '@typescript-eslint/project-service@8.59.1':
+    resolution: {integrity: sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/rule-tester@8.58.2':
+    resolution: {integrity: sha512-HF7ry5ZhQSLn4JAJfQCPX39D6BE5MhYXE743I0phrJw1BvB0adH8JpsEc4owCxEESQflodyhRWNUZY+m2EVenw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
-  '@typescript-eslint/rule-tester@8.59.0':
-    resolution: {integrity: sha512-2Ej6W28DqObFuEUQ+puEpDZFWFXAW7jIZ4TsgfLUCTNz1FID0NMfp1sXc+fQq8m5ysfPdhXAPjti6jYEu1oRcg==}
+  '@typescript-eslint/rule-tester@8.59.1':
+    resolution: {integrity: sha512-VAlTRylRP+zh2jepYylwEllQSI8yP0QWQqUKc3xcPbuSlnDeC0CjbpWAOp5CrqfGl9ZMGw74BjZnutb7mILOzA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3536,22 +3536,22 @@ packages:
     resolution: {integrity: sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.57.1':
-    resolution: {integrity: sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==}
+  '@typescript-eslint/scope-manager@8.58.2':
+    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.59.0':
-    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
+  '@typescript-eslint/scope-manager@8.59.1':
+    resolution: {integrity: sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.57.1':
-    resolution: {integrity: sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==}
+  '@typescript-eslint/tsconfig-utils@8.58.2':
+    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/tsconfig-utils@8.59.0':
-    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
+  '@typescript-eslint/tsconfig-utils@8.59.1':
+    resolution: {integrity: sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -3574,12 +3574,12 @@ packages:
     resolution: {integrity: sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.57.1':
-    resolution: {integrity: sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==}
+  '@typescript-eslint/types@8.58.2':
+    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.59.0':
-    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
+  '@typescript-eslint/types@8.59.1':
+    resolution: {integrity: sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.17.0':
@@ -3597,14 +3597,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/typescript-estree@8.57.1':
-    resolution: {integrity: sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==}
+  '@typescript-eslint/typescript-estree@8.58.2':
+    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/typescript-estree@8.59.0':
-    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+  '@typescript-eslint/typescript-estree@8.59.1':
+    resolution: {integrity: sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -3626,15 +3626,15 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/utils@8.57.1':
-    resolution: {integrity: sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==}
+  '@typescript-eslint/utils@8.58.2':
+    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.59.0':
-    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+  '@typescript-eslint/utils@8.59.1':
+    resolution: {integrity: sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3648,12 +3648,12 @@ packages:
     resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.57.1':
-    resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
+  '@typescript-eslint/visitor-keys@8.58.2':
+    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.59.0':
-    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
+  '@typescript-eslint/visitor-keys@8.59.1':
+    resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -3997,10 +3997,6 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4670,11 +4666,11 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-storybook@10.3.5:
-    resolution: {integrity: sha512-rEFkfU3ypF44GpB4tiJ9EFDItueoGvGi3+weLHZax2ON2MB7VIDsxdSUGvIU5tMURg+oWYlpzCyLm4TpDq2deA==}
+  eslint-plugin-storybook@10.3.6:
+    resolution: {integrity: sha512-8udrL+Rmp5LFaZvgRe4J226X1MYls25bWCyHuzR5X8s2qbFTryX+wKC+o/0Ato4A1AvwnDg8OOMPc6yWJ9JpcA==}
     peerDependencies:
       eslint: '>=8'
-      storybook: ^10.3.5
+      storybook: ^10.3.6
 
   eslint-plugin-testing-library@7.1.1:
     resolution: {integrity: sha512-nszC833aZPwB6tik1nMkbFqmtgIXTT0sfJEYs0zMBKMlkQ4to2079yUV96SvmLh00ovSBJI4pgcBC1TiIP8mXg==}
@@ -6216,10 +6212,6 @@ packages:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -7218,10 +7210,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  storybook-addon-pseudo-states@10.3.5:
-    resolution: {integrity: sha512-wtPB4BlMmqwTmAANqE4evVa6orMS1q6U3/5LT9LSX0jMO/7Sz2RnOlngqMcIB7Onz6TifYHLXVU+tn7+jCvHoQ==}
+  storybook-addon-pseudo-states@10.3.6:
+    resolution: {integrity: sha512-0ue+X3FmteLuZLWdqrdJbfKv8u4WlUPz34KuUQfSAuBWkW0xeAcMwOWCbnTU7GQHtNHivGBtOqSoTch4AxkZJg==}
     peerDependencies:
-      storybook: ^10.3.5
+      storybook: ^10.3.6
 
   storybook-addon-tag-badges@3.1.0:
     resolution: {integrity: sha512-sVWVyUT8woEmSKDsePJtSFCP9RFojrmsibD11dL0/+pkn7HrkhaJC96uz3mnqt78OuO7qflFMLF1Bqg3JwnrJA==}
@@ -7475,12 +7467,6 @@ packages:
 
   ts-api-utils@2.0.0:
     resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      typescript: '>=4.8.4'
-
-  ts-api-utils@2.4.0:
-    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -9765,18 +9751,18 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@storybook/addon-a11y@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@storybook/addon-a11y@10.3.6(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.2
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@storybook/addon-docs@10.3.5(@types/react@18.3.18)(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
+  '@storybook/addon-docs@10.3.6(@types/react@18.3.18)(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@18.3.18)(react@18.2.0)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@storybook/icons': 2.0.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@storybook/react-dom-shim': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@storybook/react-dom-shim': 10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -9824,9 +9810,9 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
+  '@storybook/builder-vite@10.3.6(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-dedent: 2.2.0
       vite: 6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0)
@@ -9835,7 +9821,7 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
+  '@storybook/csf-plugin@10.3.6(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       unplugin: 2.3.11
@@ -9861,18 +9847,18 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/react-dom-shim@10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@storybook/react-dom-shim@10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
+  '@storybook/react-vite@10.3.6(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
-      '@storybook/react': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)
+      '@storybook/builder-vite': 10.3.6(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+      '@storybook/react': 10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.2.0
@@ -9889,10 +9875,10 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)':
+  '@storybook/react@10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@storybook/react-dom-shim': 10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react: 18.2.0
       react-docgen: 8.0.2
       react-docgen-typescript: 2.2.2(typescript@5.7.3)
@@ -10290,53 +10276,53 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.59.1(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.1(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.58.2(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/types': 8.58.2
       debug: 4.4.3
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.0(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.59.1(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.59.1
       debug: 4.4.3
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/rule-tester@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.57.1(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.57.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@8.57.1)(typescript@5.7.3)
       ajv: 6.12.6
       eslint: 8.57.1
       json-stable-stringify-without-jsonify: 1.0.1
@@ -10346,11 +10332,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/rule-tester@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/rule-tester@8.59.1(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.59.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@8.57.1)(typescript@5.7.3)
       ajv: 6.12.6
       eslint: 8.57.1
       json-stable-stringify-without-jsonify: 1.0.1
@@ -10370,21 +10356,21 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/visitor-keys': 8.22.0
 
-  '@typescript-eslint/scope-manager@8.57.1':
+  '@typescript-eslint/scope-manager@8.58.2':
     dependencies:
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
 
-  '@typescript-eslint/scope-manager@8.59.0':
+  '@typescript-eslint/scope-manager@8.59.1':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/visitor-keys': 8.59.1
 
-  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@5.7.3)':
+  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.7.3)':
     dependencies:
       typescript: 5.7.3
 
-  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.7.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.1(typescript@5.7.3)':
     dependencies:
       typescript: 5.7.3
 
@@ -10404,9 +10390,9 @@ snapshots:
 
   '@typescript-eslint/types@8.22.0': {}
 
-  '@typescript-eslint/types@8.57.1': {}
+  '@typescript-eslint/types@8.58.2': {}
 
-  '@typescript-eslint/types@8.59.0': {}
+  '@typescript-eslint/types@8.59.1': {}
 
   '@typescript-eslint/typescript-estree@8.17.0(typescript@5.7.3)':
     dependencies:
@@ -10437,27 +10423,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.57.1(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.7.3)
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/visitor-keys': 8.57.1
+      '@typescript-eslint/project-service': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.7.3)
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.7.3)
+      ts-api-utils: 2.5.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.59.1(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/project-service': 8.59.1(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -10490,23 +10476,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.58.2(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.57.1
-      '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.7.3)
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.59.1(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.59.1
+      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.7.3)
       eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -10522,14 +10508,14 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       eslint-visitor-keys: 4.2.0
 
-  '@typescript-eslint/visitor-keys@8.57.1':
+  '@typescript-eslint/visitor-keys@8.58.2':
     dependencies:
-      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
-  '@typescript-eslint/visitor-keys@8.59.0':
+  '@typescript-eslint/visitor-keys@8.59.1':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/types': 8.59.1
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -10975,10 +10961,6 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.4:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.5:
     dependencies:
@@ -11755,9 +11737,9 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@10.3.5(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3):
+  eslint-plugin-storybook@10.3.6(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.59.1(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
@@ -14059,10 +14041,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.4
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -15256,7 +15234,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook-addon-pseudo-states@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
+  storybook-addon-pseudo-states@10.3.6(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
@@ -15536,10 +15514,6 @@ snapshots:
       typescript: 5.7.3
 
   ts-api-utils@2.0.0(typescript@5.7.3):
-    dependencies:
-      typescript: 5.7.3
-
-  ts-api-utils@2.4.0(typescript@5.7.3):
     dependencies:
       typescript: 5.7.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 8.17.0
         version: 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/rule-tester':
+        specifier: ^8.46.3
+        version: 8.57.1(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
         version: 3.9.0(@swc/helpers@0.5.17)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
@@ -3487,6 +3490,13 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.57.1':
+    resolution: {integrity: sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/parser@8.59.0':
     resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3494,11 +3504,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.57.1':
+    resolution: {integrity: sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/project-service@8.59.0':
     resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/rule-tester@8.57.1':
+    resolution: {integrity: sha512-gk0q0rLa7a1uEB0iD2t1GZELK1z6HfudiKYeSVhjQ5gW5FdL0OcZ+8f09Lg7NbmHSBF3V+S9BDuw0qoCFkHR+w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
   '@typescript-eslint/rule-tester@8.59.0':
     resolution: {integrity: sha512-2Ej6W28DqObFuEUQ+puEpDZFWFXAW7jIZ4TsgfLUCTNz1FID0NMfp1sXc+fQq8m5ysfPdhXAPjti6jYEu1oRcg==}
@@ -3514,9 +3536,19 @@ packages:
     resolution: {integrity: sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.57.1':
+    resolution: {integrity: sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/scope-manager@8.59.0':
     resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.57.1':
+    resolution: {integrity: sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/tsconfig-utils@8.59.0':
     resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
@@ -3542,6 +3574,10 @@ packages:
     resolution: {integrity: sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.57.1':
+    resolution: {integrity: sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/types@8.59.0':
     resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3560,6 +3596,12 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/typescript-estree@8.57.1':
+    resolution: {integrity: sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/typescript-estree@8.59.0':
     resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
@@ -3584,6 +3626,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
+  '@typescript-eslint/utils@8.57.1':
+    resolution: {integrity: sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@8.59.0':
     resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3597,6 +3646,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.22.0':
     resolution: {integrity: sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.57.1':
+    resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.59.0':
@@ -3944,6 +3997,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -6159,6 +6216,10 @@ packages:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -7414,6 +7475,12 @@ packages:
 
   ts-api-utils@2.0.0:
     resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -10223,6 +10290,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.57.1
+      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.57.1
+      debug: 4.4.3
+      eslint: 8.57.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.0
@@ -10235,6 +10314,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.57.1(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.57.1
+      debug: 4.4.3
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.59.0(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
@@ -10243,6 +10331,20 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
+
+  '@typescript-eslint/rule-tester@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/parser': 8.57.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@8.57.1)(typescript@5.7.3)
+      ajv: 6.12.6
+      eslint: 8.57.1
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@typescript-eslint/rule-tester@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
@@ -10268,10 +10370,19 @@ snapshots:
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/visitor-keys': 8.22.0
 
+  '@typescript-eslint/scope-manager@8.57.1':
+    dependencies:
+      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/visitor-keys': 8.57.1
+
   '@typescript-eslint/scope-manager@8.59.0':
     dependencies:
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/visitor-keys': 8.59.0
+
+  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@5.7.3)':
+    dependencies:
+      typescript: 5.7.3
 
   '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.7.3)':
     dependencies:
@@ -10292,6 +10403,8 @@ snapshots:
   '@typescript-eslint/types@8.17.0': {}
 
   '@typescript-eslint/types@8.22.0': {}
+
+  '@typescript-eslint/types@8.57.1': {}
 
   '@typescript-eslint/types@8.59.0': {}
 
@@ -10320,6 +10433,21 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.7.0
       ts-api-utils: 2.0.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.57.1(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/visitor-keys': 8.57.1
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -10362,6 +10490,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.57.1(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.57.1
+      '@typescript-eslint/types': 8.57.1
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.7.3)
+      eslint: 8.57.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
@@ -10382,6 +10521,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.22.0
       eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.57.1':
+    dependencies:
+      '@typescript-eslint/types': 8.57.1
+      eslint-visitor-keys: 5.0.1
 
   '@typescript-eslint/visitor-keys@8.59.0':
     dependencies:
@@ -10831,6 +10975,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   brace-expansion@5.0.5:
     dependencies:
@@ -13911,6 +14059,10 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -15384,6 +15536,10 @@ snapshots:
       typescript: 5.7.3
 
   ts-api-utils@2.0.0(typescript@5.7.3):
+    dependencies:
+      typescript: 5.7.3
+
+  ts-api-utils@2.4.0(typescript@5.7.3):
     dependencies:
       typescript: 5.7.3
 


### PR DESCRIPTION
## Summary:
This new lint rule will flag invalid children within BodyText:
- `viewChild` — always warns when `View` is a direct child of `BodyText`, regardless of `tag` prop
- `divChild` — warns when `<div>` is a direct child and `BodyText` renders as `<p>` (no `tag` or `tag="p"`)
- `paragraphChild` — warns when `<p>` or a default `<BodyText>` (renders as `<p>`) is a direct child
- `blockChild` — warns on other block-level HTML elements (`section`, `ul`, `h1`–`h6`, etc.) and WB heading components when `BodyText` renders as `<p>`
- Block-child checks are skipped when `BodyText` has an inline or block-container tag prop set

It also splits off a second lint rule for excessive child elements - `no-excessive-bodytext-children`, which can affect screen reader output:
- `tooManyChildren` — warns when direct JSX element children exceed a configurable threshold (default: 5)

Issue: WB-2248

## Test plan:
1. Ensure tests pass
2. Test in frontend: https://github.com/Khan/frontend/pull/10738