### PR TITLE
Run Storybook tests and a11y checks for each theme

### DIFF
--- a/.storybook/vitest.setup.default.ts
+++ b/.storybook/vitest.setup.default.ts
@@ -1,0 +1,3 @@
+import {setupForTheme} from "./vitest.setup";
+
+setupForTheme("default");

--- a/.storybook/vitest.setup.thunderblocks.ts
+++ b/.storybook/vitest.setup.thunderblocks.ts
@@ -1,0 +1,3 @@
+import {setupForTheme} from "./vitest.setup";
+
+setupForTheme("thunderblocks");

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -6,9 +6,12 @@ import * as previewAnnotations from "./preview";
 
 // This is an important step to apply the right configuration when testing your stories.
 // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
-const annotations = setProjectAnnotations([
-    a11yAddonAnnotations,
-    previewAnnotations,
-]);
+export function setupForTheme(theme: string) {
+    const annotations = setProjectAnnotations([
+        a11yAddonAnnotations,
+        previewAnnotations,
+        {initialGlobals: {theme}},
+    ]);
 
-beforeAll(annotations.beforeAll);
+    beforeAll(annotations.beforeAll);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,35 +4,36 @@ import {playwright} from "@vitest/browser-playwright";
 import {storybookTest} from "@storybook/addon-vitest/vitest-plugin";
 import viteConfig from "./vite.config";
 
+// Themes the storybook a11y suite runs against
+const themes = ["default", "thunderblocks"] as const;
+
 // More info at: https://storybook.js.org/docs/writing-tests/vitest-plugin
 export default mergeConfig(
     viteConfig,
     defineConfig({
         test: {
-            projects: [
-                {
-                    extends: true,
-                    plugins: [
-                        // See options at: https://storybook.js.org/docs/writing-tests/vitest-plugin#storybooktest
-                        storybookTest({
-                            configDir: ".storybook",
-                            storybookUrl:
-                                process.env.SB_URL || "http://localhost:6061",
-                        }),
-                    ],
+            projects: themes.map((theme) => ({
+                extends: true,
+                plugins: [
+                    // See options at: https://storybook.js.org/docs/writing-tests/vitest-plugin#storybooktest
+                    storybookTest({
+                        configDir: ".storybook",
+                        storybookUrl:
+                            process.env.SB_URL || "http://localhost:6061",
+                    }),
+                ],
 
-                    test: {
-                        name: "storybook",
-                        browser: {
-                            enabled: true,
-                            instances: [{browser: "chromium"}],
-                            headless: true,
-                            provider: playwright({}),
-                        },
-                        setupFiles: ["./.storybook/vitest.setup.ts"],
+                test: {
+                    name: `storybook-${theme}`,
+                    browser: {
+                        enabled: true,
+                        instances: [{browser: "chromium"}],
+                        headless: true,
+                        provider: playwright({}),
                     },
+                    setupFiles: [`./.storybook/vitest.setup.${theme}.ts`],
                 },
-            ],
+            })),
         },
     }),
 );


### PR DESCRIPTION
## Summary:

Previously, SB tests and a11y checks ran only for the `default` theme.

With these changes, we run the tests and a11y checks across themes. The goal of this is to have
automated a11y test coverage for all themes, which is important since it can catch potential
color contrast issues.

We will include the `syl-dark` theme in these tests once all components have been reviewed for syl-dark readiness

Issue: WB-2234

## Test plan:

Confirm that the a11y checks runs on the `default` and `thunderblocks` themes