### PR TITLE
SYL Dark - Badges

### DIFF
--- a/.changeset/fifty-rules-drop.md
+++ b/.changeset/fifty-rules-drop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update `semanticColor.core.border.neutral.*` tokens in `syl-dark`

--- a/.changeset/fifty-rules-drop.md
+++ b/.changeset/fifty-rules-drop.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tokens": patch
 ---
 
-Update `semanticColor.core.border.neutral.*` and `semanticColor.core.background.strong` tokens in `syl-dark`
+Update `semanticColor.core.border.neutral.*` and `semanticColor.core.background.neutral.strong` tokens in `syl-dark`

--- a/.changeset/fifty-rules-drop.md
+++ b/.changeset/fifty-rules-drop.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-tokens": patch
 ---
 
-Update `semanticColor.core.border.neutral.*` tokens in `syl-dark`
+Update `semanticColor.core.border.neutral.*` and `semanticColor.core.background.strong` tokens in `syl-dark`

--- a/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge-testing-snapshots.stories.tsx
@@ -29,7 +29,7 @@ import {Heading} from "@khanacademy/wonder-blocks-typography";
 import singleColoredIcon from "../components/single-colored-icon.svg";
 import {multiColoredIcon} from "../components/icons-for-testing";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 /**
  * Badges are visual indicators used to display concise information, such as
@@ -45,7 +45,7 @@ export default {
             />
         ),
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     tags: ["!manifest"],

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -11,7 +11,6 @@ import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes, {iconArgType} from "./badge.argtypes";
 import {multiColoredIcon} from "../components/icons-for-testing";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
-import {allThemeModes} from "../../.storybook/modes";
 
 export default {
     title: "Packages / Badge / Badge",
@@ -27,7 +26,6 @@ export default {
         chromatic: {
             // Disable snapshots since they're covered by the testing snapshots
             disableSnapshot: true,
-            modes: allThemeModes,
         },
     },
     render: (args: Omit<PropsFor<typeof Badge>, "icon"> & {icon: string}) => {

--- a/__docs__/wonder-blocks-badge/badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/badge.stories.tsx
@@ -11,7 +11,7 @@ import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes, {iconArgType} from "./badge.argtypes";
 import {multiColoredIcon} from "../components/icons-for-testing";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 export default {
     title: "Packages / Badge / Badge",
@@ -27,7 +27,7 @@ export default {
         chromatic: {
             // Disable snapshots since they're covered by the testing snapshots
             disableSnapshot: true,
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     render: (args: Omit<PropsFor<typeof Badge>, "icon"> & {icon: string}) => {

--- a/__docs__/wonder-blocks-badge/due-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/due-badge.stories.tsx
@@ -5,7 +5,6 @@ import packageConfig from "../../packages/wonder-blocks-badge/package.json";
 import {DueBadge} from "@khanacademy/wonder-blocks-badge";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import badgeArgtypes, {showIconArgType} from "./badge.argtypes";
-import {themeModes} from "../../.storybook/modes";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
@@ -25,7 +24,6 @@ export default {
         chromatic: {
             // Disable snapshots since they're covered by the testing snapshots
             disableSnapshot: true,
-            modes: themeModes,
         },
     },
     render: (args: PropsFor<typeof DueBadge>) => {

--- a/__docs__/wonder-blocks-badge/neutral-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/neutral-badge.stories.tsx
@@ -10,7 +10,6 @@ import {font, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {Heading} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes, {iconArgType} from "./badge.argtypes";
 import {multiColoredIcon} from "../components/icons-for-testing";
-import {themeModes} from "../../.storybook/modes";
 
 export default {
     title: "Packages / Badge / Neutral Badge",
@@ -26,7 +25,6 @@ export default {
         chromatic: {
             // Disable snapshots since they're covered by the testing snapshots
             disableSnapshot: true,
-            modes: themeModes,
         },
     },
     render: (

--- a/__docs__/wonder-blocks-badge/status-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/status-badge.stories.tsx
@@ -11,6 +11,7 @@ import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes, {iconArgType} from "./badge.argtypes";
 import {multiColoredIcon} from "../components/icons-for-testing";
+import {allThemeModes} from "../../.storybook/modes";
 
 export default {
     title: "Packages / Badge / StatusBadge",
@@ -296,6 +297,7 @@ export const CustomIcons: StoryComponentType = {
             // Enable snapshots for this story so we can verify custom icons
             // are used correctly
             disableSnapshot: false,
+            modes: allThemeModes,
         },
     },
 };

--- a/__docs__/wonder-blocks-badge/status-badge.stories.tsx
+++ b/__docs__/wonder-blocks-badge/status-badge.stories.tsx
@@ -11,7 +11,6 @@ import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingLarge} from "@khanacademy/wonder-blocks-typography";
 import badgeArgtypes, {iconArgType} from "./badge.argtypes";
 import {multiColoredIcon} from "../components/icons-for-testing";
-import {themeModes} from "../../.storybook/modes";
 
 export default {
     title: "Packages / Badge / StatusBadge",
@@ -37,7 +36,6 @@ export default {
         chromatic: {
             // Disable snapshots since they're covered by the testing snapshots
             disableSnapshot: true,
-            modes: themeModes,
         },
     },
     render: (

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -15,9 +15,9 @@ const core = {
             strong: color.blue_50,
         },
         neutral: {
-            subtle: color.gray_10,
-            default: color.gray_20,
-            strong: color.gray_70,
+            subtle: color.gray_30,
+            default: color.gray_40,
+            strong: color.gray_60,
         },
         critical: {
             subtle: color.red_20,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -57,7 +57,7 @@ const core = {
         neutral: {
             subtle: color.gray_10,
             default: color.gray_20,
-            strong: color.black_100,
+            strong: color.gray_80,
         },
         critical: {
             subtle: color.red_01,


### PR DESCRIPTION
## Summary:

Reviewing the badge components in SYL Dark to confirm they look as expected, match the design specs, and have no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

- The semantic color core border neutral tokens were updated to align with design. This was to make it so the NeutralBadge with `showBorder=true` prop would show a visible border.
- The semantic color core background neutral strong token was also updated so that it works well with the foreground knockout token in `syl-dark`. This color combination was used for custom styles as an example for badges

Issue: WB-2166

## Test plan:

Review `?path=/story/packages-badge-testing-snapshots--state-sheet-story&globals=theme:syl-dark` and confirm things look as expected and there are no a11y violations

Review any visual changes in Chromatic due to the token change (note: Since we are gradually enabling the syl-dark snapshots, it should only catch changes in components that have been reviewed already)

<img width="1410" height="815" alt="image" src="https://github.com/user-attachments/assets/d224fc1f-06c6-4d9a-8c3b-38ba51c019b4" />
<img width="1418" height="879" alt="image" src="https://github.com/user-attachments/assets/54405dd2-0f6d-4e0a-953f-49a35b40f566" />
<img width="1415" height="882" alt="image" src="https://github.com/user-attachments/assets/f28c72e5-4e47-429a-bd73-09b93ef48892" />
