### PR TITLE
SYL Dark - Buttons

### DIFF
--- a/.changeset/fresh-dolls-roll.md
+++ b/.changeset/fresh-dolls-roll.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-icon-button": patch
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+ActivityIconButton: Add component theme token for the label to accommodate syl-dark

--- a/.changeset/proud-readers-hunt.md
+++ b/.changeset/proud-readers-hunt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add `core.shadow.chonky.disabled.subtle/default` tokens and use for `chonky.disabled.*` tokens. Update semantic color core tokens in `syl-dark` related to chonky tokens and border neutral tokens

--- a/__docs__/catalog/components-config.tsx
+++ b/__docs__/catalog/components-config.tsx
@@ -224,7 +224,7 @@ export const buttonComponents = [
         variantProps: [
             {
                 propName: "size",
-                options: ["small", "medium", "large"],
+                options: ["xsmall", "small", "medium", "large"],
             },
             {
                 propName: "kind",
@@ -266,6 +266,10 @@ export const buttonComponents = [
         name: "ActivityButton",
         Component: ActivityButton,
         variantProps: [
+            {
+                propName: "actionType",
+                options: ["progressive", "neutral"],
+            },
             {
                 propName: "kind",
                 options: ["primary", "secondary", "tertiary"],

--- a/__docs__/wonder-blocks-button/activity-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-button/activity-button-testing-snapshots.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg";
 import {ActivityButton} from "@khanacademy/wonder-blocks-button";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {longTextWithNoWordBreak} from "../components/text-for-testing";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -27,7 +27,7 @@ export default {
     },
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 } as Meta;

--- a/__docs__/wonder-blocks-button/button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-button/button-testing-snapshots.stories.tsx
@@ -17,11 +17,6 @@ import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
  */
 export default {
     title: "Packages / Button / Testing / Snapshots / Button",
-    parameters: {
-        chromatic: {
-            modes: allThemeModes,
-        },
-    },
     tags: ["!autodocs", "!manifest"],
     args: {
         children: "Button",
@@ -92,6 +87,9 @@ export const StateSheetStory: StoryComponentType = {
     },
     parameters: {
         pseudo: defaultPseudoStates,
+        chromatic: {
+            modes: allThemeModes,
+        },
     },
 };
 
@@ -102,6 +100,7 @@ const sizes = [
 ];
 
 export const Sizes: StoryComponentType = {
+    // No need to test this in all themes since this is coered by the statesheet
     render: (args) => {
         return (
             <AllVariants rows={sizes} columns={kinds} title="Size / Kind">

--- a/__docs__/wonder-blocks-button/button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-button/button-testing-snapshots.stories.tsx
@@ -3,7 +3,7 @@ import {action} from "storybook/actions";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -19,7 +19,7 @@ export default {
     title: "Packages / Button / Testing / Snapshots / Button",
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     tags: ["!autodocs", "!manifest"],

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -28,7 +28,6 @@ import ComponentInfo from "../components/component-info";
 import ButtonArgTypes from "./button.argtypes";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {allThemeModes} from "../../.storybook/modes";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
@@ -421,11 +420,6 @@ const IconExample = () => (
 export const WithIcon: StoryComponentType = {
     name: "Icon",
     render: () => <IconExample />,
-    parameters: {
-        chromatic: {
-            modes: allThemeModes,
-        },
-    },
 };
 
 /**

--- a/__docs__/wonder-blocks-button/button.stories.tsx
+++ b/__docs__/wonder-blocks-button/button.stories.tsx
@@ -28,7 +28,7 @@ import ComponentInfo from "../components/component-info";
 import ButtonArgTypes from "./button.argtypes";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 
@@ -423,7 +423,7 @@ export const WithIcon: StoryComponentType = {
     render: () => <IconExample />,
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 };

--- a/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/activity-icon-button-testing-snapshots.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg";
 import {ActivityIconButton} from "@khanacademy/wonder-blocks-icon-button";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {longTextWithNoWordBreak} from "../components/text-for-testing";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -30,7 +30,7 @@ export default {
     },
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 } as Meta;

--- a/__docs__/wonder-blocks-icon-button/conversation-icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/conversation-icon-button-testing-snapshots.stories.tsx
@@ -5,7 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 import paperPlaneIcon from "@phosphor-icons/core/fill/paper-plane-tilt-fill.svg";
 import {ConversationIconButton} from "@khanacademy/wonder-blocks-icon-button";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {Icon} from "@khanacademy/wonder-blocks-icon";
 
@@ -25,7 +25,7 @@ export default {
     },
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 } as Meta;

--- a/__docs__/wonder-blocks-icon-button/icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button-testing-snapshots.stories.tsx
@@ -8,7 +8,7 @@ import {AllVariants} from "../components/all-variants";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {Icon} from "@khanacademy/wonder-blocks-icon";
 
@@ -28,7 +28,7 @@ export default {
     },
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 } as Meta;

--- a/__docs__/wonder-blocks-icon-button/icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/icon-button-testing-snapshots.stories.tsx
@@ -26,11 +26,6 @@ export default {
         actionType: "progressive",
         size: "medium",
     },
-    parameters: {
-        chromatic: {
-            modes: allThemeModes,
-        },
-    },
 } as Meta;
 
 type StoryComponentType = StoryObj<typeof IconButton>;
@@ -74,6 +69,9 @@ export const StateSheetStory: StoryComponentType = {
     },
     parameters: {
         pseudo: defaultPseudoStates,
+        chromatic: {
+            modes: allThemeModes,
+        },
     },
 };
 

--- a/__docs__/wonder-blocks-icon-button/node-icon-button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon-button/node-icon-button-testing-snapshots.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {NodeIconButton} from "@khanacademy/wonder-blocks-icon-button";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 import {IconMappings} from "../wonder-blocks-icon/phosphor-icon.argtypes";
 import assignmentPracticeIcon from "./images/assignment-practice.svg";
@@ -24,7 +24,7 @@ export default {
     },
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 } as Meta<typeof NodeIconButton>;

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -15,6 +15,7 @@ import type {
 } from "../util/icon-button.types";
 
 import {IconButtonUnstyled} from "./icon-button-unstyled";
+import themeTokens from "../theme";
 
 type AriaLabelOnly = {
     /**
@@ -192,7 +193,7 @@ const theme = {
     },
     label: {
         color: {
-            progressive: semanticColor.core.foreground.instructive.default,
+            progressive: themeTokens.activityIconButton.label.color.progressive,
             neutral: semanticColor.core.foreground.neutral.default,
             disabled: semanticColor.core.foreground.disabled.default,
         },
@@ -336,6 +337,7 @@ const _generateStyles = (
             WebkitLineClamp: "2",
             overflow: "hidden",
             wordBreak: "break-word",
+            color: "inherit",
         },
     } as const;
 

--- a/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/activity-icon-button.tsx
@@ -337,7 +337,6 @@ const _generateStyles = (
             WebkitLineClamp: "2",
             overflow: "hidden",
             wordBreak: "break-word",
-            color: "inherit",
         },
     } as const;
 

--- a/packages/wonder-blocks-icon-button/src/theme/default.ts
+++ b/packages/wonder-blocks-icon-button/src/theme/default.ts
@@ -1,4 +1,4 @@
-import {border, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 export default {
     iconButton: {
@@ -47,6 +47,13 @@ export default {
                 small: sizing.size_240,
                 medium: sizing.size_240,
                 large: sizing.size_240,
+            },
+        },
+    },
+    activityIconButton: {
+        label: {
+            color: {
+                progressive: semanticColor.core.foreground.instructive.default,
             },
         },
     },

--- a/packages/wonder-blocks-icon-button/src/theme/syl-dark.ts
+++ b/packages/wonder-blocks-icon-button/src/theme/syl-dark.ts
@@ -1,4 +1,13 @@
 import {mergeTheme} from "@khanacademy/wonder-blocks-theming";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import thunderblocksTheme from "./thunderblocks";
 
-export default mergeTheme(thunderblocksTheme, {});
+export default mergeTheme(thunderblocksTheme, {
+    activityIconButton: {
+        label: {
+            color: {
+                progressive: semanticColor.core.foreground.neutral.strong,
+            },
+        },
+    },
+});

--- a/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
+++ b/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
@@ -248,6 +248,8 @@ import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 | \`semanticColor.core.shadow.chonky.neutral.subtle\` | \`--wb-semanticColor-core-shadow-chonky-neutral-subtle\` | \`#b8b9bb\` | \`#CBCBCD\` |
 | \`semanticColor.core.shadow.chonky.neutral.default\` | \`--wb-semanticColor-core-shadow-chonky-neutral-default\` | \`#909296\` | \`#8A8B90\` |
 | \`semanticColor.core.shadow.chonky.neutral.strong\` | \`--wb-semanticColor-core-shadow-chonky-neutral-strong\` | \`#21242c\` | \`#4A4C53\` |
+| \`semanticColor.core.shadow.chonky.disabled.subtle\` | \`--wb-semanticColor-core-shadow-chonky-disabled-subtle\` | \`transparent\` | \`transparent\` |
+| \`semanticColor.core.shadow.chonky.disabled.default\` | \`--wb-semanticColor-core-shadow-chonky-disabled-default\` | \`#b8b9bb\` | \`#CBCBCD\` |
 | \`semanticColor.learning.math.foreground.blue\` | \`--wb-semanticColor-learning-math-foreground-blue\` | \`#3D7586\` | \`#20628F\` |
 | \`semanticColor.learning.math.foreground.gold\` | \`--wb-semanticColor-learning-math-foreground-gold\` | \`#946700\` | \`#966B00\` |
 | \`semanticColor.learning.math.foreground.green\` | \`--wb-semanticColor-learning-math-foreground-green\` | \`#447A53\` | \`#3C6D4A\` |

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -138,6 +138,10 @@ const core = {
                 default: color.gray_30,
                 strong: color.gray_50,
             },
+            disabled: {
+                subtle: transparent,
+                default: color.gray_10,
+            },
         },
     },
 };
@@ -503,9 +507,9 @@ export const semanticColor = mergeTheme(thunderblocksSemanticColor, {
                 tertiary: core.foreground.disabled.subtle,
             },
             shadow: {
-                primary: core.shadow.chonky.neutral.subtle,
-                secondary: core.shadow.chonky.neutral.subtle,
-                tertiary: core.transparent,
+                primary: core.shadow.chonky.disabled.default,
+                secondary: core.shadow.chonky.disabled.default,
+                tertiary: core.shadow.chonky.disabled.subtle,
             },
         },
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -15,8 +15,8 @@ const core = {
             strong: color.blue_50,
         },
         neutral: {
-            subtle: color.gray_30,
-            default: color.gray_40,
+            subtle: color.gray_10,
+            default: color.gray_30,
             strong: color.gray_60,
         },
         critical: {

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -488,19 +488,19 @@ export const semanticColor = mergeTheme(thunderblocksSemanticColor, {
         },
         disabled: {
             background: {
-                primary: core.background.neutral.default,
-                secondary: core.background.neutral.subtle,
+                primary: core.background.disabled.strong,
+                secondary: core.background.disabled.default,
                 tertiary: core.background.disabled.subtle,
             },
             border: {
                 primary: core.border.disabled.subtle,
-                secondary: core.border.neutral.subtle,
+                secondary: core.border.disabled.default,
                 tertiary: core.border.disabled.subtle,
             },
             foreground: {
-                primary: core.foreground.knockout.default,
-                secondary: core.foreground.neutral.default,
-                tertiary: core.foreground.neutral.default,
+                primary: core.foreground.disabled.default,
+                secondary: core.foreground.disabled.default,
+                tertiary: core.foreground.disabled.subtle,
             },
             shadow: {
                 primary: core.shadow.chonky.neutral.strong,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -503,7 +503,7 @@ export const semanticColor = mergeTheme(thunderblocksSemanticColor, {
                 tertiary: core.foreground.disabled.subtle,
             },
             shadow: {
-                primary: core.shadow.chonky.neutral.strong,
+                primary: core.shadow.chonky.neutral.subtle,
                 secondary: core.shadow.chonky.neutral.subtle,
                 tertiary: core.transparent,
             },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-thunderblocks.ts
@@ -146,6 +146,10 @@ const core = {
                 default: color.gray_30,
                 strong: color.gray_10,
             },
+            disabled: {
+                subtle: transparent,
+                default: color.gray_60,
+            },
         },
     },
 };
@@ -525,9 +529,9 @@ export const semanticColor = mergeTheme(defaultSemanticColor, {
                 tertiary: color.gray_50,
             },
             shadow: {
-                primary: core.shadow.chonky.neutral.subtle,
-                secondary: core.shadow.chonky.neutral.subtle,
-                tertiary: core.transparent,
+                primary: core.shadow.chonky.disabled.default,
+                secondary: core.shadow.chonky.disabled.default,
+                tertiary: core.shadow.chonky.disabled.subtle,
             },
         },
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -146,6 +146,10 @@ const core = {
                 default: color.fadedOffBlack50,
                 strong: color.offBlack,
             },
+            disabled: {
+                subtle: transparent,
+                default: color.fadedOffBlack32,
+            },
         },
     },
 };
@@ -651,9 +655,9 @@ export const semanticColor = {
                 tertiary: core.foreground.disabled.default,
             },
             shadow: {
-                primary: core.shadow.chonky.neutral.subtle,
-                secondary: core.shadow.chonky.neutral.subtle,
-                tertiary: core.transparent,
+                primary: core.shadow.chonky.disabled.default,
+                secondary: core.shadow.chonky.disabled.default,
+                tertiary: core.shadow.chonky.disabled.subtle,
             },
         },
     },


### PR DESCRIPTION
## Summary:

Reviewing the button and icon button components in SYL Dark to confirm they look as expected, match the design specs, and have no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Changes include:
- Adds a component theme token for ActivityIconButton to support using a different token in syl dark for the label
- Adds `core.shadow.chonky.disabled.subtle/default` tokens and use them for `chonky.disabled.shadow.*` tokens
- Update semantic color core tokens in `syl-dark` related to chonky tokens and border neutral tokens

Issue: WB-2166

## Test plan:

Review the button and icon button components in syl-dark and confirm things look as expected and there are no a11y violations:
  - Button: `?path=/story/packages-button-testing-snapshots-button--state-sheet-story&globals=theme:syl-dark`
  - ActivityButton: `?path=/story/packages-button-testing-snapshots-activitybutton--state-sheet-story&globals=theme:syl-dark`
  - IconButton: `?path=/story/packages-iconbutton-testing-snapshots-iconbutton--state-sheet-story&globals=theme:syl-dark`
  - ActivityIconButton: `?path=/story/packages-iconbutton-testing-snapshots-activityiconbutton--state-sheet-story&globals=theme:syl-dark`
  - ConversationIconButton: `?path=/story/packages-iconbutton-testing-snapshots-conversationiconbutton--state-sheet-story&globals=theme:syl-dark`
  - NodeIconButton: `?path=/story/packages-iconbutton-testing-snapshots-nodeiconbutton--state-sheet-story&globals=theme:syl-dark`
  - Catalog overview: `?path=/story/catalog--buttons&globals=theme:syl-dark`

Review Chromatic snapshots and confirm there were no unintentional changes made to `default` and `thunderblocks` themes