### PR TITLE
⚠️ Make `tokenValue` safe to call when `document` is undefined

### DIFF
--- a/.changeset/wb-2160-tokenvalue-ssr-safe.md
+++ b/.changeset/wb-2160-tokenvalue-ssr-safe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Make `tokenValue` safe to call in environments without a `document` (e.g. SSR or node-based test environments). Returns an empty string for `var(...)` tokens when `document` is undefined, instead of throwing `ReferenceError: document is not defined`.

--- a/packages/wonder-blocks-tokens/src/util/__tests__/token-value.test.ts
+++ b/packages/wonder-blocks-tokens/src/util/__tests__/token-value.test.ts
@@ -160,4 +160,34 @@ describe("tokenValue", () => {
         expect(result).toBe("2rem");
         scoped.remove();
     });
+
+    // Simulates an SSR / node-based test environment where `document` is not
+    // defined globally. Some consumers call `tokenValue` at module load time
+    // (e.g. `wonder-blocks-layout/src/util/specs.ts`), so the helper must not
+    // throw a `ReferenceError` when imported in those environments.
+    describe("when document is undefined", () => {
+        beforeEach(() => {
+            jest.spyOn(globalThis, "document", "get").mockReturnValue(
+                undefined as unknown as Document,
+            );
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it("returns an empty string for a var() token", () => {
+            expect(typeof document).toBe("undefined");
+            expect(
+                tokenValue(
+                    "var(--wb-semanticColor-core-foreground-instructive-default)",
+                ),
+            ).toBe("");
+        });
+
+        it("returns a non-var() input unchanged", () => {
+            expect(typeof document).toBe("undefined");
+            expect(tokenValue("#1865f2")).toBe("#1865f2");
+        });
+    });
 });

--- a/packages/wonder-blocks-tokens/src/util/token-value.ts
+++ b/packages/wonder-blocks-tokens/src/util/token-value.ts
@@ -32,14 +32,22 @@ const cssVarRegex = /^\s*var\(\s*(--[^,)\s]+)/;
  * ```
  */
 export function tokenValue(token: string, element?: Element): string {
+    const match = token.match(cssVarRegex);
+    if (!match) {
+        return token;
+    }
+
+    // In non-browser environments (e.g. SSR or node-based tests), there is no
+    // document to read computed styles from. Return an empty string so callers
+    // can resolve values lazily at first render instead of crashing on import.
+    if (typeof document === "undefined") {
+        return "";
+    }
+
     const rootElement =
         element ||
         document.querySelector("[data-wb-theme]") ||
         document.documentElement;
 
-    const match = token.match(cssVarRegex);
-    if (!match) {
-        return token;
-    }
     return getComputedStyle(rootElement).getPropertyValue(match[1]).trim();
 }


### PR DESCRIPTION
## Summary

Adds a `typeof document === "undefined"` guard to `tokenValue` so it returns an empty string (instead of throwing `ReferenceError: document is not defined`) in SSR / node-based test environments. Consumers like `wonder-blocks-layout/src/util/specs.ts` and `wonder-blocks-tooltip/src/components/tooltip-popper.tsx` call `tokenValue` at module load time, so without this guard any downstream test that imports those modules in a node test environment crashes.

Browser behavior is unchanged.

Issue: [WB-2160](https://khanacademy.atlassian.net/browse/WB-2160)

## Test plan

- [x] Existing `token-value.test.ts` unit tests pass (verified locally).
- [ ] Manual: open the TokenValue stories in Storybook (`http://localhost:6061/?path=/docs/wonder-blocks-tokens-tokenvalue--docs`) and confirm the resolved values still render correctly — browser behavior should be a no-op.
- [ ] Downstream: webapp's node-env tests that import `@khanacademy/wonder-blocks-layout` or `-tooltip` should stop throwing `ReferenceError: document is not defined`.

## Review plan

Please review these risky changes:

1. ⚠️ [`token-value.ts`](https://github.com/Khan/wonder-blocks/pull/3049#discussion_r3237017522)

[WB-2160]: https://khanacademy.atlassian.net/browse/WB-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ