### PR TITLE
Adding Button statesheet coverage for loading state

### DIFF
--- a/__docs__/wonder-blocks-button/button-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-button/button-testing-snapshots.stories.tsx
@@ -40,6 +40,7 @@ const actionTypes = [
     {name: "Destructive", props: {actionType: "destructive"}},
     {name: "Neutral", props: {actionType: "neutral"}},
     {name: "Disabled", props: {disabled: true}},
+    {name: "Loading", props: {spinner: true, "aria-label": "Loading"}},
 ];
 
 export const StateSheetStory: StoryComponentType = {
@@ -107,19 +108,16 @@ export const Sizes: StoryComponentType = {
                 {({props}) => (
                     <View style={{gap: sizing.size_160, flexDirection: "row"}}>
                         <Button {...args} {...props} />
-                        {actionTypes.map(
-                            ({props: {actionType, disabled}}, index) => (
-                                <Button
-                                    {...args}
-                                    {...props}
-                                    actionType={actionType}
-                                    disabled={disabled}
-                                    key={index}
-                                    startIcon={paperPlaneIcon}
-                                    endIcon={paperPlaneIcon}
-                                />
-                            ),
-                        )}
+                        {actionTypes.map(({props: actionTypeProps}, index) => (
+                            <Button
+                                {...args}
+                                {...props}
+                                {...actionTypeProps}
+                                key={index}
+                                startIcon={paperPlaneIcon}
+                                endIcon={paperPlaneIcon}
+                            />
+                        ))}
                     </View>
                 )}
             </AllVariants>

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -413,6 +413,13 @@ export const WithPopperPlacement: StoryComponentType = {
             <Button endIcon={IconMappings.caretRight}>{text}</Button>
         ),
     } as Partial<typeof ActionMenu>,
+    parameters: {
+        chromatic: {
+            // Delay to allow the dropdown menu to position itself to avoid
+            // flaky snapshots.
+            delay: 300,
+        },
+    },
 };
 
 /**


### PR DESCRIPTION
## Summary:

Adding coverage for the loading state in Button in another PR so that it doesn't impact the visual regression tests in https://github.com/Khan/wonder-blocks/pull/3047

Issue: WB-2166

## Test plan:

Review Chromatic snapshots. The loading state should be included in the snapshots for Button