### PR TITLE
Enable require-logical-properties-for-rtl in recommended config (CLASS-14218)

### DIFF
--- a/.changeset/rtl-logical-properties-rule-enabled.md
+++ b/.changeset/rtl-logical-properties-rule-enabled.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin-wonder-blocks": minor
+---
+
+Enable `require-logical-properties-for-rtl` in the `recommended` config. Auto-fixes all existing WB violations (physical CSS properties → logical equivalents, `textAlign: "left"|"right"` → `"start"|"end"`). Story files using `direction: "ltr"|"rtl"` in styles are updated to use the `dir` HTML attribute instead. Part of CLASS-14218.

--- a/.changeset/rtl-logical-properties-rule.md
+++ b/.changeset/rtl-logical-properties-rule.md
@@ -1,0 +1,21 @@
+---
+"@khanacademy/eslint-plugin-wonder-blocks": minor
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-badge": patch
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-card": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-labeled-field": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-switch": patch
+"@khanacademy/wonder-blocks-tabs": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+Add `require-logical-properties-for-rtl` ESLint rule to `eslint-plugin-wonder-blocks` recommended config, and migrate all Wonder Blocks component source files to use CSS logical properties for improved RTL layout support.

--- a/.changeset/six-planes-explain.md
+++ b/.changeset/six-planes-explain.md
@@ -1,0 +1,21 @@
+---
+"@khanacademy/eslint-plugin-wonder-blocks": minor
+"@khanacademy/wonder-blocks-birthday-picker": patch
+"@khanacademy/wonder-blocks-labeled-field": patch
+"@khanacademy/wonder-blocks-accordion": patch
+"@khanacademy/wonder-blocks-dropdown": patch
+"@khanacademy/wonder-blocks-toolbar": patch
+"@khanacademy/wonder-blocks-tooltip": patch
+"@khanacademy/wonder-blocks-button": patch
+"@khanacademy/wonder-blocks-switch": patch
+"@khanacademy/wonder-blocks-badge": patch
+"@khanacademy/wonder-blocks-modal": patch
+"@khanacademy/wonder-blocks-card": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-core": patch
+"@khanacademy/wonder-blocks-form": patch
+"@khanacademy/wonder-blocks-grid": patch
+"@khanacademy/wonder-blocks-tabs": patch
+---
+
+Enable RTL logical-properties ESLint rule in recommended config

--- a/__docs__/catalog/catalog-component-info.tsx
+++ b/__docs__/catalog/catalog-component-info.tsx
@@ -135,7 +135,7 @@ export const CatalogComponentInfo = <
     ];
 
     return (
-        <View key={name} style={{maxWidth: "100%"}}>
+        <View key={name} style={{maxInlineSize: "100%"}}>
             {heading}
             <View
                 style={{
@@ -232,7 +232,7 @@ const styles = StyleSheet.create({
     stateGroup: {
         gap: sizing.size_200,
         flexWrap: "wrap",
-        maxWidth: "100%",
+        maxInlineSize: "100%",
     },
     row: {
         flexDirection: "row",
@@ -249,7 +249,7 @@ const styles = StyleSheet.create({
     },
     tooltipList: {
         margin: 0,
-        paddingLeft: sizing.size_160,
+        paddingInlineStart: sizing.size_160,
     },
     tooltipWrapper: {
         gap: sizing.size_040,

--- a/__docs__/catalog/components-config.tsx
+++ b/__docs__/catalog/components-config.tsx
@@ -1353,7 +1353,7 @@ export const floatingComponents = [
             return (
                 <View
                     style={{
-                        maxWidth: "200px",
+                        maxInlineSize: "200px",
                         marginInlineEnd: sizing.size_200,
                     }}
                 >
@@ -1549,7 +1549,7 @@ export const inputComponents = [
     createComponentConfig({
         name: "Combobox (single)",
         Component: (props: PropsFor<typeof Combobox>) => (
-            <View style={{maxWidth: "200px"}}>
+            <View style={{maxInlineSize: "200px"}}>
                 <Combobox {...props} />
             </View>
         ),
@@ -1579,7 +1579,7 @@ export const inputComponents = [
     createComponentConfig({
         name: "Combobox (multiple)",
         Component: (props: PropsFor<typeof Combobox>) => (
-            <View style={{maxWidth: "200px"}}>
+            <View style={{maxInlineSize: "200px"}}>
                 <Combobox {...props} />
             </View>
         ),

--- a/__docs__/components/all-variants.tsx
+++ b/__docs__/components/all-variants.tsx
@@ -191,11 +191,11 @@ export function AllVariants(props: Props) {
 const styles = StyleSheet.create({
     table: {
         borderCollapse: "collapse",
-        textAlign: "left",
+        textAlign: "start",
         [breakpoint.mediaQuery.smOrSmaller]: {
             display: "none",
         },
-        maxWidth: "100%",
+        maxInlineSize: "100%",
     },
     list: {
         margin: 0,
@@ -203,7 +203,7 @@ const styles = StyleSheet.create({
         listStyle: "none",
         display: "flex",
         flexDirection: "column",
-        maxWidth: "100%",
+        maxInlineSize: "100%",
     },
     listResponsive: {
         [breakpoint.mediaQuery.mdOrLarger]: {

--- a/__docs__/components/all-variants.tsx
+++ b/__docs__/components/all-variants.tsx
@@ -191,7 +191,6 @@ export function AllVariants(props: Props) {
 const styles = StyleSheet.create({
     table: {
         borderCollapse: "collapse",
-        textAlign: "start",
         [breakpoint.mediaQuery.smOrSmaller]: {
             display: "none",
         },
@@ -213,6 +212,7 @@ const styles = StyleSheet.create({
     cell: {
         margin: sizing.size_160,
         padding: sizing.size_160,
+        textAlign: "start",
     },
     childrenWrapper: {
         padding: sizing.size_080,

--- a/__docs__/components/color.tsx
+++ b/__docs__/components/color.tsx
@@ -234,12 +234,12 @@ const styles = StyleSheet.create({
         border: `1px dashed ${semanticColor.core.border.neutral.subtle}`,
     },
     item: {
-        maxWidth: itemWidth,
+        maxInlineSize: itemWidth,
         overflowWrap: "break-word",
     },
     compactItem: {
         marginBlockEnd: sizing.size_080,
-        maxWidth: "100%",
+        maxInlineSize: "100%",
         width: "100%",
 
         backgroundColor: semanticColor.core.background.base.subtle,

--- a/__docs__/components/gallery/component-gallery.tsx
+++ b/__docs__/components/gallery/component-gallery.tsx
@@ -128,7 +128,7 @@ export default function ComponentGallery() {
 
 export const styles = StyleSheet.create({
     menuBar: {
-        marginTop: sizing.size_160,
+        marginBlockStart: sizing.size_160,
         flexDirection: "row",
         alignItems: "center",
     },
@@ -138,8 +138,8 @@ export const styles = StyleSheet.create({
         flexWrap: "wrap",
     },
     sectionLabel: {
-        marginTop: sizing.size_320,
-        marginBottom: sizing.size_240,
+        marginBlockStart: sizing.size_320,
+        marginBlockEnd: sizing.size_240,
     },
     row: {
         display: "flex",

--- a/__docs__/components/gallery/component-tile.tsx
+++ b/__docs__/components/gallery/component-tile.tsx
@@ -107,7 +107,7 @@ const styles = StyleSheet.create({
     tileWithDetails: {
         // Set the width to half the max width of the stories page content.
         width: 484,
-        minHeight: 300,
+        minBlockSize: 300,
     },
     tileWithoutDetails: {
         width: "auto",
@@ -140,20 +140,20 @@ const styles = StyleSheet.create({
         alignItems: "center",
     },
     descriptionText: {
-        marginTop: sizing.size_120,
+        marginBlockStart: sizing.size_120,
     },
     componentView: {
         flexDirection: "column",
         justifyContent: "center",
         padding: sizing.size_240,
         border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
-        borderTop: "none",
+        borderBlockStart: "none",
         borderEndStartRadius: sizing.size_120,
         borderEndEndRadius: sizing.size_120,
         flexGrow: 1,
     },
     externalLinkIcon: {
-        marginLeft: sizing.size_080,
-        marginRight: sizing.size_080,
+        marginInlineStart: sizing.size_080,
+        marginInlineEnd: sizing.size_080,
     },
 });

--- a/__docs__/components/gallery/tiles/button-tile.tsx
+++ b/__docs__/components/gallery/tiles/button-tile.tsx
@@ -38,6 +38,6 @@ export default function ButtonTile(props: CommonTileProps) {
 
 const localStyles = StyleSheet.create({
     button: {
-        marginBottom: sizing.size_120,
+        marginBlockEnd: sizing.size_120,
     },
 });

--- a/__docs__/components/gallery/tiles/one-pane-dialog-tile.tsx
+++ b/__docs__/components/gallery/tiles/one-pane-dialog-tile.tsx
@@ -63,13 +63,13 @@ const localStyles = StyleSheet.create({
         justifyContent: "center",
 
         position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        insetBlockStart: 0,
+        insetBlockEnd: 0,
     },
     previewSizer: {
-        minHeight: 500,
+        minBlockSize: 500,
         width: "100%",
 
         [mobile]: {

--- a/__docs__/components/gallery/tiles/phosphor-icon-tile.tsx
+++ b/__docs__/components/gallery/tiles/phosphor-icon-tile.tsx
@@ -53,6 +53,6 @@ const localStyles = StyleSheet.create({
         alignItems: "end",
     },
     icon: {
-        marginRight: sizing.size_160,
+        marginInlineEnd: sizing.size_160,
     },
 });

--- a/__docs__/components/scenarios-layout.tsx
+++ b/__docs__/components/scenarios-layout.tsx
@@ -51,6 +51,6 @@ const styles = StyleSheet.create({
     },
     scenario: {
         gap: sizing.size_080,
-        maxWidth: "100%",
+        maxInlineSize: "100%",
     },
 });

--- a/__docs__/components/state-sheet.tsx
+++ b/__docs__/components/state-sheet.tsx
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
         color: semanticColor.core.foreground.neutral.default,
     },
     content: {
-        maxWidth: "100%",
+        maxInlineSize: "100%",
     },
     cell: {
         alignContent: "flex-start",

--- a/__docs__/components/token-table.tsx
+++ b/__docs__/components/token-table.tsx
@@ -85,7 +85,6 @@ const styles = StyleSheet.create({
         borderCollapse: "collapse",
         borderSpacing: 0,
         margin: `${sizing.size_320} 0`,
-        textAlign: "start",
         width: "100%",
         color: semanticColor.core.foreground.neutral.strong,
     },
@@ -99,5 +98,6 @@ const styles = StyleSheet.create({
     cell: {
         padding: sizing.size_080,
         verticalAlign: "middle",
+        textAlign: "start",
     },
 });

--- a/__docs__/components/token-table.tsx
+++ b/__docs__/components/token-table.tsx
@@ -85,7 +85,7 @@ const styles = StyleSheet.create({
         borderCollapse: "collapse",
         borderSpacing: 0,
         margin: `${sizing.size_320} 0`,
-        textAlign: "left",
+        textAlign: "start",
         width: "100%",
         color: semanticColor.core.foreground.neutral.strong,
     },
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
         backgroundColor: semanticColor.core.background.base.subtle,
     },
     row: {
-        borderTop: `1px solid ${semanticColor.core.border.neutral.subtle}`,
+        borderBlockStart: `1px solid ${semanticColor.core.border.neutral.subtle}`,
         backgroundColor: semanticColor.core.background.base.default,
     },
     cell: {

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -240,8 +240,8 @@ export const ReactElementInHeader: StoryComponentType = {
                                     backgroundSize: "contain",
                                     borderRadius: border.radius.radius_080,
                                     height: 40,
-                                    marginRight: sizing.size_120,
-                                    minWidth: 40,
+                                    marginInlineEnd: sizing.size_120,
+                                    minInlineSize: 40,
                                     padding: sizing.size_080,
                                     width: 40,
                                 }}
@@ -628,6 +628,6 @@ const styles = StyleSheet.create({
     },
     button: {
         width: "fit-content",
-        marginBottom: sizing.size_240,
+        marginBlockEnd: sizing.size_240,
     },
 });

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -623,9 +623,6 @@ const styles = StyleSheet.create({
     fullWidth: {
         width: "100%",
     },
-    rtl: {
-        direction: "rtl",
-    },
     space: {
         margin: sizing.size_080,
     },

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -377,7 +377,7 @@ export const CaretPositions: StoryComponentType = {
                 </View>
                 <Strut size={32} />
                 {/* Right-to-left */}
-                <View style={[styles.sideBySide, styles.rtl]}>
+                <View dir="rtl" style={styles.sideBySide}>
                     <View style={styles.fullWidth}>
                         <LabelLarge style={styles.space}>
                             Caret position: end, language direction: right to

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -181,7 +181,7 @@ export const CaretPositions: StoryComponentType = {
                     </View>
                 </View>
                 {/* Right-to-left */}
-                <View style={[styles.sideBySide, styles.rtl]}>
+                <View dir="rtl" style={styles.sideBySide}>
                     <View style={styles.fullWidth}>
                         <LabelLarge>
                             Caret position: end, language direction: right to

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -100,7 +100,7 @@ export const Default: StoryComponentType = {
 export const AllowMultipleExpanded: StoryComponentType = {
     render: () => (
         <View>
-            <View style={{maxWidth: 500, marginBottom: sizing.size_240}}>
+            <View style={{maxInlineSize: 500, marginBlockEnd: sizing.size_240}}>
                 <LabelLarge>Allow multiple expanded (default)</LabelLarge>
                 <Accordion allowMultipleExpanded>{exampleSections}</Accordion>
             </View>
@@ -364,7 +364,7 @@ export const WithAnimation: StoryComponentType = {
                         </Accordion>
                     </View>
                 </View>
-                <View style={{maxWidth: 500}}>
+                <View style={{maxInlineSize: 500}}>
                     <LabelLarge>
                         With unevenly sided sections, allowMultipleExpanded:
                         false
@@ -676,6 +676,6 @@ const styles = StyleSheet.create({
     },
     button: {
         width: "fit-content",
-        marginBottom: sizing.size_160,
+        marginBlockEnd: sizing.size_160,
     },
 });

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -671,9 +671,6 @@ const styles = StyleSheet.create({
     fullWidth: {
         width: "100%",
     },
-    rtl: {
-        direction: "rtl",
-    },
     space: {
         margin: sizing.size_080,
     },

--- a/__docs__/wonder-blocks-announcer/announcer.stories.tsx
+++ b/__docs__/wonder-blocks-announcer/announcer.stories.tsx
@@ -204,9 +204,9 @@ export const AnnouncerInModal: StoryComponentType = {
                             style={{
                                 gap: sizing.size_160,
                                 padding: `${sizing.size_240} 0`,
-                                marginTop: "auto",
-                                maxWidth: "40rem",
-                                minHeight: "20rem",
+                                marginBlockStart: "auto",
+                                maxInlineSize: "40rem",
+                                minBlockSize: "20rem",
                             }}
                         >
                             <AnnouncerExample

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -547,7 +547,7 @@ export const WithNoIcon: StoryComponentType = {
  */
 export const RightToLeft: StoryComponentType = {
     render: () => (
-        <View dir="rtl" style={[styles.rightToLeft, styles.container]}>
+        <View dir="rtl" style={styles.container}>
             <Banner
                 text="یہ اردو میں لکھا ہے۔"
                 actions={[
@@ -579,7 +579,7 @@ export const RightToLeft: StoryComponentType = {
  */
 export const RightToLeftMultiline: StoryComponentType = {
     render: () => (
-        <View dir="rtl" style={styles.rightToLeft}>
+        <View dir="rtl">
             <Banner
                 text={`یہ اردو میں لکھا ہے۔یہ اردو میں لکھا ہے۔یہ اردو میں لکھا ہے۔یہ
              اردو میں لکھا ہے۔یہ اردو میں لکھا ہے۔یہ اردو میں لکھا ہے۔یہ
@@ -651,8 +651,5 @@ const styles = StyleSheet.create({
     },
     narrowBanner: {
         maxInlineSize: 400,
-    },
-    rightToLeft: {
-        width: "100%",
     },
 });

--- a/__docs__/wonder-blocks-banner/banner.stories.tsx
+++ b/__docs__/wonder-blocks-banner/banner.stories.tsx
@@ -547,7 +547,7 @@ export const WithNoIcon: StoryComponentType = {
  */
 export const RightToLeft: StoryComponentType = {
     render: () => (
-        <View style={[styles.rightToLeft, styles.container]}>
+        <View dir="rtl" style={[styles.rightToLeft, styles.container]}>
             <Banner
                 text="یہ اردو میں لکھا ہے۔"
                 actions={[
@@ -579,7 +579,7 @@ export const RightToLeft: StoryComponentType = {
  */
 export const RightToLeftMultiline: StoryComponentType = {
     render: () => (
-        <View style={styles.rightToLeft}>
+        <View dir="rtl" style={styles.rightToLeft}>
             <Banner
                 text={`یہ اردو میں لکھا ہے۔یہ اردو میں لکھا ہے۔یہ اردو میں لکھا ہے۔یہ
              اردو میں لکھا ہے۔یہ اردو میں لکھا ہے۔یہ اردو میں لکھا ہے۔یہ
@@ -650,10 +650,9 @@ const styles = StyleSheet.create({
         gap: sizing.size_160,
     },
     narrowBanner: {
-        maxWidth: 400,
+        maxInlineSize: 400,
     },
     rightToLeft: {
         width: "100%",
-        direction: "rtl",
     },
 });

--- a/__docs__/wonder-blocks-button/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-button/accessibility.stories.tsx
@@ -6,7 +6,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 
 const styles = StyleSheet.create({
     button: {
-        marginRight: 10,
+        marginInlineEnd: 10,
     },
 });
 

--- a/__docs__/wonder-blocks-button/activity-button.stories.tsx
+++ b/__docs__/wonder-blocks-button/activity-button.stories.tsx
@@ -396,7 +396,7 @@ export const PressDurationTracking: Story = {
                         backgroundColor:
                             semanticColor.core.background.neutral.subtle,
                         borderRadius: sizing.size_080,
-                        minHeight: "120px",
+                        minBlockSize: "120px",
                     }}
                 >
                     <BodyText size="medium" weight="semi">

--- a/__docs__/wonder-blocks-button/best-practices.stories.tsx
+++ b/__docs__/wonder-blocks-button/best-practices.stories.tsx
@@ -15,11 +15,11 @@ const styles = StyleSheet.create({
         height: 16,
     },
     button: {
-        marginRight: 10,
+        marginInlineEnd: 10,
     },
     buttonMinWidth: {
-        marginRight: 10,
-        minWidth: 144,
+        marginInlineEnd: 10,
+        minInlineSize: 144,
     },
 });
 

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -76,7 +76,7 @@ export const styles: StyleDeclaration = StyleSheet.create({
     row: {
         flexDirection: "row",
         alignItems: "center",
-        marginBottom: sizing.size_080,
+        marginBlockEnd: sizing.size_080,
     },
     rowWithGap: {
         flexDirection: "row",
@@ -84,22 +84,22 @@ export const styles: StyleDeclaration = StyleSheet.create({
         gap: sizing.size_160,
     },
     button: {
-        marginRight: sizing.size_080,
+        marginInlineEnd: sizing.size_080,
     },
     truncatedButton: {
-        maxWidth: 200,
-        marginBottom: sizing.size_160,
+        maxInlineSize: 200,
+        marginBlockEnd: sizing.size_160,
     },
     fillSpace: {
-        minWidth: 140,
+        minInlineSize: 140,
     },
     example: {
         background: semanticColor.core.background.base.subtle,
         padding: sizing.size_160,
     },
     label: {
-        marginTop: sizing.size_240,
-        marginBottom: sizing.size_080,
+        marginBlockStart: sizing.size_240,
+        marginBlockEnd: sizing.size_080,
     },
 });
 
@@ -978,7 +978,7 @@ export const PressDurationTracking: StoryComponentType = {
                         backgroundColor:
                             semanticColor.core.background.base.subtle,
                         borderRadius: 4,
-                        maxWidth: 400,
+                        maxInlineSize: 400,
                     }}
                 >
                     <BodyText size="medium" weight="bold">
@@ -1005,7 +1005,7 @@ export const PressDurationTracking: StoryComponentType = {
                         Interaction History:
                     </BodyText>
                     {interactionHistory.length > 0 ? (
-                        <View style={{marginTop: sizing.size_080}}>
+                        <View style={{marginBlockStart: sizing.size_080}}>
                             {interactionHistory.map((entry, index) => (
                                 <BodyText
                                     key={index}

--- a/__docs__/wonder-blocks-card/card-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-card/card-testing-snapshots.stories.tsx
@@ -62,11 +62,11 @@ const dismissible = [
 const styles = StyleSheet.create({
     cardContainer: {
         width: "100%",
-        minHeight: sizing.size_320,
+        minBlockSize: sizing.size_320,
         display: "flex",
     },
     card: {
-        minHeight: sizing.size_320,
+        minBlockSize: sizing.size_320,
         width: "100%",
     },
 });

--- a/__docs__/wonder-blocks-card/card.stories.tsx
+++ b/__docs__/wonder-blocks-card/card.stories.tsx
@@ -204,7 +204,11 @@ export const WithBackgroundImage: StoryComponentType = {
                 <Heading size="small" style={styles.eotCardText}>
                     Practice
                 </Heading>
-                <img src={eotIcon} alt="" style={{maxWidth: sizing.size_640}} />
+                <img
+                    src={eotIcon}
+                    alt=""
+                    style={{maxInlineSize: sizing.size_640}}
+                />
                 <Heading
                     size="small"
                     weight="semi"

--- a/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/detail-cell.stories.tsx
@@ -477,7 +477,7 @@ const styles = StyleSheet.create({
     },
     navigation: {
         border: `${border.width.thin} dashed ${semanticColor.core.border.instructive.default}`,
-        marginTop: sizing.size_240,
+        marginBlockStart: sizing.size_240,
         padding: sizing.size_240,
     },
 });

--- a/__docs__/wonder-blocks-clickable/clickable.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/clickable.stories.tsx
@@ -303,11 +303,11 @@ const styles = StyleSheet.create({
         alignItems: "center",
     },
     heading: {
-        marginRight: sizing.size_240,
+        marginInlineEnd: sizing.size_240,
     },
     navigation: {
         border: `1px dashed ${semanticColor.core.border.neutral.subtle}`,
-        marginTop: sizing.size_240,
+        marginBlockStart: sizing.size_240,
         padding: sizing.size_240,
     },
     disabled: {
@@ -315,7 +315,7 @@ const styles = StyleSheet.create({
         backgroundColor: semanticColor.action.primary.disabled.background,
     },
     button: {
-        maxWidth: 150,
+        maxInlineSize: 150,
     },
     centered: {
         alignItems: "center",

--- a/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
+++ b/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
@@ -38,7 +38,7 @@ const DatePickerWrapper = (props: Props) => {
             }}
         >
             <Button>prev</Button>
-            <View style={{flexGrow: 1, maxWidth: "24rem"}}>
+            <View style={{flexGrow: 1, maxInlineSize: "24rem"}}>
                 <DatePicker
                     {...props}
                     inputAriaLabel="Choose or enter a date"
@@ -322,7 +322,7 @@ const DatePickerWithOpenOverlay = (props: Props) => {
             ref={containerRef}
             style={{
                 padding: sizing.size_240,
-                minHeight: 400,
+                minBlockSize: 400,
             }}
         >
             <DatePicker
@@ -530,7 +530,7 @@ export const InsideModal: Story = {
  */
 export const WithCustomStyles: Story = {
     render: (args) => (
-        <View style={{gap: sizing.size_240, maxWidth: 600}}>
+        <View style={{gap: sizing.size_240, maxInlineSize: 600}}>
             <View style={{gap: sizing.size_080}}>
                 <BodyText weight="bold" tag="label" htmlFor="custom-example1">
                     Date with default size (225px × 40px)

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -141,13 +141,13 @@ const styles = StyleSheet.create({
         justifyContent: "space-between",
     },
     dropdown: {
-        maxHeight: 200,
+        maxBlockSize: 200,
     },
     /**
      * Custom opener styles
      */
     customOpener: {
-        borderLeft: `${border.width.thick} solid ${semanticColor.status.warning.foreground}`,
+        borderInlineStart: `${border.width.thick} solid ${semanticColor.status.warning.foreground}`,
         borderRadius: border.radius.radius_040,
         background: semanticColor.status.warning.background,
         color: semanticColor.core.foreground.neutral.strong,
@@ -611,7 +611,7 @@ export const OpeningModal: StoryComponentType = {
                         <OnePaneDialog
                             title="Are you sure?"
                             content="This is just a test"
-                            style={{maxHeight: "fit-content"}}
+                            style={{maxBlockSize: "fit-content"}}
                             footer={
                                 <View
                                     style={{

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -93,11 +93,11 @@ export default {
 
 const styles = StyleSheet.create({
     setWidth: {
-        minWidth: 170,
+        minInlineSize: 170,
         width: "100%",
     },
     customDropdown: {
-        maxHeight: 200,
+        maxBlockSize: 200,
     },
     wrapper: {
         height: "600px",
@@ -125,7 +125,7 @@ const styles = StyleSheet.create({
      * Custom opener styles
      */
     customOpener: {
-        borderLeft: `${border.width.thick} solid ${semanticColor.core.border.instructive.default}`,
+        borderInlineStart: `${border.width.thick} solid ${semanticColor.core.border.instructive.default}`,
         borderRadius: border.radius.radius_040,
         background: semanticColor.core.background.instructive.subtle,
         color: semanticColor.core.foreground.instructive.default,
@@ -552,7 +552,7 @@ const DropdownInModalWrapper = (args: MultiSelectArgs) => {
     const modalContent = (
         <View style={styles.scrollableArea}>
             <View style={styles.scrolledWrapper}>
-                <View style={{minHeight: "100vh"}}>
+                <View style={{minBlockSize: "100vh"}}>
                     <MultiSelect
                         {...args}
                         onChange={setSelectedValues}

--- a/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select.stories.tsx
@@ -123,13 +123,13 @@ const styles = StyleSheet.create({
         justifyContent: "space-between",
     },
     dropdown: {
-        maxHeight: 200,
+        maxBlockSize: 200,
     },
     /**
      * Custom opener styles
      */
     customOpener: {
-        borderLeft: `${border.width.thick} solid ${semanticColor.core.border.instructive.default}`,
+        borderInlineStart: `${border.width.thick} solid ${semanticColor.core.border.instructive.default}`,
         borderRadius: border.radius.radius_040,
         background: semanticColor.core.background.instructive.subtle,
         color: semanticColor.core.foreground.instructive.default,
@@ -164,7 +164,7 @@ const styles = StyleSheet.create({
     // AutoFocus
     icon: {
         position: "absolute",
-        right: sizing.size_160,
+        insetInlineEnd: sizing.size_160,
     },
 });
 

--- a/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
@@ -330,18 +330,18 @@ const styles = StyleSheet.create({
         flexWrap: "wrap",
     },
     choice: {
-        marginTop: sizing.size_080,
+        marginBlockStart: sizing.size_080,
         width: 200,
     },
     title: {
-        paddingBottom: sizing.size_080,
-        borderBottom: `1px solid ${semanticColor.core.border.neutral.default}`,
+        paddingBlockEnd: sizing.size_080,
+        borderBlockEnd: `1px solid ${semanticColor.core.border.neutral.default}`,
     },
     // Multiple choice styling
     multipleChoice: {
         margin: 0,
         blockSize: sizing.size_480,
-        borderTop: "solid 1px #CCC",
+        borderBlockStart: "solid 1px #CCC",
         justifyContent: "center",
     },
     firstChoice: {
@@ -351,6 +351,6 @@ const styles = StyleSheet.create({
         color: semanticColor.core.foreground.neutral.default,
     },
     last: {
-        borderBottom: "solid 1px #CCC",
+        borderBlockEnd: "solid 1px #CCC",
     },
 });

--- a/__docs__/wonder-blocks-form/checkbox.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox.stories.tsx
@@ -372,6 +372,6 @@ const styles = StyleSheet.create({
         justifyContent: "space-evenly",
     },
     topic: {
-        maxWidth: 600,
+        maxInlineSize: 600,
     },
 });

--- a/__docs__/wonder-blocks-form/deprecated-labeled-text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/deprecated-labeled-text-field.stories.tsx
@@ -754,7 +754,7 @@ AutoComplete.parameters = {
 
 const styles = StyleSheet.create({
     button: {
-        maxWidth: 150,
+        maxInlineSize: 150,
     },
     row: {
         flexDirection: "row",
@@ -763,6 +763,6 @@ const styles = StyleSheet.create({
         flexGrow: 1,
     },
     fieldWithButton: {
-        marginBottom: sizing.size_160,
+        marginBlockEnd: sizing.size_160,
     },
 });

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -263,13 +263,13 @@ const styles = StyleSheet.create({
     choice: {
         margin: 0,
         height: 48,
-        borderTop: "solid 1px #CCC",
+        borderBlockStart: "solid 1px #CCC",
         justifyContent: "center",
     },
     lastChoice: {
-        borderBottom: "solid 1px #CCC",
+        borderBlockEnd: "solid 1px #CCC",
     },
     prompt: {
-        marginBottom: 16,
+        marginBlockEnd: 16,
     },
 });

--- a/__docs__/wonder-blocks-form/radio.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio.stories.tsx
@@ -174,6 +174,6 @@ const styles = StyleSheet.create({
         justifyContent: "space-evenly",
     },
     topic: {
-        maxWidth: 600,
+        maxInlineSize: 600,
     },
 });

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
         backgroundColor: semanticColor.status.notice.background,
         color: semanticColor.status.notice.foreground,
         border: "none",
-        maxWidth: 250,
+        maxInlineSize: 250,
         "::placeholder": {
             color: semanticColor.core.foreground.neutral.default,
         },
@@ -191,7 +191,7 @@ export const WithValue: ControlledStoryComponentType = {
 export const AutoResize: StoryComponentType = {
     render: (args) => {
         return (
-            <View style={{gap: sizing.size_240, maxWidth: "500px"}}>
+            <View style={{gap: sizing.size_240, maxInlineSize: "500px"}}>
                 <ControlledTextArea
                     {...args}
                     autoResize={false}
@@ -551,19 +551,19 @@ export const AutoFocus = () => {
                 autoFocus={true}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
-                style={{flexGrow: 1, marginLeft: sizing.size_120}}
+                style={{flexGrow: 1, marginInlineStart: sizing.size_120}}
             />
         </View>
     );
 
     return (
         <View>
-            <LabelLarge style={{marginBottom: sizing.size_120}}>
+            <LabelLarge style={{marginBlockEnd: sizing.size_120}}>
                 Press the button to view the textarea with autofocus.
             </LabelLarge>
             <Button
                 onClick={handleShowDemo}
-                style={{width: 300, marginBottom: sizing.size_240}}
+                style={{width: 300, marginBlockEnd: sizing.size_240}}
             >
                 Toggle autoFocus demo
             </Button>

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -829,19 +829,19 @@ export const WithAutofocus: StoryComponentType = {
                     autoFocus={true}
                     onChange={handleChange}
                     onKeyDown={handleKeyDown}
-                    style={{flexGrow: 1, marginLeft: sizing.size_120}}
+                    style={{flexGrow: 1, marginInlineStart: sizing.size_120}}
                 />
             </View>
         );
 
         return (
             <View>
-                <LabelLarge style={{marginBottom: sizing.size_120}}>
+                <LabelLarge style={{marginBlockEnd: sizing.size_120}}>
                     Press the button to view the text field with autofocus.
                 </LabelLarge>
                 <Button
                     onClick={handleShowDemo}
-                    style={{width: 300, marginBottom: sizing.size_240}}
+                    style={{width: 300, marginBlockEnd: sizing.size_240}}
                 >
                     Toggle autoFocus demo
                 </Button>
@@ -911,15 +911,15 @@ const styles = StyleSheet.create({
         backgroundColor: semanticColor.status.notice.background,
         color: semanticColor.status.notice.foreground,
         border: "none",
-        maxWidth: 250,
+        maxInlineSize: 250,
         "::placeholder": {
             color: semanticColor.core.foreground.neutral.default,
         },
     },
     button: {
-        maxWidth: 150,
+        maxInlineSize: 150,
     },
     fieldWithButton: {
-        marginBottom: sizing.size_160,
+        marginBlockEnd: sizing.size_160,
     },
 });

--- a/__docs__/wonder-blocks-icon/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-icon/accessibility.stories.tsx
@@ -31,7 +31,7 @@ export const IconContrast = {
         <View
             style={{
                 flexDirection: "row",
-                marginBottom: sizing.size_080,
+                marginBlockEnd: sizing.size_080,
             }}
         >
             <LabelMedium>High contrast icon (GOOD):</LabelMedium>
@@ -51,7 +51,7 @@ export const RightToLeftIcons = {
         <View
             style={{
                 flexDirection: "row",
-                direction: "ltr",
+                direction: "ltr", // eslint-disable-line @khanacademy/wonder-blocks/require-logical-properties-for-rtl
             }}
         >
             <PhosphorIcon icon={IconMappings.caretRight} />

--- a/__docs__/wonder-blocks-icon/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-icon/accessibility.stories.tsx
@@ -49,9 +49,9 @@ export const IconContrast = {
 export const RightToLeftIcons = {
     render: () => (
         <View
+            dir="ltr"
             style={{
                 flexDirection: "row",
-                direction: "ltr", // eslint-disable-line @khanacademy/wonder-blocks/require-logical-properties-for-rtl
             }}
         >
             <PhosphorIcon icon={IconMappings.caretRight} />

--- a/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
@@ -349,7 +349,7 @@ const styles = StyleSheet.create({
     table: {
         borderCollapse: "collapse",
         borderSpacing: 0,
-        maxWidth: 600,
+        maxInlineSize: 600,
         textAlign: "center",
     },
 

--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -343,7 +343,7 @@ const scenarios = [
 export const Scenarios = (args: PropsFor<typeof LabeledField>) => {
     const [textFieldValue, setTextFieldValue] = React.useState("");
     return (
-        <View style={{maxWidth: "475px"}}>
+        <View style={{maxInlineSize: "475px"}}>
             <ScenariosLayout
                 scenarios={scenarios}
                 styles={{root: {alignItems: "stretch"}}}

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -581,7 +581,7 @@ export const WithTitle: StoryComponentType = {
 export const RightToLeftWithIcons: StoryComponentType = {
     render: () => (
         <View style={{padding: sizing.size_160}}>
-            <View style={styles.rightToLeft}>
+            <View dir="rtl">
                 <Link
                     href="/"
                     startIcon={
@@ -641,10 +641,7 @@ const styles = StyleSheet.create({
         display: "inline-block",
         marginBlockEnd: sizing.size_080,
     },
-    rightToLeft: {
-        width: "100%",
-        direction: "rtl", // eslint-disable-line @khanacademy/wonder-blocks/require-logical-properties-for-rtl
-    },
+
     multiLine: {
         display: "inline-block",
         marginBlockEnd: sizing.size_080,

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -620,11 +620,11 @@ export const RightToLeftWithIcons: StoryComponentType = {
 
 const styles = StyleSheet.create({
     heading: {
-        marginRight: sizing.size_240,
+        marginInlineEnd: sizing.size_240,
     },
     navigation: {
         border: `1px dashed ${semanticColor.core.border.neutral.subtle}`,
-        marginTop: sizing.size_240,
+        marginBlockStart: sizing.size_240,
         padding: sizing.size_240,
     },
     customLink: {
@@ -639,16 +639,16 @@ const styles = StyleSheet.create({
         // instead of taking the full width of the parent
         // container.
         display: "inline-block",
-        marginBottom: sizing.size_080,
+        marginBlockEnd: sizing.size_080,
     },
     rightToLeft: {
         width: "100%",
-        direction: "rtl",
+        direction: "rtl", // eslint-disable-line @khanacademy/wonder-blocks/require-logical-properties-for-rtl
     },
     multiLine: {
         display: "inline-block",
-        marginBottom: sizing.size_080,
-        maxWidth: "15%",
+        marginBlockEnd: sizing.size_080,
+        maxInlineSize: "15%",
     },
     card: {
         background: semanticColor.core.background.base.subtle,

--- a/__docs__/wonder-blocks-modal/drawer-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/drawer-dialog.stories.tsx
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
         padding: sizing.size_160,
     },
     section: {
-        marginBottom: sizing.size_160,
+        marginBlockEnd: sizing.size_160,
     },
     form: {
         display: "flex",

--- a/__docs__/wonder-blocks-modal/flexible-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/flexible-dialog.stories.tsx
@@ -403,7 +403,7 @@ export const WithFullScreenStyling: StoryComponentType = () => {
                     maxWidth: "none",
                     maxHeight: "none",
                     height: "100%",
-                    minHeight: "100vh",
+                    minBlockSize: "100vh",
                     margin: 0,
                 },
             }}

--- a/__docs__/wonder-blocks-modal/flexible-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/flexible-dialog.stories.tsx
@@ -107,7 +107,7 @@ export const WithBackgroundImage: StoryComponentType = {
                         <View style={styles.centered}>
                             <img
                                 src={celebrationChest}
-                                style={{maxWidth: "240px"}}
+                                style={{maxInlineSize: "240px"}}
                                 alt=""
                             />
                             {title}
@@ -390,7 +390,7 @@ export const WithFullScreenStyling: StoryComponentType = () => {
                 <Heading
                     size="xxlarge"
                     style={{
-                        marginBottom: sizing.size_320,
+                        marginBlockEnd: sizing.size_320,
                     }}
                 >
                     Full-Screen Dialog
@@ -414,7 +414,7 @@ export const WithFullScreenStyling: StoryComponentType = () => {
                         style={{
                             color: semanticColor.core.foreground.neutral
                                 .default,
-                            marginBottom: sizing.size_480,
+                            marginBlockEnd: sizing.size_480,
                         }}
                     >
                         This FlexibleDialog demonstrates full-screen
@@ -521,10 +521,10 @@ const styles = StyleSheet.create({
         justifyContent: "center",
 
         position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        insetBlockStart: 0,
+        insetBlockEnd: 0,
     },
     centered: {
         alignItems: "center",
@@ -533,7 +533,7 @@ const styles = StyleSheet.create({
         textAlign: "center",
     },
     previewSizer: {
-        minHeight: "calc(100vh - 1.6rem)",
+        minBlockSize: "calc(100vh - 1.6rem)",
         width: "100%",
     },
     row: {
@@ -548,7 +548,7 @@ const styles = StyleSheet.create({
         width: "100%",
     },
     launcherButton: {
-        marginTop: "auto",
+        marginBlockStart: "auto",
     },
     fullScreenContent: {
         display: "flex",
@@ -557,8 +557,8 @@ const styles = StyleSheet.create({
         justifyContent: "center",
         height: "100%",
         textAlign: "center",
-        minHeight: "100vh",
-        minWidth: "unset",
+        minBlockSize: "100vh",
+        minInlineSize: "unset",
     },
     fullScreenActions: {
         display: "flex",

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -269,13 +269,13 @@ const styles = StyleSheet.create({
         justifyContent: "center",
 
         position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        insetBlockStart: 0,
+        insetBlockEnd: 0,
     },
     previewSizer: {
-        minHeight: 600,
+        minBlockSize: 600,
         width: "100%",
     },
     row: {
@@ -289,12 +289,12 @@ const styles = StyleSheet.create({
         width: "100%",
     },
     squareDialog: {
-        maxHeight: 500,
-        maxWidth: 500,
+        maxBlockSize: 500,
+        maxInlineSize: 500,
         backgroundColor: semanticColor.core.background.neutral.strong,
     },
     smallSquarePanel: {
-        maxHeight: 400,
-        maxWidth: 400,
+        maxBlockSize: 400,
+        maxInlineSize: 400,
     },
 });

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -292,8 +292,8 @@ export const WithMultipleActions: StoryComponentType = {
 
 const styles = StyleSheet.create({
     dialog: {
-        maxWidth: 600,
-        maxHeight: 500,
+        maxInlineSize: 600,
+        maxBlockSize: 500,
     },
     modalPositioner: {
         // Checkerboard background
@@ -307,10 +307,10 @@ const styles = StyleSheet.create({
         justifyContent: "center",
 
         position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        insetBlockStart: 0,
+        insetBlockEnd: 0,
     },
     previewSizer: {
         height: 600,

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -225,8 +225,8 @@ export const WithBreadcrumbs: StoryComponentType = {
 
 const styles = StyleSheet.create({
     dialog: {
-        maxWidth: 600,
-        maxHeight: 500,
+        maxInlineSize: 600,
+        maxBlockSize: 500,
     },
     modalPositioner: {
         // Checkerboard background
@@ -240,10 +240,10 @@ const styles = StyleSheet.create({
         justifyContent: "center",
 
         position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        insetBlockStart: 0,
+        insetBlockEnd: 0,
     },
     previewSizer: {
         height: 600,

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -722,7 +722,7 @@ const styles = StyleSheet.create({
         display: "flex",
         flexDirection: "column",
         gap: sizing.size_240,
-        maxWidth: 600,
+        maxInlineSize: 600,
     },
     description: {
         display: "flex",
@@ -892,7 +892,7 @@ export const CreatingACustomModal: StoryComponentType = {
                 }}
             >
                 <ModalPanel
-                    style={{maxWidth: 423}}
+                    style={{maxInlineSize: 423}}
                     closeButtonVisible={true}
                     content={
                         <View style={{gap: sizing.size_240}}>

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -350,8 +350,8 @@ export const WithStyle: StoryComponentType = {
 
 const styles = StyleSheet.create({
     dialog: {
-        maxWidth: 600,
-        maxHeight: 500,
+        maxInlineSize: 600,
+        maxBlockSize: 500,
     },
     modalPositioner: {
         // Checkerboard background
@@ -365,10 +365,10 @@ const styles = StyleSheet.create({
         justifyContent: "center",
 
         position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        insetBlockStart: 0,
+        insetBlockEnd: 0,
     },
     previewSizer: {
         height: 600,

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -582,13 +582,13 @@ const styles = StyleSheet.create({
         justifyContent: "center",
 
         position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        insetBlockStart: 0,
+        insetBlockEnd: 0,
     },
     previewSizer: {
-        minHeight: 600,
+        minBlockSize: 600,
         width: "100%",
     },
     row: {

--- a/__docs__/wonder-blocks-pill/deprecated-pill.stories.tsx
+++ b/__docs__/wonder-blocks-pill/deprecated-pill.stories.tsx
@@ -196,7 +196,7 @@ export const Variants: StoryComponentType = {
                                 <View
                                     key={kind}
                                     style={{
-                                        marginRight: tokens.sizing.size_120,
+                                        marginInlineEnd: tokens.sizing.size_120,
                                     }}
                                 >
                                     <Pill
@@ -219,7 +219,7 @@ export const Variants: StoryComponentType = {
                                 <View
                                     key={kind}
                                     style={{
-                                        marginRight: tokens.sizing.size_120,
+                                        marginInlineEnd: tokens.sizing.size_120,
                                     }}
                                 >
                                     <Pill
@@ -322,7 +322,7 @@ export const InList: StoryComponentType = () => {
                         onClick={() => setSelected(option)}
                         aria-checked={option === selected}
                         role="radio"
-                        style={{marginRight: tokens.sizing.size_080}}
+                        style={{marginInlineEnd: tokens.sizing.size_080}}
                     >
                         {option}
                     </Pill>
@@ -362,7 +362,7 @@ export const VerticallyStacked: StoryComponentType = {
                 {sizes.map((size) => (
                     <View
                         key={size}
-                        style={{marginRight: tokens.sizing.size_160}}
+                        style={{marginInlineEnd: tokens.sizing.size_160}}
                     >
                         <LabelMedium>{size}px margin</LabelMedium>
                         <Strut size={12} />

--- a/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
         padding: 0,
     },
     customPopover: {
-        maxWidth: `calc(${sizing.size_160} * 25)`,
+        maxInlineSize: `calc(${sizing.size_160} * 25)`,
         width: `calc(${sizing.size_160} * 25)`,
         textAlign: "center",
     },

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
     },
     playground: {
         border: `1px dashed ${semanticColor.core.border.neutral.subtle}`,
-        marginTop: sizing.size_240,
+        marginBlockStart: sizing.size_240,
         padding: sizing.size_240,
         flexDirection: "row",
         gap: sizing.size_160,
@@ -602,7 +602,7 @@ export const CustomKeyboardNavigation: StoryComponentType = {
         };
 
         return (
-            <View style={[{padding: "120px 0"}]}>
+            <View style={[{paddingBlock: "120px", paddingInline: "0"}]}>
                 <View style={[styles.row, {gap: sizing.size_160}]}>
                     <Button
                         kind="secondary"
@@ -786,7 +786,7 @@ export const PopoverAlignment: StoryComponentType = {
 export const WithDocumentRootBoundary: StoryComponentType = {
     render: () => {
         return (
-            <View style={{paddingBottom: "500px"}}>
+            <View style={{paddingBlockEnd: "500px"}}>
                 <Popover
                     rootBoundary="document"
                     content={() => (

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -1028,8 +1028,8 @@ export const AutoUpdate: StoryComponentType = {
                         style={
                             position && {
                                 position: "absolute",
-                                top: position.y,
-                                left: position.x,
+                                insetBlockStart: position.y,
+                                insetInlineStart: position.x,
                             }
                         }
                     >

--- a/__docs__/wonder-blocks-progress-spinner/circular-spinner.stories.tsx
+++ b/__docs__/wonder-blocks-progress-spinner/circular-spinner.stories.tsx
@@ -191,6 +191,6 @@ const styles = StyleSheet.create({
     },
     row: {
         flexDirection: "row",
-        marginBottom: sizing.size_320,
+        marginBlockEnd: sizing.size_320,
     },
 });

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -224,19 +224,19 @@ export const WithAutofocus: StoryComponentType = {
                     autoFocus={true}
                     onChange={handleChange}
                     onKeyDown={handleKeyDown}
-                    style={{flexGrow: 1, marginLeft: sizing.size_120}}
+                    style={{flexGrow: 1, marginInlineStart: sizing.size_120}}
                 />
             </View>
         );
 
         return (
             <View>
-                <LabelLarge style={{marginBottom: sizing.size_120}}>
+                <LabelLarge style={{marginBlockEnd: sizing.size_120}}>
                     Press the button to view the search field with autofocus.
                 </LabelLarge>
                 <Button
                     onClick={handleShowDemo}
-                    style={{width: 300, marginBottom: sizing.size_240}}
+                    style={{width: 300, marginBlockEnd: sizing.size_240}}
                 >
                     Toggle autoFocus demo
                 </Button>

--- a/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch-best-practices.stories.tsx
@@ -54,7 +54,7 @@ export const WithLabel: StoryComponentType = (() => {
             <LabelMedium
                 id="label-for-switch-with-label"
                 htmlFor="switch-with-label"
-                style={{marginLeft: sizing.size_080}}
+                style={{marginInlineStart: sizing.size_080}}
                 tag="label"
             >
                 Superpowers
@@ -80,7 +80,7 @@ export const WithLabelAndDescription: StoryComponentType = (() => {
                 aria-labelledby="label-for-switch-with-desc"
                 aria-describedby="desc-for-switch-with-desc"
             />
-            <View style={{marginLeft: sizing.size_080}}>
+            <View style={{marginInlineStart: sizing.size_080}}>
                 <LabelMedium
                     id="label-for-switch-with-desc"
                     htmlFor="switch-with-desc"
@@ -117,7 +117,7 @@ export const WithLabelAndOnOff: StoryComponentType = (() => {
             <LabelMedium
                 id="label-for-switch-with-on-off"
                 htmlFor="switch-with-on-off"
-                style={{marginRight: sizing.size_080}}
+                style={{marginInlineEnd: sizing.size_080}}
                 tag="label"
             >
                 Gravity
@@ -130,7 +130,7 @@ export const WithLabelAndOnOff: StoryComponentType = (() => {
             />
             <LabelSmall
                 style={{
-                    marginLeft: sizing.size_080,
+                    marginInlineStart: sizing.size_080,
                     color: semanticColor.core.foreground.neutral.subtle,
                 }}
                 aria-hidden={true}

--- a/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs.stories.tsx
@@ -157,7 +157,7 @@ export const HeaderWithNavigationTabsExample: StoryComponentType = {
                 display: "flex",
                 alignItems: "center",
                 flexWrap: "wrap",
-                borderBottom: `1px solid ${semanticColor.core.border.neutral.subtle}`,
+                borderBlockEnd: `1px solid ${semanticColor.core.border.neutral.subtle}`,
                 gap: sizing.size_240,
                 padding: `${headerVerticalSpacing} ${sizing.size_240}`,
             },
@@ -357,7 +357,7 @@ export const ChildrenRenderFunction: StoryComponentType = {
             <View
                 style={{
                     // Need to set the height so tooltip/popover are captured in chromatic
-                    minHeight: 400,
+                    minBlockSize: 400,
                     gap: sizing.size_240,
                 }}
             >

--- a/__docs__/wonder-blocks-tokens/semantic-color-groups.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/semantic-color-groups.stories.tsx
@@ -245,6 +245,6 @@ const styles = StyleSheet.create({
     },
 
     banner: {
-        marginBottom: sizing.size_320,
+        marginBlockEnd: sizing.size_320,
     },
 });

--- a/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
@@ -85,7 +85,7 @@ export const SemanticColors = () => (
             {
                 label: "CSS Variable",
                 cell: (row) => (
-                    <Code style={{minWidth: "200px"}}>{row.css}</Code>
+                    <Code style={{minInlineSize: "200px"}}>{row.css}</Code>
                 ),
             },
             {

--- a/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.argtypes.tsx
@@ -20,9 +20,9 @@ const mobile = "@media (max-width: 1023px)";
 
 const styles = StyleSheet.create({
     fillContent: {
-        marginLeft: sizing.size_120,
+        marginInlineStart: sizing.size_120,
         [mobile]: {
-            marginLeft: 0,
+            marginInlineStart: 0,
             width: "100%",
         },
     },

--- a/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
@@ -236,7 +236,7 @@ export const CustomToolbar: StoryComponentType = {
             <View
                 style={{
                     width: 300,
-                    maxWidth: "100%",
+                    maxInlineSize: "100%",
                     height: sizing.size_080,
                     background: semanticColor.mastery.primary,
                 }}

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -27,7 +27,7 @@ import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 const styles = StyleSheet.create({
     storyCanvas: {
         // NOTE: This is needed for Chromatic to include the tooltip bubble.
-        minHeight: 280,
+        minBlockSize: 280,
         padding: sizing.size_640,
         justifyContent: "center",
         textAlign: "center",
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
         margin: sizing.size_120,
     },
     hostbox: {
-        minHeight: "200vh",
+        minBlockSize: "200vh",
     },
     modalbox: {
         height: "200vh",
@@ -467,8 +467,8 @@ export const AutoUpdate: StoryComponentType = {
                         style={[
                             position && {
                                 position: "absolute",
-                                top: position.y,
-                                left: position.x,
+                                insetBlockStart: position.y,
+                                insetInlineStart: position.x,
                             },
                         ]}
                     >
@@ -521,8 +521,8 @@ export const InTopCorner = {
         <View
             style={{
                 position: "absolute",
-                top: 0,
-                left: 0,
+                insetBlockStart: 0,
+                insetInlineStart: 0,
             }}
         >
             <Tooltip content="This is an example descriptor that's long with more content to see if it will display properly in different browsers">

--- a/__docs__/wonder-blocks-typography/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-typography/accessibility.stories.tsx
@@ -12,17 +12,17 @@ const styles = StyleSheet.create({
     explanation: {
         fontWeight: 700,
         flexDirection: "row",
-        marginTop: sizing.size_080,
+        marginBlockStart: sizing.size_080,
     },
     correct: {
         color: semanticColor.core.foreground.success.default,
-        marginRight: sizing.size_040,
-        paddingTop: sizing.size_020,
+        marginInlineEnd: sizing.size_040,
+        paddingBlockStart: sizing.size_020,
     },
     incorrect: {
         color: semanticColor.core.foreground.critical.default,
-        marginRight: sizing.size_040,
-        paddingTop: sizing.size_020,
+        marginInlineEnd: sizing.size_040,
+        paddingBlockStart: sizing.size_020,
     },
 });
 

--- a/__docs__/wonder-blocks-typography/body-text.stories.tsx
+++ b/__docs__/wonder-blocks-typography/body-text.stories.tsx
@@ -239,6 +239,6 @@ const styles = StyleSheet.create({
         fontSize: sizing.size_280,
         fontWeight: font.weight.bold,
         lineHeight: sizing.size_320,
-        marginTop: sizing.size_200,
+        marginBlockStart: sizing.size_200,
     },
 });

--- a/__docs__/wonder-blocks-typography/heading.stories.tsx
+++ b/__docs__/wonder-blocks-typography/heading.stories.tsx
@@ -263,6 +263,6 @@ const styles = StyleSheet.create({
         fontSize: sizing.size_320,
         fontWeight: font.weight.semi,
         lineHeight: sizing.size_400,
-        marginTop: sizing.size_200,
+        marginBlockStart: sizing.size_200,
     },
 });

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -74,4 +74,4 @@ The following shows what rules are enabled in each config:
 | [`no-excessive-bodytext-children`](docs/no-excessive-bodytext-children.md)| |✅|
 | [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅|✅|
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|
-| [`require-logical-properties-for-rtl`](docs/require-logical-properties-for-rtl.md)| | |
+| [`require-logical-properties-for-rtl`](docs/require-logical-properties-for-rtl.md)|✅|✅|

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -74,4 +74,4 @@ The following shows what rules are enabled in each config:
 | [`no-excessive-bodytext-children`](docs/no-excessive-bodytext-children.md)| |✅|
 | [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅|✅|
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|
-| [`require-logical-properties-for-rtl`](docs/require-logical-properties-for-rtl.md)|✅|✅|
+| [`require-logical-properties-for-rtl`](docs/require-logical-properties-for-rtl.md)| | |

--- a/packages/eslint-plugin-wonder-blocks/docs/require-logical-properties-for-rtl.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/require-logical-properties-for-rtl.md
@@ -98,7 +98,3 @@ Some CSS values are directional but have no straightforward logical replacement.
 ```
 
 All options are booleans. Property-name and `textAlign` fixes always run regardless of options; the options only gate the value-based warnings listed above.
-
-## When not to use
-
-This rule is enabled in the recommended config. Disable per-line with `// eslint-disable-next-line @khanacademy/wonder-blocks/require-logical-properties-for-rtl` when a physical property is genuinely intentional (rare).

--- a/packages/eslint-plugin-wonder-blocks/docs/require-logical-properties-for-rtl.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/require-logical-properties-for-rtl.md
@@ -98,3 +98,7 @@ Some CSS values are directional but have no straightforward logical replacement.
 ```
 
 All options are booleans. Property-name and `textAlign` fixes always run regardless of options; the options only gate the value-based warnings listed above.
+
+## When not to use
+
+This rule is enabled in the recommended config. Disable per-line with `// eslint-disable-next-line @khanacademy/wonder-blocks/require-logical-properties-for-rtl` when a physical property is genuinely intentional (rare).

--- a/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
@@ -2,7 +2,8 @@ export default {
     plugins: ["@khanacademy/wonder-blocks"],
     rules: {
         "@khanacademy/wonder-blocks/no-invalid-bodytext-children": "error",
-        "@khanacademy/wonder-blocks/require-logical-properties-for-rtl":
-            "error",
+        // require-logical-properties-for-rtl is intentionally not enabled here yet.
+        // It will be turned on in a follow-up PR once WB's existing violations
+        // are auto-fixed via `eslint --fix` as part of CLASS-14218
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
@@ -2,7 +2,16 @@ export default {
     plugins: ["@khanacademy/wonder-blocks"],
     rules: {
         "@khanacademy/wonder-blocks/no-invalid-bodytext-children": "error",
-        "@khanacademy/wonder-blocks/require-logical-properties-for-rtl":
+        "@khanacademy/wonder-blocks/require-logical-properties-for-rtl": [
             "error",
+            {
+                warnDirectionalTransforms: true,
+                warnBackgroundPosition: true,
+                warnShadows: true,
+                warnGradients: true,
+                warnCursorDirections: true,
+                warnBackgroundPositionXY: true,
+            },
+        ],
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
@@ -2,8 +2,7 @@ export default {
     plugins: ["@khanacademy/wonder-blocks"],
     rules: {
         "@khanacademy/wonder-blocks/no-invalid-bodytext-children": "error",
-        // require-logical-properties-for-rtl is intentionally not enabled here yet.
-        // It will be turned on in a follow-up PR once WB's existing violations
-        // are auto-fixed via `eslint --fix` as part of CLASS-14218
+        "@khanacademy/wonder-blocks/require-logical-properties-for-rtl":
+            "error",
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/require-logical-properties-for-rtl.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/require-logical-properties-for-rtl.test.ts
@@ -62,6 +62,16 @@ ruleTester.run(ruleName, rule, {
         {code: '<div style={{cursor: "e-resize"}} />'},
         {code: '<div style={{backgroundPositionX: "left"}} />'},
 
+        // Zero X-offset shadows are not directional.
+        {
+            code: '<div style={{boxShadow: "0 4px 8px rgba(0,0,0,.2)"}} />',
+            options: [{warnShadows: true}],
+        },
+        {
+            code: '<div style={{boxShadow: "0px 4px 8px rgba(0,0,0,.2)"}} />',
+            options: [{warnShadows: true}],
+        },
+
         // When warnBackgroundPosition is explicitly off, directional bg is allowed.
         {
             code: '<div style={{backgroundPosition: "left top"}} />',

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/require-logical-properties-for-rtl.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/require-logical-properties-for-rtl.test.ts
@@ -67,6 +67,18 @@ ruleTester.run(ruleName, rule, {
             code: '<div style={{backgroundPosition: "left top"}} />',
             options: [{warnBackgroundPosition: false}],
         },
+
+        // Computed property keys (variables) must not be auto-fixed.
+        {code: '<div style={{[marginLeft]: "10px"}} />'},
+
+        // background with url() containing "left"/"right" in the filename
+        // must not trigger the directional warning.
+        {
+            code: '<div style={{background: "url(/images/left-arrow.png) no-repeat"}} />',
+        },
+        {
+            code: '<div style={{backgroundPosition: "url(top-right.svg) center"}} />',
+        },
     ],
     invalid: [
         // --- Property key auto-fixes -----------------------------------------
@@ -286,6 +298,25 @@ ruleTester.run(ruleName, rule, {
         {
             code: 'StyleSheet.create({foo: {[mediaLarge]: {marginLeft: "10px"}}});',
             output: 'StyleSheet.create({foo: {[mediaLarge]: {marginInlineStart: "10px"}}});',
+            errors: [{messageId: "useLogicalProperty"}],
+        },
+
+        // --- Top-level conditional expression in style={...} -----------------
+        {
+            code: '<div style={cond ? {marginLeft: "10px"} : null} />',
+            output: '<div style={cond ? {marginInlineStart: "10px"} : null} />',
+            errors: [{messageId: "useLogicalProperty"}],
+        },
+        {
+            code: '<div style={cond ? null : {paddingRight: "8px"}} />',
+            output: '<div style={cond ? null : {paddingInlineEnd: "8px"}} />',
+            errors: [{messageId: "useLogicalProperty"}],
+        },
+
+        // --- Top-level logical && in style={...} -----------------------------
+        {
+            code: '<div style={cond && {marginLeft: "10px"}} />',
+            output: '<div style={cond && {marginInlineStart: "10px"}} />',
             errors: [{messageId: "useLogicalProperty"}],
         },
     ],

--- a/packages/eslint-plugin-wonder-blocks/src/rules/require-logical-properties-for-rtl.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/require-logical-properties-for-rtl.ts
@@ -134,6 +134,9 @@ function getKeyName(property: TSESTree.Property): string | null {
     if (property.method || property.kind !== "init" || property.shorthand) {
         return null;
     }
+    if (property.computed) {
+        return null;
+    }
     if (property.key.type === "Identifier") {
         return property.key.name;
     }
@@ -197,7 +200,7 @@ export default createRule<Options, MessageIds>({
             avoidDirectionalCursor:
                 "Cursor is directional; consider 'ew-resize' or conditional swap based on `dir`.",
             avoidForceDirection:
-                "Avoid forcing 'direction' in component styles; rely on container `dir` unless whitelisted.",
+                "Avoid forcing 'direction' in component styles; rely on container `dir` instead.",
             preferLogicalPaddingShorthand:
                 "Prefer logical shorthands: 'paddingBlock'/'paddingInline' instead of two-value 'padding'.",
             preferLogicalMarginShorthand:
@@ -321,7 +324,9 @@ export default createRule<Options, MessageIds>({
                     if (
                         (keyName === "backgroundPosition" ||
                             keyName === "background") &&
-                        /\b(left|right)\b/.test(strVal) &&
+                        /\b(left|right)\b/.test(
+                            strVal.replace(/url\([^)]*\)/g, ""),
+                        ) &&
                         (options.warnBackgroundPosition ?? true)
                     ) {
                         context.report({
@@ -513,6 +518,21 @@ export default createRule<Options, MessageIds>({
         function handleStyleExpression(expr: TSESTree.Expression) {
             if (expr.type === "ObjectExpression") {
                 checkProperties(expr.properties);
+                return;
+            }
+            if (expr.type === "ConditionalExpression") {
+                if (expr.consequent.type === "ObjectExpression") {
+                    checkProperties(expr.consequent.properties);
+                }
+                if (expr.alternate.type === "ObjectExpression") {
+                    checkProperties(expr.alternate.properties);
+                }
+                return;
+            }
+            if (expr.type === "LogicalExpression" && expr.operator === "&&") {
+                if (expr.right.type === "ObjectExpression") {
+                    checkProperties(expr.right.properties);
+                }
                 return;
             }
             if (expr.type === "ArrayExpression") {

--- a/packages/eslint-plugin-wonder-blocks/src/rules/require-logical-properties-for-rtl.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/require-logical-properties-for-rtl.ts
@@ -400,7 +400,7 @@ export default createRule<Options, MessageIds>({
                 case "boxShadow":
                 case "textShadow": {
                     if (
-                        /^(?:inset\s+)?(?:-?(?:\d*\.\d+|\d+)|calc\(|var\()/.test(
+                        /^(?:inset\s+)?(?!0(?:\s|$|[a-zA-Z%]))(?:-?(?:\d*\.\d+|\d+)|calc\(|var\()/.test(
                             strVal,
                         ) &&
                         (options.warnShadows ?? false)

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -158,8 +158,8 @@ const ANIMATION_LENGTH = "300ms";
 
 const styles = StyleSheet.create({
     heading: {
-        // As this is a grid item, it has a default minWidth of auto,
-        // which means it would grow to fit its content. minWidth 0 is
+        // As this is a grid item, it has a default minInlineSize of auto,
+        // which means it would grow to fit its content. minInlineSize 0 is
         // necessary here to stop a custom header from overflowing out of
         // it container when its content is too long (See AccordionSection's
         // "React Element in Header" story).

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -163,15 +163,15 @@ const styles = StyleSheet.create({
         // necessary here to stop a custom header from overflowing out of
         // it container when its content is too long (See AccordionSection's
         // "React Element in Header" story).
-        minWidth: 0,
-        marginTop: 0,
+        minInlineSize: 0,
+        marginBlockStart: 0,
     },
     headerWrapper: {
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
         overflow: "hidden",
-        minWidth: "auto",
+        minInlineSize: "auto",
         width: "100%",
         // Always make the header's outline show up in front of
         // the content panel.

--- a/packages/wonder-blocks-badge/src/components/badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/badge.tsx
@@ -154,7 +154,7 @@ const styles = StyleSheet.create({
         color: badgeTokens.root.color.foreground,
     },
     icon: {
-        // Use minWidth and minHeight to ensure custom sized icons don't
+        // Use minInlineSize and minBlockSize to ensure custom sized icons don't
         // overflow the badge
         minInlineSize: badgeTokens.icon.sizing.width,
         minBlockSize: badgeTokens.icon.sizing.height,

--- a/packages/wonder-blocks-badge/src/components/badge.tsx
+++ b/packages/wonder-blocks-badge/src/components/badge.tsx
@@ -137,7 +137,7 @@ const styles = StyleSheet.create({
     },
     label: {
         // Truncate the label after ~30 characters
-        maxWidth: "30ch",
+        maxInlineSize: "30ch",
         overflow: "hidden",
         textOverflow: "ellipsis",
         whiteSpace: "nowrap",
@@ -156,8 +156,8 @@ const styles = StyleSheet.create({
     icon: {
         // Use minWidth and minHeight to ensure custom sized icons don't
         // overflow the badge
-        minWidth: badgeTokens.icon.sizing.width,
-        minHeight: badgeTokens.icon.sizing.height,
+        minInlineSize: badgeTokens.icon.sizing.width,
+        minBlockSize: badgeTokens.icon.sizing.height,
         display: "flex",
         alignItems: "center",
         justifyContent: "center",

--- a/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
+++ b/packages/wonder-blocks-birthday-picker/src/components/birthday-picker.tsx
@@ -157,7 +157,7 @@ const defaultStyles = StyleSheet.create({
     },
     input: {
         [screenSizes.small]: {
-            minWidth: "100%",
+            minInlineSize: "100%",
         },
     },
     errorRow: {
@@ -423,7 +423,7 @@ export default class BirthdayPicker extends React.Component<Props, State> {
                 selectedValue={day}
                 style={[
                     {
-                        minWidth: FIELD_MIN_WIDTH_DAY,
+                        minInlineSize: FIELD_MIN_WIDTH_DAY,
                     },
                     defaultStyles.input,
                     dropdownStyle,

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -234,7 +234,7 @@ const sharedStyles = StyleSheet.create({
         // View has a default minWidth of 0, which causes the label text
         // to encroach on the icon when it needs to truncate. We can fix
         // this by setting the minWidth to auto.
-        minWidth: "auto",
+        minInlineSize: "auto",
     },
     endIconWrapper: {
         marginInlineStart: theme.icon.margin.inline.inner,

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -231,9 +231,9 @@ const sharedStyles = StyleSheet.create({
     },
     iconWrapper: {
         padding: theme.icon.padding,
-        // View has a default minWidth of 0, which causes the label text
+        // View has a default minInlineSize of 0, which causes the label text
         // to encroach on the icon when it needs to truncate. We can fix
-        // this by setting the minWidth to auto.
+        // this by setting the minInlineSize to auto.
         minInlineSize: "auto",
     },
     endIconWrapper: {

--- a/packages/wonder-blocks-card/src/components/dismiss-button.tsx
+++ b/packages/wonder-blocks-card/src/components/dismiss-button.tsx
@@ -40,7 +40,7 @@ const componentStyles = StyleSheet.create({
         position: "absolute",
         // insetInlineEnd supports both RTL and LTR layouts
         insetInlineEnd: sizing.size_080,
-        top: sizing.size_080,
+        insetBlockStart: sizing.size_080,
         // This is to allow the button to be tab-ordered before the component
         // content but still be above the content.
         zIndex: 1,

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -236,7 +236,7 @@ const styles = StyleSheet.create({
         background: semanticColor.core.background.base.default,
         borderRadius: theme.root.border.radius.default,
         color: semanticColor.core.foreground.neutral.strong,
-        minHeight: theme.root.sizing.minHeight,
+        minBlockSize: theme.root.sizing.minHeight,
         // Hide overflow so that if custom styling applies a border radius, the
         // left visual indicator for press/active states does not overflow
         overflow: "hidden",
@@ -263,7 +263,7 @@ const styles = StyleSheet.create({
 
     accessory: {
         // Use content width by default.
-        minWidth: "auto",
+        minInlineSize: "auto",
         // Horizontal alignment of the accessory.
         alignItems: "center",
         // Vertical alignment.
@@ -322,9 +322,9 @@ const styles = StyleSheet.create({
             ":before": {
                 content: "''",
                 position: "absolute",
-                top: 0,
-                left: 0,
-                bottom: 0,
+                insetBlockStart: 0,
+                insetInlineStart: 0,
+                insetBlockEnd: 0,
                 width: theme.root.border.width.default,
                 // We use the border token as this element acts like a border
                 // when the cell is pressed.
@@ -342,9 +342,9 @@ const styles = StyleSheet.create({
             // Styles for the left bar indicator
             content: "''",
             position: "absolute",
-            top: 0,
-            left: 0,
-            bottom: 0,
+            insetBlockStart: 0,
+            insetInlineStart: 0,
+            insetBlockEnd: 0,
             width: theme.root.border.width.selected,
             backgroundColor: theme.root.color.selected.border,
         },

--- a/packages/wonder-blocks-cell/src/components/internal/common.ts
+++ b/packages/wonder-blocks-cell/src/components/internal/common.ts
@@ -31,9 +31,9 @@ const styles = StyleSheet.create({
             content: "''",
             position: "absolute",
             // align to the bottom of the cell
-            bottom: 0,
+            insetBlockEnd: 0,
             // align border to the right of the cell
-            right: 0,
+            insetInlineEnd: 0,
             height: theme.rule.sizing.height,
             boxShadow: theme.rule.shadow,
         },

--- a/packages/wonder-blocks-core/src/components/__tests__/__snapshots__/view.test.tsx.snap
+++ b/packages/wonder-blocks-core/src/components/__tests__/__snapshots__/view.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`View Should set the tag to be article 1`] = `
 <div>
   <article
     class=""
-    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0;"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0;"
   />
 </div>
 `;
@@ -13,7 +13,7 @@ exports[`View Should set the tag to be aside 1`] = `
 <div>
   <aside
     class=""
-    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0;"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0;"
   />
 </div>
 `;
@@ -22,7 +22,7 @@ exports[`View Should set the tag to be div 1`] = `
 <div>
   <div
     class=""
-    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0;"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0;"
   />
 </div>
 `;
@@ -31,7 +31,7 @@ exports[`View Should set the tag to be main 1`] = `
 <div>
   <main
     class=""
-    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0;"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0;"
   />
 </div>
 `;
@@ -40,7 +40,7 @@ exports[`View Should set the tag to be nav 1`] = `
 <div>
   <nav
     class=""
-    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0;"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0;"
   />
 </div>
 `;
@@ -49,7 +49,7 @@ exports[`View Should set the tag to be section 1`] = `
 <div>
   <section
     class=""
-    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0;"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0;"
   />
 </div>
 `;

--- a/packages/wonder-blocks-core/src/components/text.tsx
+++ b/packages/wonder-blocks-core/src/components/text.tsx
@@ -23,8 +23,8 @@ const styles = StyleSheet.create({
     header: {
         // User agent stylesheets add vertical margins to header tags by
         // default. We prefer to be more deliberate in our spacing instead.
-        marginTop: 0,
-        marginBottom: 0,
+        marginBlockStart: 0,
+        marginBlockEnd: 0,
     },
 });
 

--- a/packages/wonder-blocks-core/src/components/view.tsx
+++ b/packages/wonder-blocks-core/src/components/view.tsx
@@ -21,8 +21,8 @@ const styles = StyleSheet.create({
         position: "relative",
         zIndex: 0,
         // fix flexbox bugs
-        minHeight: 0,
-        minWidth: 0,
+        minBlockSize: 0,
+        minInlineSize: 0,
     },
 });
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1134,7 +1134,7 @@ describe("SingleSelect", () => {
                 "dropdown-core-container",
             );
             expect(dropdownMenuWrapper).toHaveStyle(
-                "max-height: var(--popper-max-height)",
+                "max-block-size: var(--popper-max-height)",
             );
         });
 
@@ -1169,7 +1169,7 @@ describe("SingleSelect", () => {
             );
             // Max allowed height
             expect(dropdownMenuWrapper).toHaveStyle(
-                "max-height: var(--popper-max-height)",
+                "max-block-size: var(--popper-max-height)",
             );
         });
 

--- a/packages/wonder-blocks-dropdown/src/components/action-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-item.tsx
@@ -213,7 +213,7 @@ export default class ActionItem extends React.Component<ActionProps> {
 
 const styles = StyleSheet.create({
     wrapper: {
-        minHeight: DROPDOWN_ITEM_HEIGHT,
+        minBlockSize: DROPDOWN_ITEM_HEIGHT,
         // This removes the 300ms click delay on mobile browsers by indicating
         // that "double-tap to zoom" shouldn't be used on this element.
         touchAction: "manipulation",
@@ -239,7 +239,7 @@ const styles = StyleSheet.create({
         },
     },
     shared: {
-        minHeight: DROPDOWN_ITEM_HEIGHT,
+        minBlockSize: DROPDOWN_ITEM_HEIGHT,
         // Make sure that the item is always at least as tall as 40px.
         paddingBlock: theme.item.layout.padding.block,
     },

--- a/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/action-menu.tsx
@@ -320,7 +320,7 @@ const styles = StyleSheet.create({
     },
     // This is to adjust the space between the menu and the opener.
     menuTopSpace: {
-        top: `calc(-1 * ${sizing.size_040})`,
+        insetBlockStart: `calc(-1 * ${sizing.size_040})`,
     },
 });
 

--- a/packages/wonder-blocks-dropdown/src/components/check.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/check.tsx
@@ -43,8 +43,8 @@ const styles = StyleSheet.create({
         alignSelf: "center",
         height: sizing.size_160,
         // Semantically, this are the constants for a small-sized icon
-        minHeight: sizing.size_160,
-        minWidth: sizing.size_160,
+        minBlockSize: sizing.size_160,
+        minInlineSize: sizing.size_160,
     },
 
     hide: {

--- a/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/checkbox.tsx
@@ -78,8 +78,8 @@ const styles = StyleSheet.create({
     checkbox: {
         alignSelf: "center",
         // Semantically, this are the constants for a small-sized icon
-        minHeight: sizing.size_160,
-        minWidth: sizing.size_160,
+        minBlockSize: sizing.size_160,
+        minInlineSize: sizing.size_160,
         height: sizing.size_160,
         background: checkboxTokens.color.default.background,
         // TODO(WB-1864): Use the correct token once TB is updated.
@@ -104,7 +104,7 @@ const styles = StyleSheet.create({
     // of place. Move it back.
     disabledCheckFormatting: {
         position: "absolute",
-        top: -1,
-        left: -1,
+        insetBlockStart: -1,
+        insetInlineStart: -1,
     },
 });

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -688,7 +688,7 @@ export default function Combobox({
                                         // The listbox width is at least the
                                         // width of the combobox.
                                         {
-                                            minWidth:
+                                            minInlineSize:
                                                 rootNodeRef?.current
                                                     ?.offsetWidth,
                                         },
@@ -716,7 +716,7 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         alignItems: "center",
         width: "100%",
-        maxWidth: "100%",
+        maxInlineSize: "100%",
         flexWrap: "wrap",
         // The following styles are to emulate the input styles
         background: semanticColor.core.background.base.default,
@@ -746,7 +746,7 @@ const styles = StyleSheet.create({
         border: "none",
         outline: "none",
         padding: 0,
-        minWidth: sizing.size_040,
+        minInlineSize: sizing.size_040,
         width: "auto",
         display: "inline-grid",
         gridArea: "1 / 2",
@@ -766,7 +766,7 @@ const styles = StyleSheet.create({
         // We use a custom property to set the max height of the dropdown.
         // This comes from the maxHeight custom modifier.
         // @see ../util/popper-max-height-modifier.ts
-        maxHeight: "var(--popper-max-height)",
+        maxBlockSize: "var(--popper-max-height)",
         overflowY: "auto",
     },
     hidden: {

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -669,7 +669,7 @@ export default function Combobox({
                                             // The listbox width is at least the
                                             // width of the combobox.
                                             {
-                                                minWidth:
+                                                minInlineSize:
                                                     rootNodeRef?.current
                                                         ?.offsetWidth,
                                             },

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -1114,7 +1114,7 @@ const styles = StyleSheet.create({
     searchInputStyle: {
         margin: sizing.size_080,
         marginBlockStart: sizing.size_040,
-        // Set `minHeight` to "auto" to stop the search field from having
+        // Set `minBlockSize` to "auto" to stop the search field from having
         // a height of 0 and being cut off.
         minBlockSize: "auto",
         position: "sticky",

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -1016,7 +1016,7 @@ class DropdownCore extends React.Component<Props, State> {
                     style={[
                         styles.listboxOrMenu,
                         {
-                            minWidth: minDropdownWidth,
+                            minInlineSize: minDropdownWidth,
                         },
                     ]}
                     // Only the `listbox` role supports aria-invalid and aria-required because
@@ -1080,7 +1080,7 @@ class DropdownCore extends React.Component<Props, State> {
 const styles = StyleSheet.create({
     menuWrapper: {
         width: "fit-content",
-        maxWidth: "100%",
+        maxInlineSize: "100%",
     },
 
     dropdown: {
@@ -1093,7 +1093,7 @@ const styles = StyleSheet.create({
         // We use a custom property to set the max height of the dropdown.
         // This comes from the maxHeight custom modifier.
         // @see ../util/popper-max-height-modifier.ts
-        maxHeight: "var(--popper-max-height)",
+        maxBlockSize: "var(--popper-max-height)",
     },
 
     listboxOrMenu: {
@@ -1116,7 +1116,7 @@ const styles = StyleSheet.create({
         marginBlockStart: sizing.size_040,
         // Set `minHeight` to "auto" to stop the search field from having
         // a height of 0 and being cut off.
-        minHeight: "auto",
+        minBlockSize: "auto",
         position: "sticky",
     },
 

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-popper.tsx
@@ -99,7 +99,7 @@ const DropdownPopper = function ({
                 return (
                     <div
                         ref={ref}
-                        style={{...style, maxWidth: "100%"}}
+                        style={{...style, maxInlineSize: "100%"}}
                         data-testid="dropdown-popper"
                         data-placement={placement}
                     >

--- a/packages/wonder-blocks-dropdown/src/components/option-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/option-item.tsx
@@ -292,7 +292,7 @@ const styles = StyleSheet.create({
         paddingInlineEnd: theme.item.layout.padding.inlineEnd,
         whiteSpace: "nowrap",
         // Make sure that the item is always at least as tall as 40px.
-        minHeight: sizing.size_400,
+        minBlockSize: sizing.size_400,
 
         /**
          * States

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -252,7 +252,7 @@ const styles = StyleSheet.create({
     },
 
     caret: {
-        minWidth: sizing.size_160,
+        minInlineSize: sizing.size_160,
     },
     /**
      * Theming

--- a/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/separator-item.tsx
@@ -40,9 +40,9 @@ export default class SeparatorItem extends React.Component<{
 
 const styles = StyleSheet.create({
     separator: {
-        borderTop: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
+        borderBlockStart: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
         height: 1,
-        minHeight: 1,
+        minBlockSize: 1,
         marginBlock: sizing.size_040,
     },
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
@@ -417,7 +417,7 @@ describe("LabeledTextField", () => {
 
         // Assert
         const fieldHeading = container.childNodes[0];
-        expect(fieldHeading).toHaveStyle("min-width: 250px");
+        expect(fieldHeading).toHaveStyle("min-inline-size: 250px");
     });
 
     it("testId prop is passed to textfield", async () => {

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
@@ -400,7 +400,7 @@ describe("LabeledTextField", () => {
         // Arrange
         const styles = StyleSheet.create({
             style1: {
-                minWidth: 250,
+                minInlineSize: 250,
                 background: "blue",
             },
         });

--- a/packages/wonder-blocks-form/src/components/checkbox-core.tsx
+++ b/packages/wonder-blocks-form/src/components/checkbox-core.tsx
@@ -147,8 +147,8 @@ const sharedStyles = StyleSheet.create({
     default: {
         height: baseStyles.choice.sizing.size,
         width: baseStyles.choice.sizing.size,
-        minHeight: baseStyles.choice.sizing.size,
-        minWidth: baseStyles.choice.sizing.size,
+        minBlockSize: baseStyles.choice.sizing.size,
+        minInlineSize: baseStyles.choice.sizing.size,
         margin: 0,
         outline: "none",
         boxSizing: "border-box",

--- a/packages/wonder-blocks-form/src/components/radio-core.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-core.tsx
@@ -92,8 +92,8 @@ const sharedStyles = StyleSheet.create({
     default: {
         height: baseStyles.choice.sizing.size,
         width: baseStyles.choice.sizing.size,
-        minHeight: baseStyles.choice.sizing.size,
-        minWidth: baseStyles.choice.sizing.size,
+        minBlockSize: baseStyles.choice.sizing.size,
+        minInlineSize: baseStyles.choice.sizing.size,
         margin: 0,
         outline: "none",
         boxSizing: "border-box",

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -443,7 +443,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                         readOnly && styles.readOnly,
                         rows && {
                             // Set the min height to the height of the number of rows
-                            minHeight: getHeightForNumberOfRows(rows),
+                            minBlockSize: getHeightForNumberOfRows(rows),
                         },
                         autoResize && autoResizeStyles,
                         style,

--- a/packages/wonder-blocks-grid/src/util/styles.ts
+++ b/packages/wonder-blocks-grid/src/util/styles.ts
@@ -12,7 +12,8 @@ const styles: StyleDeclaration = StyleSheet.create({
 
     rowMaxWidth: {
         [WIDE_SCREEN]: {
-            margin: "0 auto",
+            marginBlock: "0",
+            marginInline: "auto",
         },
     },
 

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -340,7 +340,7 @@ const styles = StyleSheet.create({
     label: {
         color: semanticColor.core.foreground.neutral.strong,
         overflowWrap: "break-word",
-        minWidth: sizing.size_0, // This enables the wrapping behaviour
+        minInlineSize: sizing.size_0, // This enables the wrapping behaviour
     },
     contextLabel: {
         // Make the line height match the label so the context label is aligned
@@ -348,7 +348,7 @@ const styles = StyleSheet.create({
         lineHeight: font.body.lineHeight.medium,
         // At most, the context label will take up 30% of the width of the
         // LabeledField
-        maxWidth: "30%",
+        maxInlineSize: "30%",
         // This prevents the context label from shrinking to fit the label
         flexShrink: 0,
     },
@@ -384,7 +384,7 @@ const styles = StyleSheet.create({
         color: theme.helperText.color.default.foreground,
         fontSize: theme.helperText.font.size,
         lineHeight: theme.helperText.font.lineHeight,
-        minWidth: sizing.size_0, // This enables the wrapping behaviour on the helper message
+        minInlineSize: sizing.size_0, // This enables the wrapping behaviour on the helper message
         overflowWrap: "break-word",
     },
     disabledHelperText: {
@@ -394,7 +394,7 @@ const styles = StyleSheet.create({
         color: semanticColor.core.foreground.critical.default,
     },
     errorIcon: {
-        marginTop: sizing.size_010, // This vertically aligns the icon with the text
+        marginBlockStart: sizing.size_010, // This vertically aligns the icon with the text
     },
     errorMessage: {
         fontWeight: theme.error.font.weight,

--- a/packages/wonder-blocks-modal/src/components/drawer-backdrop.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-backdrop.tsx
@@ -196,8 +196,8 @@ const keyframes = {
 const styles = StyleSheet.create({
     drawerPositioner: {
         position: "fixed",
-        left: 0,
-        top: 0,
+        insetInlineStart: 0,
+        insetBlockStart: 0,
         width: "100%",
         height: "100%",
         display: "flex",

--- a/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
@@ -247,24 +247,24 @@ const getComponentStyles = ({
 
             // Override FlexibleDialog defaults for drawer usage
             height: "100%",
-            minHeight: "100vh",
+            minBlockSize: "100vh",
 
             // Use common widths for mininum/maximum
-            minWidth: breakpoint.width.xsMax,
-            maxWidth: breakpoint.width.smMax,
+            minInlineSize: breakpoint.width.xsMax,
+            maxInlineSize: breakpoint.width.smMax,
             width: "100%",
 
             // Unset minimums on smaller screens
             [breakpoint.mediaQuery.smOrSmaller]: {
-                minWidth: "unset",
-                maxWidth: "unset",
+                minInlineSize: "unset",
+                maxInlineSize: "unset",
             },
         },
         dialog: {
             // Override the minHeight and minWidth on View
             // And allow BlockEnd content to provide its own height
-            minHeight: alignment === "blockEnd" ? "unset" : "100vh",
-            minWidth: "unset",
+            minBlockSize: alignment === "blockEnd" ? "unset" : "100vh",
+            minInlineSize: "unset",
         },
         inlineStart: {
             // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
@@ -302,8 +302,8 @@ const getComponentStyles = ({
             animationTimingFunction: "linear",
             animationFillMode: "forwards",
             height: "auto",
-            minHeight: "unset",
-            maxWidth: "unset",
+            minBlockSize: "unset",
+            maxInlineSize: "unset",
 
             [breakpoint.mediaQuery.smOrSmaller]: {
                 height: "auto",

--- a/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
@@ -261,7 +261,7 @@ const getComponentStyles = ({
             },
         },
         dialog: {
-            // Override the minHeight and minWidth on View
+            // Override the minBlockSize and minInlineSize on View
             // And allow BlockEnd content to provide its own height
             minBlockSize: alignment === "blockEnd" ? "unset" : "100vh",
             minInlineSize: "unset",

--- a/packages/wonder-blocks-modal/src/components/flexible-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/flexible-dialog.tsx
@@ -194,8 +194,8 @@ const componentStyles = StyleSheet.create({
 
         // Default widths/heights for FlexibleDialog alone
         height: "auto",
-        maxHeight: "100vh",
-        maxWidth: 576,
+        maxBlockSize: "100vh",
+        maxInlineSize: 576,
         width: "93.75%",
     },
 });

--- a/packages/wonder-blocks-modal/src/components/flexible-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/flexible-panel.tsx
@@ -162,7 +162,7 @@ const componentStyles = StyleSheet.create({
         position: "absolute",
         // insetInlineEnd supports both RTL and LTR layouts
         insetInlineEnd: theme.closeButton.layout.gapRight,
-        top: theme.closeButton.layout.gapTop,
+        insetBlockStart: theme.closeButton.layout.gapTop,
         // This is to allow the button to be tab-ordered before the modal
         // content but still be above the header and content.
         zIndex: 1,

--- a/packages/wonder-blocks-modal/src/components/modal-backdrop.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-backdrop.tsx
@@ -170,8 +170,8 @@ export default ModalBackdrop;
 const styles = StyleSheet.create({
     modalPositioner: {
         position: "fixed",
-        left: 0,
-        top: 0,
+        insetInlineStart: 0,
+        insetBlockStart: 0,
 
         width: "100%",
         height: "100%",

--- a/packages/wonder-blocks-modal/src/components/modal-content.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-content.tsx
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
     wrapperSmallHeight: {
         [modalMediaQuery.smMinOrSmallerHeight as any]: {
             flex: "unset",
-            minHeight: "unset",
+            minBlockSize: "unset",
             overflow: "unset",
         },
     },
@@ -90,7 +90,7 @@ const styles = StyleSheet.create({
 
     content: {
         flex: 1,
-        minHeight: "100%",
+        minBlockSize: "100%",
         padding: theme.panel.layout.gap.default,
         boxSizing: "border-box",
         [modalMediaQuery.midOrSmaller as any]: {
@@ -102,7 +102,7 @@ const styles = StyleSheet.create({
     contentSmallHeight: {
         [modalMediaQuery.smMinOrSmallerHeight as any]: {
             flex: "unset",
-            minHeight: "unset",
+            minBlockSize: "unset",
             overflow: "unset",
         },
     },

--- a/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-dialog.tsx
@@ -151,20 +151,20 @@ const componentStyles = StyleSheet.create({
     above: {
         pointerEvents: "none",
         position: "absolute",
-        top: 0,
-        left: 0,
-        bottom: 0,
-        right: 0,
+        insetBlockStart: 0,
+        insetInlineStart: 0,
+        insetBlockEnd: 0,
+        insetInlineEnd: 0,
         zIndex: 1,
     },
 
     below: {
         pointerEvents: "none",
         position: "absolute",
-        top: 0,
-        left: 0,
-        bottom: 0,
-        right: 0,
+        insetBlockStart: 0,
+        insetInlineStart: 0,
+        insetBlockEnd: 0,
+        insetInlineEnd: 0,
         zIndex: -1,
     },
 });

--- a/packages/wonder-blocks-modal/src/components/modal-footer.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-footer.tsx
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
         boxSizing: "border-box",
         // ensure footer stays at the bottom of modal content with scrolling
         marginBlockStart: "auto",
-        minHeight: sizing.size_640,
+        minBlockSize: sizing.size_640,
         paddingInline: theme.footer.layout.padding.inline,
         paddingBlock: theme.footer.layout.padding.block,
 

--- a/packages/wonder-blocks-modal/src/components/modal-header.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-header.tsx
@@ -139,7 +139,7 @@ const styles = StyleSheet.create({
         boxShadow: `0px 1px 0px ${semanticColor.core.border.neutral.subtle}`,
         display: "flex",
         flexDirection: "column",
-        minHeight: 66,
+        minBlockSize: 66,
         paddingBlock: theme.header.layout.padding.block,
         paddingInline: theme.header.layout.padding.inline.default,
         position: "relative",
@@ -149,7 +149,7 @@ const styles = StyleSheet.create({
             paddingInline: theme.header.layout.padding.inline.small,
         },
         [modalMediaQuery.smMinOrSmallerHeight as any]: {
-            minHeight: "unset",
+            minBlockSize: "unset",
         },
     },
 

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -161,7 +161,7 @@ const styles = StyleSheet.create({
         position: "absolute",
         // insetInlineEnd supports both RTL and LTR layouts
         insetInlineEnd: theme.closeButton.layout.gapRight,
-        top: theme.closeButton.layout.gapTop,
+        insetBlockStart: theme.closeButton.layout.gapTop,
         // This is to allow the button to be tab-ordered before the modal
         // content but still be above the header and content.
         zIndex: 1,

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -244,13 +244,13 @@ const _generateStyles = (
                 ...sharedSwitchStyles,
             },
             slider: {
-                transform: theme.slider.transform.default,
+                insetInlineStart: theme.slider.transform.default,
             },
             icon: {
                 color: disabled
                     ? baseStyles.color.bg.icon.disabledOn
                     : baseStyles.color.bg.icon.on,
-                transform: theme.icon.transform.default,
+                insetInlineStart: theme.icon.transform.default,
             },
         };
     } else {

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -107,8 +107,8 @@ const sharedStyles = StyleSheet.create({
     } as any,
     slider: {
         position: "absolute",
-        top: theme.slider.position.top,
-        left: theme.slider.position.left,
+        insetBlockStart: theme.slider.position.top,
+        insetInlineStart: theme.slider.position.left,
         height: theme.slider.sizing.height,
         width: theme.slider.sizing.width,
         borderRadius: theme.root.border.radius.default,
@@ -117,8 +117,8 @@ const sharedStyles = StyleSheet.create({
     },
     icon: {
         position: "absolute",
-        top: theme.icon.position.top,
-        left: theme.icon.position.left,
+        insetBlockStart: theme.icon.position.top,
+        insetInlineStart: theme.icon.position.left,
         zIndex: 1,
         transition: theme.icon.transform.transition,
     },

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {CSSProperties, StyleSheet} from "aphrodite";
 
 import {AriaProps, View, addStyle} from "@khanacademy/wonder-blocks-core";
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {useId} from "react";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
@@ -113,14 +113,14 @@ const sharedStyles = StyleSheet.create({
         width: theme.slider.sizing.width,
         borderRadius: theme.root.border.radius.default,
         backgroundColor: baseStyles.color.bg.slider.on,
-        transition: theme.slider.transform.transition,
+        transition: "inset-inline-start 0.15s ease-in-out",
     },
     icon: {
         position: "absolute",
         insetBlockStart: theme.icon.position.top,
         insetInlineStart: theme.icon.position.left,
         zIndex: 1,
-        transition: theme.icon.transform.transition,
+        transition: "inset-inline-start 0.15s ease-in-out",
     },
 });
 
@@ -244,13 +244,17 @@ const _generateStyles = (
                 ...sharedSwitchStyles,
             },
             slider: {
-                insetInlineStart: theme.slider.transform.default,
+                // Positions the slider at the far end of the track:
+                // track width - slider width - edge offset
+                insetInlineStart: `calc(100% - ${sizing.size_200} - ${sizing.size_020})`,
             },
             icon: {
                 color: disabled
                     ? baseStyles.color.bg.icon.disabledOn
                     : baseStyles.color.bg.icon.on,
-                insetInlineStart: theme.icon.transform.default,
+                // Positions the icon at the far end of the track:
+                // track width - icon width (small = size_160) - edge offset
+                insetInlineStart: `calc(100% - ${sizing.size_160} - ${sizing.size_040})`,
             },
         };
     } else {

--- a/packages/wonder-blocks-switch/src/theme/default.ts
+++ b/packages/wonder-blocks-switch/src/theme/default.ts
@@ -23,19 +23,11 @@ export default {
             top: sizing.size_020,
             left: sizing.size_020,
         },
-        transform: {
-            default: `calc(100% - ${sizing.size_200} - ${sizing.size_020})`,
-            transition: "inset-inline-start 0.15s ease-in-out",
-        },
     },
     icon: {
         position: {
             top: sizing.size_040,
             left: sizing.size_040,
-        },
-        transform: {
-            default: `calc(100% - ${sizing.size_160} - ${sizing.size_040})`,
-            transition: "inset-inline-start 0.15s ease-in-out",
         },
     },
 };

--- a/packages/wonder-blocks-switch/src/theme/default.ts
+++ b/packages/wonder-blocks-switch/src/theme/default.ts
@@ -24,8 +24,8 @@ export default {
             left: sizing.size_020,
         },
         transform: {
-            default: `translateX(${sizing.size_160})`,
-            transition: "transform 0.15s ease-in-out",
+            default: `calc(100% - ${sizing.size_200} - ${sizing.size_020})`,
+            transition: "inset-inline-start 0.15s ease-in-out",
         },
     },
     icon: {
@@ -34,8 +34,8 @@ export default {
             left: sizing.size_040,
         },
         transform: {
-            default: `translateX(${sizing.size_160})`,
-            transition: "transform 0.15s ease-in-out",
+            default: `calc(100% - ${sizing.size_160} - ${sizing.size_040})`,
+            transition: "inset-inline-start 0.15s ease-in-out",
         },
     },
 };

--- a/packages/wonder-blocks-switch/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-switch/src/theme/thunderblocks.ts
@@ -13,14 +13,4 @@ export default mergeTheme(defaultTheme, {
             width: sizing.size_440,
         },
     },
-    slider: {
-        transform: {
-            default: `translateX(${sizing.size_200})`,
-        },
-    },
-    icon: {
-        transform: {
-            default: `translateX(${sizing.size_200})`,
-        },
-    },
 });

--- a/packages/wonder-blocks-tabs/src/components/navigation-tabs-dropdown.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tabs-dropdown.tsx
@@ -265,7 +265,7 @@ const styles = StyleSheet.create({
     },
     labelStyle: {
         flexGrow: 1,
-        maxWidth: "100%",
+        maxInlineSize: "100%",
         textAlign: "start",
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/responsive-navigation-tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/responsive-navigation-tabs.tsx
@@ -285,6 +285,6 @@ const styles = StyleSheet.create({
     },
     container: {
         width: "100%",
-        minHeight: "auto", // override setting the min height: 0 style
+        minBlockSize: "auto", // override setting the min height: 0 style
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/responsive-tabs.tsx
+++ b/packages/wonder-blocks-tabs/src/components/responsive-tabs.tsx
@@ -213,6 +213,6 @@ const styles = StyleSheet.create({
     },
     container: {
         width: "100%",
-        minHeight: "auto", // override setting the min height: 0 style
+        minBlockSize: "auto", // override setting the min height: 0 style
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -130,9 +130,9 @@ export const styles = StyleSheet.create({
         ":after": {
             content: "''",
             position: "absolute",
-            left: 0,
-            right: 0,
-            bottom: `calc(${bottomSpacing} * -1)`,
+            insetInlineStart: 0,
+            insetInlineEnd: 0,
+            insetBlockEnd: `calc(${bottomSpacing} * -1)`,
         },
         // Only apply hover styles to tabs that are not selected
         [":hover:not([aria-selected='true'])" as any]: {

--- a/packages/wonder-blocks-tabs/src/components/tablist.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tablist.tsx
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
     tablist: {
         display: "flex",
         gap: sizing.size_240,
-        borderBottom: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
+        borderBlockEnd: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
         // Add horizontal padding for focus outline of first/last elements
         paddingInline: sizing.size_040,
     },

--- a/packages/wonder-blocks-tabs/src/components/tabs-dropdown.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tabs-dropdown.tsx
@@ -257,7 +257,7 @@ const styles = StyleSheet.create({
     },
     labelStyle: {
         flexGrow: 1,
-        maxWidth: "100%",
+        maxInlineSize: "100%",
         textAlign: "start",
     },
 });

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -131,7 +131,7 @@ const sharedStyles = StyleSheet.create({
         flex: 1,
         display: "grid",
         alignItems: "center",
-        minHeight: 66,
+        minBlockSize: 66,
         paddingInline: sizing.size_160,
         width: "100%",
     },
@@ -146,7 +146,7 @@ const sharedStyles = StyleSheet.create({
         gridTemplateColumns: "auto auto 1fr",
     },
     small: {
-        minHeight: 50,
+        minBlockSize: 50,
     },
     // TODO(WB-1852): Remove light variant.
     dark: {
@@ -172,7 +172,7 @@ const sharedStyles = StyleSheet.create({
         padding: sizing.size_120,
         textAlign: "center",
         justifySelf: "center",
-        maxWidth: "100%",
+        maxInlineSize: "100%",
     },
     spacer: {
         minInlineSize: sizing.size_120,

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
@@ -50,7 +50,7 @@ describe("TooltipTail", () => {
   <div
     class=""
     data-placement="top"
-    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
   >
     <svg
       aria-hidden="true"
@@ -120,7 +120,7 @@ describe("TooltipTail", () => {
                   <div
                     class=""
                     data-placement="top"
-                    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
+                    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
                   >
                     <div
                       aria-hidden="true"

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
@@ -125,7 +125,7 @@ describe("TooltipTail", () => {
                     <div
                       aria-hidden="true"
                       class=""
-                      style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-height: 0; min-width: 0; inline-size: 12px; flex-basis: 12px; flex-shrink: 0;"
+                      style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0; inline-size: 12px; flex-basis: 12px; flex-shrink: 0;"
                     />
                   </div>
                 </div>

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -127,7 +127,7 @@ const styles = StyleSheet.create({
     },
 
     content: {
-        maxWidth: 472,
+        maxInlineSize: 472,
         borderRadius: border.radius.radius_040,
         border: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         backgroundColor: semanticColor.core.background.base.default,


### PR DESCRIPTION
## Summary

- Enables `@khanacademy/wonder-blocks/require-logical-properties-for-rtl` in the plugin's `recommended` config
- Runs `eslint --fix` to auto-fix all existing violations across 

Where are we in our RTL update:
| Step | Body of work | Repo | This PR? | Tracking |
  | --- | --- | --- | --- | --- |
  | 1 | Add `require-logical-properties-for-rtl` rule (TS port of frontend's JS rule), tests, docs, demo, Storybook story, changeset. Ship in plugin but **not enabled in any config**. | wonder-blocks | ✅ 🚢   https://github.com/Khan/wonder-blocks/pull/3040 | [CLASS-14218](https://khanacademy.atlassian.net/jira/software/c/projects/CLASS/boards/35?assignee=624f84e6f3824d006a5d78bb&selectedIssue=CLASS-14218) |
  | 2 | Enable rule in `recommended` config. Run `eslint --fix` against WB. Verify Chromatic. | wonder-blocks | **Here**  https://github.com/Khan/wonder-blocks/pull/3042 | [CLASS-14218](https://khanacademy.atlassian.net/jira/software/c/projects/CLASS/boards/35?assignee=624f84e6f3824d006a5d78bb&selectedIssue=CLASS-14218) |
  | 3 | In frontend: bump plugin, switch `.eslintrc.js` to WB rule, delete internal copy, rename `eslint-disable` comments. No new violations expected. | frontend | ❌ Follow-up | [CLASS-14239](https://khanacademy.atlassian.net/browse/CLASS-14239) |
  | 4 | Extend rule coverage and fix resulting violations in frontend:<ul><li>3- and 4-value `padding`/`margin` shorthand (`padding: "10px 20px 30px"`) — only 2-value is currently handled</li><li>`height` / `width` → `blockSize` / `inlineSize`</li><li>Warn on `translateX` / `transformOrigin` directional use (no auto-fix; manual review)</li><li>Remove unused warning rules</li></ul> | wonder-blocks → frontend | ❌ Future | [CLASS-14240](https://khanacademy.atlassian.net/browse/CLASS-14240) |
  | 5 | Enable in perseus as one full sweep — picks up the complete final rule with no follow-up passes needed. | perseus | ❌ Future | [CLASS-14252](https://khanacademy.atlassian.net/browse/CLASS-14252) |

## Jira

CLASS-14218

Issue: CLASS-14218

## Test plan

- [ ] `pnpm lint` — passes (0 violations)
- [ ] `pnpm typecheck` — passes
- [ ] `pnpm jest packages/eslint-plugin-wonder-blocks` — all 4 suites pass


[CLASS-14218]: https://khanacademy.atlassian.net/browse/CLASS-14218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLASS-14218]: https://khanacademy.atlassian.net/browse/CLASS-14218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLASS-14239]: https://khanacademy.atlassian.net/browse/CLASS-14239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ