### PR TITLE
Allow Strut to accept sizing strings

### DIFF
--- a/.changeset/slimy-bulldogs-flow.md
+++ b/.changeset/slimy-bulldogs-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-layout": minor
+---
+
+Allow Strut to accept sizing strings

--- a/packages/wonder-blocks-layout/src/components/strut.tsx
+++ b/packages/wonder-blocks-layout/src/components/strut.tsx
@@ -4,7 +4,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type Props = {
-    size: number;
+    size: number | string;
     style?: StyleType;
 };
 
@@ -20,7 +20,7 @@ export default class Strut extends React.Component<Props> {
     }
 }
 
-const strutStyle = (size: number) => {
+const strutStyle = (size: number | string) => {
     return {
         width: size,
         MsFlexBasis: size,


### PR DESCRIPTION
## Summary:

This is in response to: https://github.com/Khan/perseus/pull/3466#discussion_r3157369990

The `Strut` component doesn't let me use `sizing` but `spacing` is deprecated.

## Test plan:

I'm not really sure. There weren't tests for `Strut`.