### PR TITLE
Improve robustness of responsive tabs logic to avoid flaky sb tests

### DIFF
--- a/.changeset/brown-nails-walk.md
+++ b/.changeset/brown-nails-walk.md
@@ -2,4 +2,7 @@
 "@khanacademy/wonder-blocks-tabs": patch
 ---
 
-Improve robustness of responsive logic in ResponsiveTabs and ResponsiveNavigationTabs by using a MutationObserver to trigger when we should check for overflow to decide if a dropdown or horizontal tabs layout should be used. Also fixes edge cases where additional container padding/margin could cause continuous layout changes.
+Improve robustness of responsive logic in ResponsiveTabs and ResponsiveNavigationTabs by:
+- Using a MutationObserver to trigger when we should check for overflow to decide if a dropdown or horizontal tabs layout should be used
+- Fixing edge cases where additional container padding/margin could cause continuous layout changes
+- Only trigger the check for overflow when the width changes in the ResizeObserver

--- a/.changeset/brown-nails-walk.md
+++ b/.changeset/brown-nails-walk.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tabs": patch
 ---
 
-Improve robustness of responsive logic in ResponsiveTabs and ResponsiveNavigationTabs by using a MutationObserver to trigger when we should check for overflow to decide if a dropdown or horizontal tabs layout should be used
+Improve robustness of responsive logic in ResponsiveTabs and ResponsiveNavigationTabs by using a MutationObserver to trigger when we should check for overflow to decide if a dropdown or horizontal tabs layout should be used. Also fixes edge cases where additional container padding/margin could cause continuous layout changes.

--- a/.changeset/brown-nails-walk.md
+++ b/.changeset/brown-nails-walk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tabs": patch
+---
+
+Improve robustness of responsive logic in ResponsiveTabs and ResponsiveNavigationTabs by using a MutationObserver to trigger when we should check for overflow to decide if a dropdown or horizontal tabs layout should be used

--- a/packages/wonder-blocks-tabs/src/hooks/use-responsive-layout.ts
+++ b/packages/wonder-blocks-tabs/src/hooks/use-responsive-layout.ts
@@ -89,8 +89,12 @@ export function useResponsiveLayout(
                     scrollableWrapper.clientWidth;
 
                 if (hasOverflow) {
-                    // Store the width before switching
-                    tabsWidthRef.current = scrollableWrapper.scrollWidth;
+                    // Store the container width needed to show tabs without
+                    // overflow. Accounts for any gap (padding/margin) between
+                    // the container and the scrollable element.
+                    tabsWidthRef.current =
+                        scrollableWrapper.scrollWidth +
+                        (container.clientWidth - scrollableWrapper.clientWidth);
                     setShowDropdown(true);
                 }
             }

--- a/packages/wonder-blocks-tabs/src/hooks/use-responsive-layout.ts
+++ b/packages/wonder-blocks-tabs/src/hooks/use-responsive-layout.ts
@@ -106,9 +106,10 @@ export function useResponsiveLayout(
     }, [showDropdown, elementWithOverflowRef, containerRef]);
 
     React.useEffect(() => {
-        // When tabsSignature changes and dropdown is shown, reset to tabs
-        // layout so we can re-measure with the new content. The MutationObserver
-        // handles checking for overflow once the new content is mounted.
+        // When tabsSignature changes and dropdown is shown, reset to horizontal tabs
+        // layout so we can re-measure with the new content (label, icon, number of tabs, etc).
+        // The MutationObserver handles checking for overflow once the new content
+        // is rendered.
         if (showDropdown) {
             tabsWidthRef.current = null;
             setShowDropdown(false);

--- a/packages/wonder-blocks-tabs/src/hooks/use-responsive-layout.ts
+++ b/packages/wonder-blocks-tabs/src/hooks/use-responsive-layout.ts
@@ -62,6 +62,9 @@ export function useResponsiveLayout(
     // we can switch back to the tabs view when the container width is wide enough.
     const tabsWidthRef = React.useRef<number | null>(null);
 
+    // Keep track of the container width to avoid unnecessary overflow checks when the container width is the same.
+    const containerWidthRef = React.useRef<number | null>(null);
+
     // Create a signature of the tabs to detect changes (tab added/removed, label changed, presence of tab icon)
     const tabsSignature = React.useMemo(
         () =>
@@ -130,7 +133,11 @@ export function useResponsiveLayout(
 
         // Check for overflow when the container size changes (screen size change, width change, etc)
         const resizeObserver = new ResizeObserver(() => {
-            checkOverflow();
+            // Only check for overflow if the container width has changed
+            if (containerWidthRef.current !== container.clientWidth) {
+                containerWidthRef.current = container.clientWidth;
+                checkOverflow();
+            }
         });
 
         resizeObserver.observe(container);

--- a/packages/wonder-blocks-tabs/src/hooks/use-responsive-layout.ts
+++ b/packages/wonder-blocks-tabs/src/hooks/use-responsive-layout.ts
@@ -106,19 +106,12 @@ export function useResponsiveLayout(
     }, [showDropdown, elementWithOverflowRef, containerRef]);
 
     React.useEffect(() => {
-        // This effect handles the case where the length of tabs or the tabs
-        // labels change. This determines whether to switch to the dropdown or
-        // tabs layout.
+        // When tabsSignature changes and dropdown is shown, reset to tabs
+        // layout so we can re-measure with the new content. The MutationObserver
+        // handles checking for overflow once the new content is mounted.
         if (showDropdown) {
-            // When tabsSignature changes and dropdown is shown, reset to
-            // tabs layout so we can re-measure and see if we can switch
-            // back
             tabsWidthRef.current = null;
             setShowDropdown(false);
-        } else {
-            // When tabsSignature changes and tabs layout is shown, check
-            // for overflow
-            checkOverflow();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps -- explicitly only depend on tabsSignature
     }, [tabsSignature]);
@@ -130,6 +123,7 @@ export function useResponsiveLayout(
             return;
         }
 
+        // Check for overflow when the container size changes (screen size change, width change, etc)
         const resizeObserver = new ResizeObserver(() => {
             checkOverflow();
         });
@@ -140,6 +134,32 @@ export function useResponsiveLayout(
             resizeObserver.disconnect();
         };
     }, [checkOverflow, containerRef]);
+
+    React.useEffect(() => {
+        const element = elementWithOverflowRef.current;
+        if (!element) {
+            return;
+        }
+
+        // Check for overflow when elementWithOverflow is there (ie. horizontal tabs layout is used)
+        checkOverflow();
+
+        // Set up a MutationObserver to detect when the tab content changes (tabs added/removed,
+        // icons mounted, labels changed) in the horizontal tabs layout.
+        const mutationObserver = new MutationObserver(() => {
+            checkOverflow();
+        });
+
+        mutationObserver.observe(element, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+        });
+
+        return () => {
+            mutationObserver.disconnect();
+        };
+    }, [checkOverflow, elementWithOverflowRef]);
 
     React.useEffect(() => {
         onLayoutChange?.(showDropdown ? "dropdown" : "tabs");


### PR DESCRIPTION
## Summary:

Previously, the Storybook interactions tests run in CI would be flaky for the ResponsiveNavigationTabs Toggle Icon interaction test. The test would sometimes fail because the layout wouldn't properly switch to the dropdown layout after the icons were toggled on. This was because we would check overflow when the tabs data changes with icons, rather than when the icons are rendered. To make it more robust, we check overflow once the tabs layout is rendered and when there are any changes to it or its descendants (using a MutationObserver).

Other improvements include:
- Triggering the `checkOverflow` logic only when the width changes in the ResizeObserver to prevent additional calls 
- Fixing edge cases where additional container padding/margin could cause continuous layout changes

Issue: WB-2311

## Test plan:

1. Unit tests pass
2. SB Interaction tests for ResponsiveTabs and ResponsiveNavigationTabs continue to pass (layout should change as expected based on triggers like changing the number of tabs, changing the tab labels, zoom level, if there are icons)
  - `?path=/story/packages-tabs-responsivetabs--interactive`
  - `?path=/story/packages-tabs-responsivenavigationtabs--interactive` 