### PR TITLE
SYL Dark - Tabs components

### DIFF
--- a/.changeset/poor-months-grow.md
+++ b/.changeset/poor-months-grow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tabs": patch
+---
+
+Tabs components: Update token usage to align with design

--- a/__docs__/wonder-blocks-tabs/navigation-tab-item-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tab-item-testing-snapshots.stories.tsx
@@ -18,7 +18,7 @@ import {
 } from "../components/text-for-testing";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {ScenariosLayout} from "../components/scenarios-layout";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 const StyledA = addStyle("a");
 const generateRows = (rtl: boolean = false) => {
@@ -153,7 +153,7 @@ const meta = {
     component: NavigationTabItem,
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     tags: ["!autodocs", "!manifest"],

--- a/__docs__/wonder-blocks-tabs/navigation-tabs-dropdown-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs-dropdown-testing-snapshots.stories.tsx
@@ -7,7 +7,7 @@ import {
     longTextWithNoWordBreak,
 } from "../components/text-for-testing";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {allModes, themeModes} from "../../.storybook/modes";
+import {allModes, allThemeModes} from "../../.storybook/modes";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
@@ -17,7 +17,7 @@ export default {
     tags: ["!autodocs", "!manifest"],
     parameters: {
         chromatic: {
-            modes: {...themeModes, small: allModes.small},
+            modes: {...allThemeModes, small: allModes.small},
         },
     },
 } as Meta<typeof NavigationTabsDropdown>;

--- a/__docs__/wonder-blocks-tabs/navigation-tabs-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/navigation-tabs-testing-snapshots.stories.tsx
@@ -21,7 +21,7 @@ import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {generateChildren} from "./navigation-tabs-utils";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 const StyledA = addStyle("a");
 const generateRows = (rtl: boolean = false) => [
@@ -186,7 +186,7 @@ const meta = {
     component: NavigationTabs,
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     tags: ["!autodocs", "!manifest"],

--- a/__docs__/wonder-blocks-tabs/responsive-navigation-tabs-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/responsive-navigation-tabs-testing-snapshots.stories.tsx
@@ -4,7 +4,7 @@ import {ResponsiveNavigationTabs} from "@khanacademy/wonder-blocks-tabs";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {longText} from "../components/text-for-testing";
-import {allModes, themeModes} from "../../.storybook/modes";
+import {allModes, allThemeModes} from "../../.storybook/modes";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
@@ -15,7 +15,7 @@ export default {
     tags: ["!autodocs", "!manifest"],
     parameters: {
         chromatic: {
-            modes: {...themeModes, small: allModes.small},
+            modes: {...allThemeModes, small: allModes.small},
         },
         a11y: {
             config: {

--- a/__docs__/wonder-blocks-tabs/responsive-tabs-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/responsive-tabs-testing-snapshots.stories.tsx
@@ -4,7 +4,7 @@ import {ResponsiveTabs} from "@khanacademy/wonder-blocks-tabs";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {longText} from "../components/text-for-testing";
-import {allModes, themeModes} from "../../.storybook/modes";
+import {allModes, allThemeModes} from "../../.storybook/modes";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
@@ -15,7 +15,7 @@ export default {
     tags: ["!autodocs", "!manifest"],
     parameters: {
         chromatic: {
-            modes: {...themeModes, small: allModes.small},
+            modes: {...allThemeModes, small: allModes.small},
         },
         a11y: {
             config: {

--- a/__docs__/wonder-blocks-tabs/tab-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tab-testing-snapshots.stories.tsx
@@ -8,7 +8,7 @@ import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {rtlText} from "../components/text-for-testing";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 const StyledDiv = addStyle("div");
 
@@ -100,7 +100,7 @@ const meta = {
     args: {},
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     tags: ["!autodocs", "!manifest"],

--- a/__docs__/wonder-blocks-tabs/tabs-dropdown-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs-dropdown-testing-snapshots.stories.tsx
@@ -7,7 +7,7 @@ import {
     longTextWithNoWordBreak,
 } from "../components/text-for-testing";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {allModes, themeModes} from "../../.storybook/modes";
+import {allModes, allThemeModes} from "../../.storybook/modes";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
@@ -17,7 +17,7 @@ export default {
     tags: ["!autodocs", "!manifest"],
     parameters: {
         chromatic: {
-            modes: {...themeModes, small: allModes.small},
+            modes: {...allThemeModes, small: allModes.small},
         },
     },
 } as Meta<typeof TabsDropdown>;

--- a/__docs__/wonder-blocks-tabs/tabs-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs-testing-snapshots.stories.tsx
@@ -14,7 +14,7 @@ import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {ControlledTabs, generateTabs} from "./tabs-utils";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 const StyledDiv = addStyle("div");
 
@@ -187,7 +187,7 @@ const meta = {
     },
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
             delay: 500, // Delay to allow focus to settle
         },
     },

--- a/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
@@ -111,10 +111,12 @@ const styles = StyleSheet.create({
         listStyle: "none",
         display: "inline-flex",
         [":has(a:hover)" as any]: {
-            boxShadow: `inset 0 calc(${sizing.size_020}*-1) 0 0 ${semanticColor.core.border.instructive.default}`,
+            // Using background token to match underline styling in Figma
+            boxShadow: `inset 0 calc(${sizing.size_020}*-1) 0 0 ${semanticColor.core.background.instructive.default}`,
         },
         [":has(a:active)" as any]: {
-            boxShadow: `inset 0 calc(${sizing.size_060}*-1) 0 0 ${semanticColor.core.border.instructive.strong}`,
+            // Using background token to match underline styling in Figma
+            boxShadow: `inset 0 calc(${sizing.size_060}*-1) 0 0 ${semanticColor.core.background.instructive.default}`,
         },
         paddingBlockStart: sizing.size_080,
         paddingBlockEnd: sizing.size_180,
@@ -136,10 +138,10 @@ const styles = StyleSheet.create({
         },
     },
     currentLink: {
-        color: semanticColor.link.rest,
+        color: semanticColor.core.foreground.instructive.default,
         [":active:not([aria-disabled=true])" as any]: {
             // Make sure the current link doesn't change color when pressed
-            color: semanticColor.link.rest,
+            color: semanticColor.core.foreground.instructive.default,
         },
     },
     link: {
@@ -156,7 +158,7 @@ const styles = StyleSheet.create({
             textDecoration: "none",
             border: "none",
             outline: "none",
-            color: semanticColor.link.hover,
+            color: semanticColor.core.foreground.instructive.default,
             backgroundColor: "transparent",
         },
         // NOTE: We use :not[aria-disabled] to avoid the hover styles to be
@@ -165,10 +167,9 @@ const styles = StyleSheet.create({
             textDecoration: "none",
             border: "none",
             outline: "none",
-            color: semanticColor.link.press,
+            color: semanticColor.core.foreground.instructive.default,
         },
         ":focus-visible": {
-            color: semanticColor.link.rest,
             border: "none",
             outline: "none",
             boxShadow: `0 0 0 ${sizing.size_020} ${semanticColor.focus.inner}, 0 0 0 ${sizing.size_040} ${semanticColor.focus.outer}`,

--- a/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
@@ -5,7 +5,6 @@ import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography"
 import {
     border,
     breakpoint,
-    font,
     semanticColor,
     sizing,
 } from "@khanacademy/wonder-blocks-tokens";
@@ -140,7 +139,6 @@ const styles = StyleSheet.create({
     },
     currentLink: {
         color: semanticColor.core.foreground.instructive.default,
-        fontWeight: font.weight.bold,
         [":active:not([aria-disabled=true])" as any]: {
             // Make sure the current link doesn't change color when pressed
             color: semanticColor.core.foreground.instructive.default,

--- a/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
@@ -5,6 +5,7 @@ import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography"
 import {
     border,
     breakpoint,
+    font,
     semanticColor,
     sizing,
 } from "@khanacademy/wonder-blocks-tokens";
@@ -139,6 +140,7 @@ const styles = StyleSheet.create({
     },
     currentLink: {
         color: semanticColor.core.foreground.instructive.default,
+        fontWeight: font.weight.bold,
         [":active:not([aria-disabled=true])" as any]: {
             // Make sure the current link doesn't change color when pressed
             color: semanticColor.core.foreground.instructive.default,

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -136,22 +136,24 @@ export const styles = StyleSheet.create({
         },
         // Only apply hover styles to tabs that are not selected
         [":hover:not([aria-selected='true'])" as any]: {
-            color: semanticColor.link.hover,
+            color: semanticColor.core.foreground.instructive.default,
             [":after" as any]: {
                 height: border.width.thin,
-                backgroundColor: semanticColor.link.hover,
+                backgroundColor:
+                    semanticColor.core.background.instructive.default,
             },
         },
         // Only apply active styles to tabs that are not selected
         [":active:not([aria-selected='true'])" as any]: {
-            color: semanticColor.link.press,
+            color: semanticColor.core.foreground.instructive.default,
             [":after" as any]: {
                 height: border.width.thick,
-                backgroundColor: semanticColor.link.press,
+                backgroundColor:
+                    semanticColor.core.background.instructive.default,
             },
         },
     },
     selectedTab: {
-        color: semanticColor.link.rest,
+        color: semanticColor.core.foreground.instructive.default,
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -6,7 +6,12 @@ import {
 } from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    font,
+    semanticColor,
+    sizing,
+} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 
@@ -155,5 +160,6 @@ export const styles = StyleSheet.create({
     },
     selectedTab: {
         color: semanticColor.core.foreground.instructive.default,
+        fontWeight: font.weight.bold,
     },
 });

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -6,12 +6,7 @@ import {
 } from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
-import {
-    border,
-    font,
-    semanticColor,
-    sizing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {styles as typographyStyles} from "@khanacademy/wonder-blocks-typography";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 
@@ -160,6 +155,5 @@ export const styles = StyleSheet.create({
     },
     selectedTab: {
         color: semanticColor.core.foreground.instructive.default,
-        fontWeight: font.weight.bold,
     },
 });

--- a/packages/wonder-blocks-tabs/src/hooks/use-tab-indicator.ts
+++ b/packages/wonder-blocks-tabs/src/hooks/use-tab-indicator.ts
@@ -169,8 +169,7 @@ const styles = {
         bottom: 0,
         left: 0,
         height: border.width.thick,
-        backgroundColor:
-            semanticColor.action.secondary.progressive.default.foreground,
+        backgroundColor: semanticColor.core.background.instructive.default,
     },
     underlineTransition: {
         transition: "transform 0.3s ease, width 0.3s ease",


### PR DESCRIPTION
## Summary:

Reviewing the Tabs components in SYL Dark to confirm it looks as expected, matches the design specs, and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Changes specific to the component:
- Enable snapshots for syl-dark
- Update semantic color token usage to match Figma specs (note: we now use semantic color core tokens directly instead of the link tokens)

Issue: WB-2166

Design: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=2156-54&m=dev

## Test plan:

Review stories in the tabs package and confirm things look as expected across themes

Review visual changes in Chromatic