### PR TITLE
syl-dark tokens: Update `core.background.neutral.default` to `gray_30`

### DIFF
--- a/.changeset/sixty-drinks-sniff.md
+++ b/.changeset/sixty-drinks-sniff.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+syl-dark theme: Update `core.background.neutral.default` to `gray_30`

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -56,7 +56,7 @@ const core = {
         },
         neutral: {
             subtle: color.gray_10,
-            default: color.gray_20,
+            default: color.gray_30,
             strong: color.gray_80,
         },
         critical: {


### PR DESCRIPTION
## Summary:

Update syl-dark token value for `core.background.neutral.default` from `gray_20` to `gray_30` so that it has high enough contrast when used with `core.foreground.knockout.default` 


Issue: WB-2166

## Test plan:

Review that updated token matches Figma. 

Review Chromatic snapshots