### PR TITLE
New WB lint rule: no-hardcoded-color

### DIFF
--- a/.changeset/beige-stingrays-sleep.md
+++ b/.changeset/beige-stingrays-sleep.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-wonder-blocks-demo": minor
+"@khanacademy/eslint-plugin-wonder-blocks": minor
+---
+
+Add new lint rule for no-hardcoded-color that suggests semanticColor usage for theming support

--- a/.changeset/disable-rtl-rule-from-recommended.md
+++ b/.changeset/disable-rtl-rule-from-recommended.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/eslint-plugin-wonder-blocks": patch
+---
+
+Disable `require-logical-properties-for-rtl` from the recommended (and strict) configs to facilitate intentional rollout. The rule is still available in the plugin for opt-in use.

--- a/__docs__/components/component-info.tsx
+++ b/__docs__/components/component-info.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import githubLogo from "@phosphor-icons/core/fill/github-logo-fill.svg";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {Caption} from "@khanacademy/wonder-blocks-typography";
 
 type Props = {
@@ -38,7 +39,7 @@ function ComponentInfo({name, version}: Props): React.ReactElement {
                 kind="secondary"
                 href={`https://github.com/Khan/wonder-blocks/tree/main/packages/${packageFolder}`}
                 target="_blank"
-                style={{color: "black"}}
+                style={{color: semanticColor.core.foreground.neutral.strong}}
                 startIcon={githubLogo}
             >
                 Source code

--- a/__docs__/components/gallery/tiles/one-pane-dialog-tile.tsx
+++ b/__docs__/components/gallery/tiles/one-pane-dialog-tile.tsx
@@ -4,6 +4,7 @@ import {StyleSheet} from "aphrodite";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import ComponentTile from "../component-tile";
@@ -53,8 +54,7 @@ const mobile = "@media (max-width: 1023px)";
 const localStyles = StyleSheet.create({
     modalPositioner: {
         // Checkerboard background
-        backgroundImage:
-            "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 

--- a/__docs__/components/gallery/tiles/one-pane-dialog-tile.tsx
+++ b/__docs__/components/gallery/tiles/one-pane-dialog-tile.tsx
@@ -4,11 +4,11 @@ import {StyleSheet} from "aphrodite";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {Body} from "@khanacademy/wonder-blocks-typography";
 
 import ComponentTile from "../component-tile";
 import {CommonTileProps} from "../types";
+import {modalPositionerStyle} from "../../../wonder-blocks-modal/modal-story-utils";
 
 export default function OnePaneDialogTile(props: CommonTileProps) {
     return (
@@ -52,22 +52,7 @@ export default function OnePaneDialogTile(props: CommonTileProps) {
 const mobile = "@media (max-width: 1023px)";
 
 const localStyles = StyleSheet.create({
-    modalPositioner: {
-        // Checkerboard background
-        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-
-        position: "absolute",
-        insetInlineStart: 0,
-        insetInlineEnd: 0,
-        insetBlockStart: 0,
-        insetBlockEnd: 0,
-    },
+    modalPositioner: modalPositionerStyle,
     previewSizer: {
         minBlockSize: 500,
         width: "100%",

--- a/__docs__/components/icons-for-testing.tsx
+++ b/__docs__/components/icons-for-testing.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+
 export const singleColoredIcon = (
     <svg
         viewBox="0 0 256 256"
@@ -25,27 +27,34 @@ export const multiColoredIcon = (
         <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
             <g>
                 <g>
-                    <mask id="mask-2" fill="white">
+                    <mask
+                        id="mask-2"
+                        fill={semanticColor.core.background.base.default}
+                    >
                         <use xlinkHref="#path-1" />
                     </mask>
-                    <use id="Mask" fill="#1865F2" xlinkHref="#path-1" />
+                    <use
+                        id="Mask"
+                        fill={semanticColor.core.background.instructive.default}
+                        xlinkHref="#path-1"
+                    />
                     <path
                         d="M51,128 L205,128 C205,170.525926 170.525926,205 128,205 C85.4740743,205 51,170.525926 51,128 Z"
                         id="Smile"
-                        fill="#FFFFFF"
+                        fill={semanticColor.core.foreground.knockout.default}
                         fillRule="nonzero"
                         mask="url(#mask-2)"
                     />
                     <path
                         d="M128,0 L252,0 C254.209139,-4.05812251e-16 256,1.790861 256,4 L256,128 L128,128 L128,0 Z M192,91 C206.911688,91 219,78.9116882 219,64 C219,49.0883118 206.911688,37 192,37 C177.088312,37 165,49.0883118 165,64 C165,78.9116882 177.088312,91 192,91 Z"
                         id="Right-Eye"
-                        fill="#FFD633"
+                        fill={semanticColor.core.foreground.warning.default}
                         mask="url(#mask-2)"
                     />
                     <path
                         d="M4,0 L128,0 L128,128 L0,128 L0,4 C-2.705415e-16,1.790861 1.790861,4.05812251e-16 4,0 Z M64,91 C78.9116882,91 91,78.9116882 91,64 C91,49.0883118 78.9116882,37 64,37 C49.0883118,37 37,49.0883118 37,64 C37,78.9116882 49.0883118,91 64,91 Z"
                         id="Left-Eye"
-                        fill="#37C5FD"
+                        fill={semanticColor.core.foreground.instructive.subtle}
                         mask="url(#mask-2)"
                     />
                 </g>

--- a/__docs__/components/icons-for-testing.tsx
+++ b/__docs__/components/icons-for-testing.tsx
@@ -1,6 +1,5 @@
+/* eslint-disable @khanacademy/wonder-blocks/no-hardcoded-color -- WB logo colors; these are theme-invariant and must not be replaced with semantic tokens */
 import * as React from "react";
-
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 export const singleColoredIcon = (
     <svg
@@ -30,28 +29,24 @@ export const multiColoredIcon = (
                     <mask id="mask-2" fill="white">
                         <use xlinkHref="#path-1" />
                     </mask>
-                    <use
-                        id="Mask"
-                        fill={semanticColor.core.background.instructive.default}
-                        xlinkHref="#path-1"
-                    />
+                    <use id="Mask" fill="#1865F2" xlinkHref="#path-1" />
                     <path
                         d="M51,128 L205,128 C205,170.525926 170.525926,205 128,205 C85.4740743,205 51,170.525926 51,128 Z"
                         id="Smile"
-                        fill={semanticColor.core.foreground.knockout.default}
+                        fill="#FFFFFF"
                         fillRule="nonzero"
                         mask="url(#mask-2)"
                     />
                     <path
                         d="M128,0 L252,0 C254.209139,-4.05812251e-16 256,1.790861 256,4 L256,128 L128,128 L128,0 Z M192,91 C206.911688,91 219,78.9116882 219,64 C219,49.0883118 206.911688,37 192,37 C177.088312,37 165,49.0883118 165,64 C165,78.9116882 177.088312,91 192,91 Z"
                         id="Right-Eye"
-                        fill={semanticColor.core.foreground.warning.default}
+                        fill="#FFD633"
                         mask="url(#mask-2)"
                     />
                     <path
                         d="M4,0 L128,0 L128,128 L0,128 L0,4 C-2.705415e-16,1.790861 1.790861,4.05812251e-16 4,0 Z M64,91 C78.9116882,91 91,78.9116882 91,64 C91,49.0883118 78.9116882,37 64,37 C49.0883118,37 37,49.0883118 37,64 C37,78.9116882 49.0883118,91 64,91 Z"
                         id="Left-Eye"
-                        fill={semanticColor.core.foreground.instructive.subtle}
+                        fill="#37C5FD"
                         mask="url(#mask-2)"
                     />
                 </g>

--- a/__docs__/components/icons-for-testing.tsx
+++ b/__docs__/components/icons-for-testing.tsx
@@ -27,10 +27,7 @@ export const multiColoredIcon = (
         <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
             <g>
                 <g>
-                    <mask
-                        id="mask-2"
-                        fill={semanticColor.core.background.base.default}
-                    >
+                    <mask id="mask-2" fill="white">
                         <use xlinkHref="#path-1" />
                     </mask>
                     <use

--- a/__docs__/tools/eslint-plugin-wonder-blocks/no-hardcoded-color.mdx
+++ b/__docs__/tools/eslint-plugin-wonder-blocks/no-hardcoded-color.mdx
@@ -1,0 +1,8 @@
+import {Meta, Markdown} from "@storybook/addon-docs/blocks";
+import lintRuleDocs from "../../../packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md?raw";
+
+<Meta
+    title="Tools / eslint-plugin-wonder-blocks / Rules / no-hardcoded-color"
+/>
+
+<Markdown>{lintRuleDocs}</Markdown>

--- a/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
+++ b/__docs__/wonder-blocks-cell/compact-cell.stories.tsx
@@ -289,7 +289,7 @@ export const CompactCellActive: StoryComponentType = {
                 <PhosphorIcon
                     icon={IconMappings.playCircle}
                     size="medium"
-                    color="black"
+                    color={semanticColor.core.foreground.neutral.strong}
                 />
             }
             rightAccessory={

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -113,7 +113,7 @@ const styles = StyleSheet.create({
     scrolledWrapper: {
         height: 200,
         overflow: "auto",
-        border: "1px solid grey",
+        border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
         borderRadius: border.radius.radius_040,
         margin: sizing.size_080,
         padding: sizing.size_160,

--- a/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
@@ -341,7 +341,7 @@ const styles = StyleSheet.create({
     multipleChoice: {
         margin: 0,
         blockSize: sizing.size_480,
-        borderBlockStart: "solid 1px #CCC",
+        borderBlockStart: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         justifyContent: "center",
     },
     firstChoice: {
@@ -351,6 +351,6 @@ const styles = StyleSheet.create({
         color: semanticColor.core.foreground.neutral.default,
     },
     last: {
-        borderBlockEnd: "solid 1px #CCC",
+        borderBlockEnd: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
     },
 });

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -263,11 +263,11 @@ const styles = StyleSheet.create({
     choice: {
         margin: 0,
         height: 48,
-        borderBlockStart: "solid 1px #CCC",
+        borderBlockStart: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
         justifyContent: "center",
     },
     lastChoice: {
-        borderBlockEnd: "solid 1px #CCC",
+        borderBlockEnd: `solid 1px ${semanticColor.core.border.neutral.subtle}`,
     },
     prompt: {
         marginBlockEnd: 16,

--- a/__docs__/wonder-blocks-modal/flexible-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/flexible-dialog.stories.tsx
@@ -511,8 +511,7 @@ const styles = StyleSheet.create({
     },
     modalPositioner: {
         // Checkerboard background
-        backgroundImage:
-            "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 

--- a/__docs__/wonder-blocks-modal/flexible-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/flexible-dialog.stories.tsx
@@ -12,6 +12,7 @@ import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
 import ComponentInfo from "../components/component-info";
 import FlexibleDialogArgTypes from "./flexible-dialog.argtypes";
+import {modalPositionerStyle} from "./modal-story-utils";
 import {allModes} from "../../.storybook/modes";
 
 import celebrationBg from "../../static/celebration_bg.svg";
@@ -509,22 +510,7 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "center",
     },
-    modalPositioner: {
-        // Checkerboard background
-        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-
-        position: "absolute",
-        insetInlineStart: 0,
-        insetInlineEnd: 0,
-        insetBlockStart: 0,
-        insetBlockEnd: 0,
-    },
+    modalPositioner: modalPositionerStyle,
     centered: {
         alignItems: "center",
         justifyContent: "center",

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -16,6 +16,7 @@ import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 import modalDialogArgtypes from "./modal-dialog.argtypes";
 import {reallyLongText} from "../components/text-for-testing";
+import {modalPositionerStyle} from "./modal-story-utils";
 
 /**
  * `ModalDialog` is a component that contains these elements:
@@ -257,22 +258,7 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "center",
     },
-    modalPositioner: {
-        // Checkerboard background
-        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-
-        position: "absolute",
-        insetInlineStart: 0,
-        insetInlineEnd: 0,
-        insetBlockStart: 0,
-        insetBlockEnd: 0,
-    },
+    modalPositioner: modalPositionerStyle,
     previewSizer: {
         minBlockSize: 600,
         width: "100%",

--- a/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-dialog.stories.tsx
@@ -259,8 +259,7 @@ const styles = StyleSheet.create({
     },
     modalPositioner: {
         // Checkerboard background
-        backgroundImage:
-            "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -297,8 +297,7 @@ const styles = StyleSheet.create({
     },
     modalPositioner: {
         // Checkerboard background
-        backgroundImage:
-            "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 

--- a/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-footer.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -15,6 +15,7 @@ import {
 import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
 import ComponentInfo from "../components/component-info";
+import {modalPositionerStyle} from "./modal-story-utils";
 
 const longBody = (
     <>
@@ -295,22 +296,7 @@ const styles = StyleSheet.create({
         maxInlineSize: 600,
         maxBlockSize: 500,
     },
-    modalPositioner: {
-        // Checkerboard background
-        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-
-        position: "absolute",
-        insetInlineStart: 0,
-        insetInlineEnd: 0,
-        insetBlockStart: 0,
-        insetBlockEnd: 0,
-    },
+    modalPositioner: modalPositionerStyle,
     previewSizer: {
         height: 600,
     },

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from "@khanacademy/wonder-blocks-breadcrumbs";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -230,8 +231,7 @@ const styles = StyleSheet.create({
     },
     modalPositioner: {
         // Checkerboard background
-        backgroundImage:
-            "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 

--- a/__docs__/wonder-blocks-modal/modal-header.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-header.stories.tsx
@@ -8,7 +8,6 @@ import {
 } from "@khanacademy/wonder-blocks-breadcrumbs";
 import {View} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {
@@ -20,6 +19,7 @@ import packageConfig from "../../packages/wonder-blocks-modal/package.json";
 
 import ComponentInfo from "../components/component-info";
 import ModalHeaderArgtypes from "./modal-header.argtypes";
+import {modalPositionerStyle} from "./modal-story-utils";
 
 const longBody = (
     <>
@@ -229,22 +229,7 @@ const styles = StyleSheet.create({
         maxInlineSize: 600,
         maxBlockSize: 500,
     },
-    modalPositioner: {
-        // Checkerboard background
-        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-
-        position: "absolute",
-        insetInlineStart: 0,
-        insetInlineEnd: 0,
-        insetBlockStart: 0,
-        insetBlockEnd: 0,
-    },
+    modalPositioner: modalPositionerStyle,
     previewSizer: {
         height: 600,
     },

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -729,7 +729,7 @@ const styles = StyleSheet.create({
         flexDirection: "column",
         gap: sizing.size_160,
         padding: sizing.size_160,
-        backgroundColor: "rgba(33, 36, 44, 0.08)",
+        backgroundColor: semanticColor.core.background.neutral.subtle,
         borderRadius: 4,
     },
     buttonRow: {

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -18,6 +18,7 @@ import ComponentInfo from "../components/component-info";
 import modalPanelArgtypes from "./modal-panel.argtypes";
 import {allModes} from "../../.storybook/modes";
 import {focusStyles} from "@khanacademy/wonder-blocks-styles";
+import {modalPositionerStyle} from "./modal-story-utils";
 
 const longBody = (
     <View style={{gap: sizing.size_160}}>
@@ -353,22 +354,7 @@ const styles = StyleSheet.create({
         maxInlineSize: 600,
         maxBlockSize: 500,
     },
-    modalPositioner: {
-        // Checkerboard background
-        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-
-        position: "absolute",
-        insetInlineStart: 0,
-        insetInlineEnd: 0,
-        insetBlockStart: 0,
-        insetBlockEnd: 0,
-    },
+    modalPositioner: modalPositionerStyle,
     previewSizer: {
         height: 600,
     },

--- a/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-panel.stories.tsx
@@ -355,8 +355,7 @@ const styles = StyleSheet.create({
     },
     modalPositioner: {
         // Checkerboard background
-        backgroundImage:
-            "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 

--- a/__docs__/wonder-blocks-modal/modal-story-utils.ts
+++ b/__docs__/wonder-blocks-modal/modal-story-utils.ts
@@ -1,0 +1,27 @@
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+
+/**
+ * Shared Aphrodite style for the checkerboard background used as a decorator
+ * in modal stories. Spread this into a `modalPositioner` key inside
+ * `StyleSheet.create(...)`.
+ *
+ * The checkerboard uses two tones — `semanticColor.core.background.neutral.subtle`
+ * and `semanticColor.core.transparent` — so it adapts automatically to light
+ * and dark mode.
+ */
+export const modalPositionerStyle = {
+    // Checkerboard background
+    backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, ${semanticColor.core.transparent} 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, ${semanticColor.core.transparent} 25%), linear-gradient(45deg, ${semanticColor.core.transparent} 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, ${semanticColor.core.transparent} 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
+    backgroundSize: "20px 20px",
+    backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
+
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+
+    position: "absolute",
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
+    insetBlockStart: 0,
+    insetBlockEnd: 0,
+} as const;

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -572,8 +572,7 @@ const styles = StyleSheet.create({
     },
     modalPositioner: {
         // Checkerboard background
-        backgroundImage:
-            "linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(-45deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(-45deg, transparent 75%, #ccc 75%)",
+        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
         backgroundSize: "20px 20px",
         backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
 

--- a/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
+++ b/__docs__/wonder-blocks-modal/one-pane-dialog.stories.tsx
@@ -20,6 +20,7 @@ import ComponentInfo from "../components/component-info";
 import OnePaneDialogArgTypes from "./one-pane-dialog.argtypes";
 import {allModes} from "../../.storybook/modes";
 import {reallyLongText} from "../components/text-for-testing";
+import {modalPositionerStyle} from "./modal-story-utils";
 
 export default {
     title: "Packages / Modal / OnePaneDialog",
@@ -570,22 +571,7 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "center",
     },
-    modalPositioner: {
-        // Checkerboard background
-        backgroundImage: `linear-gradient(45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(-45deg, ${semanticColor.core.background.neutral.subtle} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%), linear-gradient(-45deg, transparent 75%, ${semanticColor.core.background.neutral.subtle} 75%)`,
-        backgroundSize: "20px 20px",
-        backgroundPosition: "0 0, 0 10px, 10px -10px, -10px 0px",
-
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-
-        position: "absolute",
-        insetInlineStart: 0,
-        insetInlineEnd: 0,
-        insetBlockStart: 0,
-        insetBlockEnd: 0,
-    },
+    modalPositioner: modalPositionerStyle,
     previewSizer: {
         minBlockSize: 600,
         width: "100%",

--- a/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content-core.stories.tsx
@@ -58,7 +58,7 @@ const styles = StyleSheet.create({
         padding: `${sizing.size_120} 0`,
     },
     action: {
-        backgroundColor: "transparent",
+        backgroundColor: semanticColor.core.transparent,
         border: "none",
         color: semanticColor.core.foreground.knockout.default,
         cursor: "pointer",

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -17,7 +17,7 @@ import {TextField} from "@khanacademy/wonder-blocks-form";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Placeholder} from "../components/placeholder";
 import {generateTabs, ControlledTabs} from "./tabs-utils";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {Popover, PopoverContent} from "@khanacademy/wonder-blocks-popover";
 import {Icon, PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -451,10 +451,19 @@ export const CustomStyles: StoryComponentType = {
         // visual regression tests to ensure that the custom styles are applied
         // correctly.
         styles: {
-            root: {border: "2px solid lightpink"},
-            tablist: {backgroundColor: "lavender"},
-            tabPanel: {backgroundColor: "lavenderblush"},
-            tab: {backgroundColor: "lightcyan"},
+            root: {
+                border: `2px solid ${semanticColor.learning.border.gems.default}`,
+            },
+            tablist: {
+                backgroundColor:
+                    semanticColor.core.background.instructive.subtle,
+            },
+            tabPanel: {
+                backgroundColor: semanticColor.core.background.warning.subtle,
+            },
+            tab: {
+                backgroundColor: semanticColor.core.background.success.subtle,
+            },
         },
         tabs: [
             {
@@ -471,7 +480,8 @@ export const CustomStyles: StoryComponentType = {
                 label: (
                     <View
                         style={{
-                            backgroundColor: "honeydew",
+                            backgroundColor:
+                                semanticColor.core.background.neutral.subtle,
                             fontStyle: "italic",
                         }}
                     >
@@ -482,7 +492,8 @@ export const CustomStyles: StoryComponentType = {
                 panel: (
                     <View
                         style={{
-                            backgroundColor: "honeydew",
+                            backgroundColor:
+                                semanticColor.core.background.neutral.subtle,
                             fontStyle: "italic",
                         }}
                     >

--- a/__docs__/wonder-blocks-tabs/tabs.stories.tsx
+++ b/__docs__/wonder-blocks-tabs/tabs.stories.tsx
@@ -459,10 +459,10 @@ export const CustomStyles: StoryComponentType = {
                     semanticColor.core.background.instructive.subtle,
             },
             tabPanel: {
-                backgroundColor: semanticColor.core.background.warning.subtle,
+                backgroundColor: semanticColor.core.background.success.subtle,
             },
             tab: {
-                backgroundColor: semanticColor.core.background.success.subtle,
+                backgroundColor: semanticColor.core.background.base.default,
             },
         },
         tabs: [
@@ -481,7 +481,9 @@ export const CustomStyles: StoryComponentType = {
                     <View
                         style={{
                             backgroundColor:
-                                semanticColor.core.background.neutral.subtle,
+                                semanticColor.core.background.base.strong,
+                            color: semanticColor.core.foreground.knockout
+                                .default,
                             fontStyle: "italic",
                         }}
                     >

--- a/__docs__/wonder-blocks-tokens/deprecated-color.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/deprecated-color.stories.tsx
@@ -102,7 +102,7 @@ export const Default = {
                             <View
                                 style={{
                                     backgroundColor: row.value,
-                                    boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.1)",
+                                    boxShadow: `0 0 0 1px ${semanticColor.core.shadow.transparent.color.subtle}`,
                                 }}
                             >
                                 &nbsp;

--- a/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip.stories.tsx
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
     scrollbox: {
         height: 100,
         overflow: "auto",
-        border: "1px solid black",
+        border: `1px solid ${semanticColor.core.border.neutral.strong}`,
         margin: sizing.size_120,
     },
     hostbox: {

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -75,4 +75,4 @@ The following shows what rules are enabled in each config:
 | [`no-hardcoded-color`](docs/no-hardcoded-color.md)| |✅|
 | [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅|✅|
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|
-| [`require-logical-properties-for-rtl`](docs/require-logical-properties-for-rtl.md)|✅|✅|
+| [`require-logical-properties-for-rtl`](docs/require-logical-properties-for-rtl.md)| opt-in | opt-in |

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -72,6 +72,7 @@ The following shows what rules are enabled in each config:
 |------|-------------------------|---------------------|
 | [`no-custom-tab-role`](docs/no-custom-tab-role.md)| |✅|
 | [`no-excessive-bodytext-children`](docs/no-excessive-bodytext-children.md)| |✅|
+| [`no-hardcoded-color`](docs/no-hardcoded-color.md)| |✅|
 | [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅|✅|
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|
 | [`require-logical-properties-for-rtl`](docs/require-logical-properties-for-rtl.md)|✅|✅|

--- a/packages/eslint-plugin-wonder-blocks/demo/package.json
+++ b/packages/eslint-plugin-wonder-blocks/demo/package.json
@@ -13,6 +13,7 @@
         "typescript": "5.7.3"
     },
     "dependencies": {
+        "aphrodite": "catalog:",
         "@khanacademy/wonder-blocks-button": "workspace:*",
         "@khanacademy/wonder-blocks-clickable": "workspace:*",
         "@khanacademy/wonder-blocks-core": "workspace:*",

--- a/packages/eslint-plugin-wonder-blocks/demo/package.json
+++ b/packages/eslint-plugin-wonder-blocks/demo/package.json
@@ -18,8 +18,11 @@
         "@khanacademy/wonder-blocks-clickable": "workspace:*",
         "@khanacademy/wonder-blocks-core": "workspace:*",
         "@khanacademy/wonder-blocks-form": "workspace:*",
+        "@khanacademy/wonder-blocks-icon": "workspace:*",
         "@khanacademy/wonder-blocks-link": "workspace:*",
+        "@khanacademy/wonder-blocks-tokens": "workspace:*",
         "@khanacademy/wonder-blocks-typography": "workspace:*",
+        "@phosphor-icons/core": "catalog:",
         "@types/react": "^18.2.6",
         "react": "^18.2.0"
     }

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
@@ -17,24 +17,18 @@ export function ValidExample() {
     );
 }
 
-// ❌ Invalid: hardcoded hex color in StyleSheet.create
-// eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
+// ❌ Invalid: hardcoded hex colors in StyleSheet.create
 const invalidHexStyles = StyleSheet.create({
     root: {
-        // @khanacademy/wonder-blocks/no-hardcoded-color: '#333333' is hardcoded
         color: "#333333",
-        // @khanacademy/wonder-blocks/no-hardcoded-color: '#ffffff' is hardcoded
         backgroundColor: "#ffffff",
     },
 });
 
-// ❌ Invalid: hardcoded RGB color in StyleSheet.create
-// eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
+// ❌ Invalid: hardcoded RGB color and named color in StyleSheet.create
 const invalidRgbStyles = StyleSheet.create({
     root: {
-        // @khanacademy/wonder-blocks/no-hardcoded-color: rgba is hardcoded
         boxShadow: "0 2px 4px rgba(0, 0, 0, 0.5)",
-        // @khanacademy/wonder-blocks/no-hardcoded-color: named color is hardcoded
         borderColor: "red",
     },
 });
@@ -42,12 +36,16 @@ const invalidRgbStyles = StyleSheet.create({
 // ❌ Invalid: hardcoded color in inline style prop
 export function InvalidExample() {
     return (
-        // @khanacademy/wonder-blocks/no-hardcoded-color: '#fff' is hardcoded
-        // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
         <div style={{color: "#fff", backgroundColor: "hsl(200, 100%, 50%)"}}>
             <span>Invalid usage</span>
         </div>
     );
+}
+
+// ❌ Invalid: hardcoded color in WB multi-part styles prop
+export function InvalidStylesPropExample() {
+    // @ts-expect-error — simplified for demo purposes
+    return <div styles={{root: {backgroundColor: "lavender"}}} />;
 }
 
 // Suppress unused variable warnings for the invalid style objects above

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
@@ -66,6 +66,26 @@ export function InvalidSvgFillExample() {
     );
 }
 
+// ✅ Valid: fill on <mask> and its children has masking semantics
+// (white = include area, black = exclude area) — not a visible color.
+// These should NOT be flagged.
+export function ValidSvgMaskExample() {
+    return (
+        <svg viewBox="0 0 100 100">
+            <defs>
+                <mask id="circle-mask">
+                    {/* fill here means "include this area in the mask" */}
+                    <rect fill="white" width="100" height="100" />
+                    <circle fill="black" cx="50" cy="50" r="30" />
+                    {/* <use> inside <mask> also has masking semantics */}
+                    <use fill="white" xlinkHref="#reusable-shape" />
+                </mask>
+            </defs>
+            <rect width="100" height="100" fill="blue" mask="url(#circle-mask)" />
+        </svg>
+    );
+}
+
 // ❌ Invalid: hardcoded color on PhosphorIcon's color prop
 export function InvalidPhosphorIconExample() {
     // @ts-expect-error — simplified for demo purposes

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
@@ -48,6 +48,31 @@ export function InvalidStylesPropExample() {
     return <div styles={{root: {backgroundColor: "lavender"}}} />;
 }
 
+// ❌ Invalid: hardcoded color in backgroundImage gradient
+const invalidGradientStyles = StyleSheet.create({
+    root: {
+        backgroundImage:
+            "linear-gradient(180deg, #b8bdc4 0%, #8b93a0 50%, #717883 100%)",
+    },
+});
+
+// ❌ Invalid: hardcoded color as SVG presentation attribute
+export function InvalidSvgFillExample() {
+    return (
+        <svg viewBox="0 0 24 24">
+            <path fill="#ff0000" d="M12 2L2 22h20L12 2z" />
+            <circle stroke="blue" cx="12" cy="12" r="10" />
+        </svg>
+    );
+}
+
+// ❌ Invalid: hardcoded color on PhosphorIcon's color prop
+export function InvalidPhosphorIconExample() {
+    // @ts-expect-error — simplified for demo purposes
+    return <PhosphorIcon color="#3C6D4A" />;
+}
+
 // Suppress unused variable warnings for the invalid style objects above
 void invalidHexStyles;
 void invalidRgbStyles;
+void invalidGradientStyles;

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
@@ -1,0 +1,55 @@
+/**
+ * This file demonstrates the wonder-blocks ESLint rule:
+ * `@khanacademy/wonder-blocks/no-hardcoded-color`
+ * Run `pnpm lint` in this directory to see the errors.
+ */
+
+import * as React from "react";
+
+import {StyleSheet} from "aphrodite";
+
+// ✅ Valid: using CSS keywords and variable references
+export function ValidExample() {
+    return (
+        <div style={{color: "inherit", backgroundColor: "transparent"}}>
+            <span className="example">Valid usage</span>
+        </div>
+    );
+}
+
+// ❌ Invalid: hardcoded hex color in StyleSheet.create
+// eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
+const invalidHexStyles = StyleSheet.create({
+    root: {
+        // @khanacademy/wonder-blocks/no-hardcoded-color: '#333333' is hardcoded
+        color: "#333333",
+        // @khanacademy/wonder-blocks/no-hardcoded-color: '#ffffff' is hardcoded
+        backgroundColor: "#ffffff",
+    },
+});
+
+// ❌ Invalid: hardcoded RGB color in StyleSheet.create
+// eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
+const invalidRgbStyles = StyleSheet.create({
+    root: {
+        // @khanacademy/wonder-blocks/no-hardcoded-color: rgba is hardcoded
+        boxShadow: "0 2px 4px rgba(0, 0, 0, 0.5)",
+        // @khanacademy/wonder-blocks/no-hardcoded-color: named color is hardcoded
+        borderColor: "red",
+    },
+});
+
+// ❌ Invalid: hardcoded color in inline style prop
+export function InvalidExample() {
+    return (
+        // @khanacademy/wonder-blocks/no-hardcoded-color: '#fff' is hardcoded
+        // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
+        <div style={{color: "#fff", backgroundColor: "hsl(200, 100%, 50%)"}}>
+            <span>Invalid usage</span>
+        </div>
+    );
+}
+
+// Suppress unused variable warnings for the invalid style objects above
+void invalidHexStyles;
+void invalidRgbStyles;

--- a/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
+++ b/packages/eslint-plugin-wonder-blocks/demo/src/no-hardcoded-color-example.tsx
@@ -7,13 +7,49 @@
 import * as React from "react";
 
 import {StyleSheet} from "aphrodite";
+import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
-// ✅ Valid: using CSS keywords and variable references
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+
+// ✅ Valid: using CSS keywords and semantic token references
 export function ValidExample() {
     return (
-        <div style={{color: "inherit", backgroundColor: "transparent"}}>
+        <div
+            style={{
+                color: "inherit",
+                backgroundColor: semanticColor.core.transparent,
+            }}
+        >
             <span className="example">Valid usage</span>
         </div>
+    );
+}
+
+// ✅ Valid: PhosphorIcon with a semantic color token
+export function ValidPhosphorIconExample() {
+    return (
+        <PhosphorIcon
+            icon={magnifyingGlassIcon}
+            color={semanticColor.core.foreground.neutral.strong}
+        />
+    );
+}
+
+// ✅ Valid: fill on <mask> children has masking semantics, not color
+export function ValidSvgMaskExample() {
+    return (
+        <svg viewBox="0 0 100 100">
+            <defs>
+                <mask id="circle-mask">
+                    {/* fill here means "include this area in the mask" */}
+                    <rect fill="white" width="100" height="100" />
+                    <circle fill="black" cx="50" cy="50" r="30" />
+                    {/* <use> inside <mask> also has masking semantics */}
+                    <use fill="white" xlinkHref="#reusable-shape" />
+                </mask>
+            </defs>
+        </svg>
     );
 }
 
@@ -42,6 +78,11 @@ export function InvalidExample() {
     );
 }
 
+// ❌ Invalid: `transparent` keyword — use semanticColor.core.transparent instead
+export function InvalidTransparentExample() {
+    return <div style={{backgroundColor: "transparent"}} />;
+}
+
 // ❌ Invalid: hardcoded color in WB multi-part styles prop
 export function InvalidStylesPropExample() {
     // @ts-expect-error — simplified for demo purposes
@@ -66,30 +107,9 @@ export function InvalidSvgFillExample() {
     );
 }
 
-// ✅ Valid: fill on <mask> and its children has masking semantics
-// (white = include area, black = exclude area) — not a visible color.
-// These should NOT be flagged.
-export function ValidSvgMaskExample() {
-    return (
-        <svg viewBox="0 0 100 100">
-            <defs>
-                <mask id="circle-mask">
-                    {/* fill here means "include this area in the mask" */}
-                    <rect fill="white" width="100" height="100" />
-                    <circle fill="black" cx="50" cy="50" r="30" />
-                    {/* <use> inside <mask> also has masking semantics */}
-                    <use fill="white" xlinkHref="#reusable-shape" />
-                </mask>
-            </defs>
-            <rect width="100" height="100" fill="blue" mask="url(#circle-mask)" />
-        </svg>
-    );
-}
-
 // ❌ Invalid: hardcoded color on PhosphorIcon's color prop
 export function InvalidPhosphorIconExample() {
-    // @ts-expect-error — simplified for demo purposes
-    return <PhosphorIcon color="#3C6D4A" />;
+    return <PhosphorIcon icon={magnifyingGlassIcon} color="#3C6D4A" />;
 }
 
 // Suppress unused variable warnings for the invalid style objects above

--- a/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
@@ -4,7 +4,14 @@ Warn about hardcoded color values in various formats to support theming and dark
 
 ## Rule Details
 
-This rule flags hardcoded color values in Aphrodite `StyleSheet.create()` calls and inline JSX `style` props. Hardcoded colors prevent the UI from adapting to themes (including dark mode) and bypass the Wonder Blocks design system's semantic color layer.
+This rule flags hardcoded color values in:
+
+- Aphrodite `StyleSheet.create()` calls
+- Inline JSX `style` and `styles` props
+- SVG presentation attributes used as JSX props (`fill`, `stroke`, `stopColor`, `floodColor`, `lightingColor`)
+- The `color` prop on WB components such as `PhosphorIcon`
+
+Hardcoded colors prevent the UI from adapting to themes (including dark mode) and bypass the Wonder Blocks design system's semantic color layer.
 
 Use semantic color tokens from `@khanacademy/wonder-blocks-tokens` instead, which resolve to the correct value for the active theme at runtime.
 
@@ -37,6 +44,7 @@ const styles = StyleSheet.create({
         color: "#333333",
         backgroundColor: "rgba(0, 0, 0, 0.5)",
         borderColor: "red",
+        backgroundImage: "linear-gradient(180deg, #b8bdc4 0%, #8b93a0 50%, #717883 100%)",
         boxShadow: "0 2px 4px rgba(0, 0, 0, 0.3)",
     },
 });
@@ -45,6 +53,17 @@ const styles = StyleSheet.create({
 ```tsx
 // Inline style
 <div style={{color: "#fff", backgroundColor: "hsl(200, 100%, 50%)"}} />
+```
+
+```tsx
+// SVG presentation attributes
+<path fill="#ff0000" />
+<circle stroke="blue" />
+```
+
+```tsx
+// PhosphorIcon color prop
+<PhosphorIcon icon={someIcon} color="#3C6D4A" />
 ```
 
 Examples of **correct** code:
@@ -89,4 +108,15 @@ const styles = StyleSheet.create({
         fill: "currentColor",
     },
 });
+```
+
+```tsx
+// SVG presentation attributes accept currentColor, none, or transparent
+<path fill="currentColor" />
+<path fill="none" />
+```
+
+```tsx
+// PhosphorIcon color prop with a semantic token
+<PhosphorIcon icon={someIcon} color={semanticColor.core.foreground.primary} />
 ```

--- a/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
@@ -13,7 +13,7 @@ This rule flags hardcoded color values in:
 
 Hardcoded colors prevent the UI from adapting to themes (including dark mode) and bypass the Wonder Blocks design system's semantic color layer.
 
-Use semantic color tokens from `@khanacademy/wonder-blocks-tokens` instead, which resolve to the correct value for the active theme at runtime.
+Use semantic color tokens from `@khanacademy/wonder-blocks-tokens` instead, which resolve to the correct value for the active theme at runtime. See the [Semantic Colors docs](https://khan.github.io/wonder-blocks/?path=/docs/packages-tokens-semantic-colors-groups--docs) for available tokens.
 
 Detected color formats:
 
@@ -22,17 +22,18 @@ Detected color formats:
 - **HSL / HSLA**: `hsl(120, 100%, 50%)`, `hsla(120, 100%, 50%, 0.3)`
 - **HWB**: `hwb(194 0% 0%)`
 - **CSS Color Level 4 functions**: `color()`, `lab()`, `lch()`, `oklab()`, `oklch()`
-- **CSS named colors**: `red`, `blue`, `white`, `black`, etc.
+- **CSS named colors**: `red`, `blue`, `white`, `black`, `transparent`, etc.
 
 The following CSS keywords are **not** flagged:
 
 | Keyword | Why it's allowed |
 |---|---|
 | `currentColor` | Inherits the computed `color` value from the nearest ancestor. Valid when that ancestor already uses a `semanticColor` token, so the value participates in theming. |
-| `transparent` | Explicitly no color; valid for clearing backgrounds or borders. |
 | `inherit` | Inherits the property value from the parent element. |
 | `initial` | Resets the property to its browser default. |
 | `unset` | Resets the property as if no value had been set. |
+
+> **Note:** `transparent` is flagged. Use `semanticColor.core.transparent` instead so the value participates in theming.
 
 Examples of **incorrect** code:
 
@@ -52,13 +53,14 @@ const styles = StyleSheet.create({
 
 ```tsx
 // Inline style
-<div style={{color: "#fff", backgroundColor: "hsl(200, 100%, 50%)"}} />
+<div style={{color: "#fff", backgroundColor: "transparent"}} />
 ```
 
 ```tsx
 // SVG presentation attributes
 <path fill="#ff0000" />
 <circle stroke="blue" />
+<path fill="transparent" />
 ```
 
 ```tsx
@@ -77,6 +79,8 @@ const styles = StyleSheet.create({
         color: semanticColor.core.foreground.primary,
         backgroundColor: semanticColor.core.background.primary,
         borderColor: semanticColor.core.border.neutral.subtle,
+        // Use semanticColor.core.transparent instead of the "transparent" keyword
+        outlineColor: semanticColor.core.transparent,
     },
 });
 ```
@@ -95,7 +99,6 @@ const styles = StyleSheet.create({
 const styles = StyleSheet.create({
     root: {
         color: "inherit",
-        backgroundColor: "transparent",
     },
 });
 ```
@@ -111,9 +114,18 @@ const styles = StyleSheet.create({
 ```
 
 ```tsx
-// SVG presentation attributes accept currentColor, none, or transparent
+// SVG presentation attributes accept currentColor and none
 <path fill="currentColor" />
 <path fill="none" />
+```
+
+```tsx
+// fill on <mask>, <clipPath>, and <pattern> elements (and their children)
+// controls masking semantics (white = include, black = exclude), not color.
+// These are not flagged.
+<mask fill="white">
+    <use fill="black" xlinkHref="#shape" />
+</mask>
 ```
 
 ```tsx

--- a/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
@@ -13,7 +13,7 @@ This rule flags hardcoded color values in:
 
 Hardcoded colors prevent the UI from adapting to themes (including dark mode) and bypass the Wonder Blocks design system's semantic color layer.
 
-Use semantic color tokens from `@khanacademy/wonder-blocks-tokens` instead, which resolve to the correct value for the active theme at runtime. See the [Semantic Colors docs](https://khan.github.io/wonder-blocks/?path=/docs/packages-tokens-semantic-colors-groups--docs) for available tokens.
+Use semantic color tokens from `@khanacademy/wonder-blocks-tokens` instead, which resolve to the correct value for the active theme at runtime. See the [Semantic Color docs](https://khan.github.io/wonder-blocks/?path=/docs/foundations-using-color--docs) for available tokens.
 
 Detected color formats:
 

--- a/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
@@ -1,0 +1,74 @@
+# no-hardcoded-color
+
+Warn about hardcoded color values in various formats to support theming and dark mode.
+
+## Rule Details
+
+This rule flags hardcoded color values in Aphrodite `StyleSheet.create()` calls and inline JSX `style` props. Hardcoded colors prevent the UI from adapting to themes (including dark mode) and bypass the Wonder Blocks design system's semantic color layer.
+
+Use semantic color tokens from `@khanacademy/wonder-blocks-tokens` instead, which resolve to the correct value for the active theme at runtime.
+
+Detected color formats:
+
+- **Hex**: `#fff`, `#ffffff`, `#ffffffff`
+- **RGB / RGBA**: `rgb(255, 0, 0)`, `rgba(0, 0, 0, 0.5)`
+- **HSL / HSLA**: `hsl(120, 100%, 50%)`, `hsla(120, 100%, 50%, 0.3)`
+- **HWB**: `hwb(194 0% 0%)`
+- **CSS Color Level 4 functions**: `color()`, `lab()`, `lch()`, `oklab()`, `oklch()`
+- **CSS named colors**: `red`, `blue`, `white`, `black`, etc.
+
+CSS keywords `transparent`, `currentColor`, `inherit`, `initial`, and `unset` are **not** flagged, as they are valid values for resetting or inheriting styles.
+
+Examples of **incorrect** code:
+
+```tsx
+import {StyleSheet} from "aphrodite";
+
+const styles = StyleSheet.create({
+    root: {
+        color: "#333333",
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        borderColor: "red",
+        boxShadow: "0 2px 4px rgba(0, 0, 0, 0.3)",
+    },
+});
+```
+
+```tsx
+// Inline style
+<div style={{color: "#fff", backgroundColor: "hsl(200, 100%, 50%)"}} />
+```
+
+Examples of **correct** code:
+
+```tsx
+import {StyleSheet} from "aphrodite";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+
+const styles = StyleSheet.create({
+    root: {
+        color: semanticColor.core.foreground.primary,
+        backgroundColor: semanticColor.core.background.primary,
+        borderColor: semanticColor.core.border.neutral.subtle,
+    },
+});
+```
+
+```tsx
+// CSS custom properties are also allowed
+const styles = StyleSheet.create({
+    root: {
+        color: "var(--wb-color-primary)",
+    },
+});
+```
+
+```tsx
+// CSS keywords for resetting values are allowed
+const styles = StyleSheet.create({
+    root: {
+        color: "inherit",
+        backgroundColor: "transparent",
+    },
+});
+```

--- a/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-hardcoded-color.md
@@ -17,7 +17,15 @@ Detected color formats:
 - **CSS Color Level 4 functions**: `color()`, `lab()`, `lch()`, `oklab()`, `oklch()`
 - **CSS named colors**: `red`, `blue`, `white`, `black`, etc.
 
-CSS keywords `transparent`, `currentColor`, `inherit`, `initial`, and `unset` are **not** flagged, as they are valid values for resetting or inheriting styles.
+The following CSS keywords are **not** flagged:
+
+| Keyword | Why it's allowed |
+|---|---|
+| `currentColor` | Inherits the computed `color` value from the nearest ancestor. Valid when that ancestor already uses a `semanticColor` token, so the value participates in theming. |
+| `transparent` | Explicitly no color; valid for clearing backgrounds or borders. |
+| `inherit` | Inherits the property value from the parent element. |
+| `initial` | Resets the property to its browser default. |
+| `unset` | Resets the property as if no value had been set. |
 
 Examples of **incorrect** code:
 
@@ -64,11 +72,21 @@ const styles = StyleSheet.create({
 ```
 
 ```tsx
-// CSS keywords for resetting values are allowed
+// CSS keywords for resetting or inheriting values are allowed
 const styles = StyleSheet.create({
     root: {
         color: "inherit",
         backgroundColor: "transparent",
+    },
+});
+```
+
+```tsx
+// currentColor is allowed — it inherits the computed color from an ancestor
+// that already uses a semanticColor token, so it participates in theming.
+const styles = StyleSheet.create({
+    icon: {
+        fill: "currentColor",
     },
 });
 ```

--- a/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
@@ -2,16 +2,10 @@ export default {
     plugins: ["@khanacademy/wonder-blocks"],
     rules: {
         "@khanacademy/wonder-blocks/no-invalid-bodytext-children": "error",
-        "@khanacademy/wonder-blocks/require-logical-properties-for-rtl": [
-            "error",
-            {
-                warnDirectionalTransforms: true,
-                warnBackgroundPosition: true,
-                warnShadows: true,
-                warnGradients: true,
-                warnCursorDirections: true,
-                warnBackgroundPositionXY: true,
-            },
-        ],
+        // require-logical-properties-for-rtl is available in the plugin but
+        // intentionally not enabled in the recommended config. It was released
+        // without a timely integration plan for consumers and caused widespread
+        // failures. It will be re-enabled here once a migration path is ready.
+        // To opt in now: "@khanacademy/wonder-blocks/require-logical-properties-for-rtl": "error"
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/strict.ts
@@ -7,5 +7,6 @@ export default {
         "@khanacademy/wonder-blocks/no-custom-tab-role": "error",
         "@khanacademy/wonder-blocks/no-excessive-bodytext-children": "error",
         "@khanacademy/wonder-blocks/no-invalid-bodytext-parent": "error",
+        "@khanacademy/wonder-blocks/no-hardcoded-color": "error",
     },
 };

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
@@ -31,7 +31,6 @@ ruleTester.run(ruleName, rule, {
         {code: `<div style={{color: "currentColor"}} />`},
         {code: `StyleSheet.create({root: {color: "initial"}})`},
         {code: `StyleSheet.create({root: {color: "unset"}})`},
-        {code: `StyleSheet.create({root: {color: "transparent"}})`},
         // CSS custom properties (variables) are allowed
         {
             code: `StyleSheet.create({root: {color: "var(--color-primary)"}})`,
@@ -64,7 +63,11 @@ ruleTester.run(ruleName, rule, {
         // SVG fill with allowed values
         {code: `<path fill="currentColor" />`},
         {code: `<path fill="none" />`},
-        {code: `<path fill="transparent" />`},
+        // SVG paint server reference — url() fragment should not false-positive
+        {code: `<path fill="url(#gradient)" />`},
+        {
+            code: `StyleSheet.create({root: {backgroundImage: "url('icon.svg#abc')"}})`,
+        },
         // color prop with token reference
         {
             code: `<PhosphorIcon color={semanticColor.core.foreground.primary} />`,
@@ -147,7 +150,19 @@ ruleTester.run(ruleName, rule, {
             code: `StyleSheet.create({root: {color: "hwb(194 0% 0%)"}})`,
             errors: [{messageId: "noHardcodedColor"}],
         },
-        // ── Named colors ──────────────────────────────────────────────
+        // ── Named colors (including transparent) ─────────────────────
+        {
+            code: `StyleSheet.create({root: {color: "transparent"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<div style={{backgroundColor: "transparent"}} />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<path fill="transparent" />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
         {
             code: `StyleSheet.create({root: {color: "red"}})`,
             errors: [{messageId: "noHardcodedColor"}],

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
@@ -61,6 +61,18 @@ ruleTester.run(ruleName, rule, {
         },
         // styles prop non-color properties
         {code: `<Tabs styles={{root: {flexGrow: 1}}} />`},
+        // SVG fill with allowed values
+        {code: `<path fill="currentColor" />`},
+        {code: `<path fill="none" />`},
+        {code: `<path fill="transparent" />`},
+        // color prop with token reference
+        {
+            code: `<PhosphorIcon color={semanticColor.core.foreground.primary} />`,
+        },
+        // backgroundImage without hardcoded colors
+        {
+            code: `StyleSheet.create({root: {backgroundImage: "url('foo.png')"}})`,
+        },
     ],
     invalid: [
         // ── Hex colors ────────────────────────────────────────────────
@@ -227,6 +239,49 @@ ruleTester.run(ruleName, rule, {
         },
         {
             code: `<Tabs styles={{root: {boxShadow: "0 2px 4px rgba(0,0,0,0.5)"}}} />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── backgroundImage with hardcoded colors ─────────────────────
+        {
+            code: `StyleSheet.create({root: {backgroundImage: "linear-gradient(180deg, #b8bdc4 0%, #8b93a0 50%, #717883 100%)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── SVG fill/stroke as direct JSX attributes ──────────────────
+        {
+            code: `<path fill="#ff0000" />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<circle fill={"#ff0000"} />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<path fill="red" />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<path stroke="#000" />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<stop stopColor="#ffffff" />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── color prop on WB components (e.g. PhosphorIcon) ───────────
+        {
+            code: `<PhosphorIcon color="#3C6D4A" />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<PhosphorIcon color={"#3C6D4A"} />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<PhosphorIcon color="green" />`,
             errors: [{messageId: "noHardcodedColor"}],
         },
     ],

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
@@ -1,0 +1,195 @@
+import {RuleTester} from "@typescript-eslint/rule-tester";
+
+import {rules} from "..";
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            ecmaVersion: 6,
+            sourceType: "module",
+            ecmaFeatures: {
+                jsx: true,
+            },
+        },
+    },
+});
+
+const ruleName = "no-hardcoded-color";
+const rule = rules[ruleName];
+
+ruleTester.run(ruleName, rule, {
+    valid: [
+        // Non-color properties are not flagged
+        {code: `StyleSheet.create({root: {margin: "10px"}})`},
+        {code: `StyleSheet.create({root: {fontSize: 16}})`},
+        // CSS keywords that are not hardcoded colors
+        {code: `StyleSheet.create({root: {color: "inherit"}})`},
+        {code: `StyleSheet.create({root: {color: "currentColor"}})`},
+        {code: `StyleSheet.create({root: {color: "initial"}})`},
+        {code: `StyleSheet.create({root: {color: "unset"}})`},
+        {code: `StyleSheet.create({root: {color: "transparent"}})`},
+        // CSS custom properties (variables) are allowed
+        {
+            code: `StyleSheet.create({root: {color: "var(--color-primary)"}})`,
+        },
+        {
+            code: `StyleSheet.create({root: {backgroundColor: "var(--wb-color-bg)"}})`,
+        },
+        // Dynamic/expression values (not string literals) are not flagged
+        {code: `StyleSheet.create({root: {color: someToken}})`},
+        {
+            code: `StyleSheet.create({root: {color: semanticColor.core.foreground.primary}})`,
+        },
+        // JSX inline style with token reference
+        {
+            code: `<div style={{color: semanticColor.core.foreground.primary}} />`,
+        },
+        // Non-style JSX attributes are not flagged
+        {code: `<div className="#ff0000" />`},
+        {code: `<div data-color="red" />`},
+        // Empty style object
+        {code: `StyleSheet.create({root: {}})`},
+        // No JSX style
+        {code: `<div />`},
+    ],
+    invalid: [
+        // ── Hex colors ────────────────────────────────────────────────
+        {
+            code: `StyleSheet.create({root: {color: "#fff"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {color: "#ffffff"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {color: "#FFFFFF"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {color: "#ffffffff"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {backgroundColor: "#1a1a1a"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── RGB / RGBA ────────────────────────────────────────────────
+        {
+            code: `StyleSheet.create({root: {color: "rgb(255, 0, 0)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {color: "rgba(0, 0, 0, 0.5)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {backgroundColor: "rgba(255, 255, 255, 0.8)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── HSL / HSLA ────────────────────────────────────────────────
+        {
+            code: `StyleSheet.create({root: {color: "hsl(120, 100%, 50%)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {color: "hsla(120, 100%, 50%, 0.3)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── HWB ──────────────────────────────────────────────────────
+        {
+            code: `StyleSheet.create({root: {color: "hwb(194 0% 0%)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── Named colors ──────────────────────────────────────────────
+        {
+            code: `StyleSheet.create({root: {color: "red"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {color: "blue"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {backgroundColor: "white"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {backgroundColor: "black"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {color: "rebeccapurple"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── Different color properties ────────────────────────────────
+        {
+            code: `StyleSheet.create({root: {borderColor: "#ccc"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {outlineColor: "rgb(0, 120, 212)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {fill: "#000000"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {stroke: "blue"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {caretColor: "#333"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {textDecorationColor: "red"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── Shorthand with embedded color ─────────────────────────────
+        {
+            code: `StyleSheet.create({root: {boxShadow: "0 2px 4px rgba(0, 0, 0, 0.5)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {border: "1px solid #ccc"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `StyleSheet.create({root: {background: "linear-gradient(#fff, #000)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── Nested pseudo-selector objects ────────────────────────────
+        {
+            code: `StyleSheet.create({root: {":hover": {color: "#007bff"}}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── Multiple violations in one block ──────────────────────────
+        {
+            code: `StyleSheet.create({root: {color: "#fff", backgroundColor: "#000"}})`,
+            errors: [
+                {messageId: "noHardcodedColor"},
+                {messageId: "noHardcodedColor"},
+            ],
+        },
+        // ── Inline JSX style prop ─────────────────────────────────────
+        {
+            code: `<div style={{color: "#fff"}} />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<div style={{backgroundColor: "rgba(0,0,0,0.5)"}} />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `<div style={{color: "red"}} />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── Template literal (no interpolations) ─────────────────────
+        {
+            code: "StyleSheet.create({root: {color: `#fff`}})",
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+    ],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
@@ -24,7 +24,11 @@ ruleTester.run(ruleName, rule, {
         {code: `StyleSheet.create({root: {fontSize: 16}})`},
         // CSS keywords that are not hardcoded colors
         {code: `StyleSheet.create({root: {color: "inherit"}})`},
+        // currentColor is valid: it inherits from an ancestor that already
+        // uses a semanticColor token, so it participates in theming.
         {code: `StyleSheet.create({root: {color: "currentColor"}})`},
+        {code: `StyleSheet.create({root: {fill: "currentColor"}})`},
+        {code: `<div style={{color: "currentColor"}} />`},
         {code: `StyleSheet.create({root: {color: "initial"}})`},
         {code: `StyleSheet.create({root: {color: "unset"}})`},
         {code: `StyleSheet.create({root: {color: "transparent"}})`},
@@ -51,6 +55,12 @@ ruleTester.run(ruleName, rule, {
         {code: `StyleSheet.create({root: {}})`},
         // No JSX style
         {code: `<div />`},
+        // styles prop with token values
+        {
+            code: `<Tabs styles={{root: {color: semanticColor.core.foreground.neutral.strong}}} />`,
+        },
+        // styles prop non-color properties
+        {code: `<Tabs styles={{root: {flexGrow: 1}}} />`},
     ],
     invalid: [
         // ── Hex colors ────────────────────────────────────────────────
@@ -189,6 +199,34 @@ ruleTester.run(ruleName, rule, {
         // ── Template literal (no interpolations) ─────────────────────
         {
             code: "StyleSheet.create({root: {color: `#fff`}})",
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── WB multi-part styles prop (JSX attribute) ─────────────────
+        {
+            code: `<Tabs styles={{root: {border: "2px solid lightpink"}}} />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── WB multi-part styles as plain object property (e.g. Storybook args)
+        {
+            code: `const story = {args: {styles: {root: {color: "red"}}}}`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        {
+            code: `const story = {args: {styles: {root: {backgroundColor: "#fff"}, tab: {borderColor: "blue"}}}}`,
+            errors: [
+                {messageId: "noHardcodedColor"},
+                {messageId: "noHardcodedColor"},
+            ],
+        },
+        {
+            code: `<Tabs styles={{tablist: {backgroundColor: "lavender"}, tab: {backgroundColor: "#fff"}}} />`,
+            errors: [
+                {messageId: "noHardcodedColor"},
+                {messageId: "noHardcodedColor"},
+            ],
+        },
+        {
+            code: `<Tabs styles={{root: {boxShadow: "0 2px 4px rgba(0,0,0,0.5)"}}} />`,
             errors: [{messageId: "noHardcodedColor"}],
         },
     ],

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
@@ -63,10 +63,21 @@ ruleTester.run(ruleName, rule, {
         // SVG fill with allowed values
         {code: `<path fill="currentColor" />`},
         {code: `<path fill="none" />`},
-        // SVG paint server reference — url() fragment should not false-positive
+        // SVG paint server reference — url() fragment should not false-positive.
+        // The hex regex would match #abc, #face, #1a2b3c if not stripped first.
         {code: `<path fill="url(#gradient)" />`},
+        {code: `<path fill="url(#face)" />`},
+        // 6-char hex-like fragment in a paint server id
+        {code: `<path fill="url(#1a2b3c)" />`},
+        // url() in a CSS property (fill as style object key)
+        {code: `StyleSheet.create({root: {fill: "url(#gradient)"}})`},
+        // Image URL with a hex-like fragment identifier
         {
             code: `StyleSheet.create({root: {backgroundImage: "url('icon.svg#abc')"}})`,
+        },
+        // Image URL whose path contains a word that is also a named color
+        {
+            code: `StyleSheet.create({root: {backgroundImage: "url('/images/red-button.png')"}})`,
         },
         // color prop with token reference
         {
@@ -98,6 +109,18 @@ ruleTester.run(ruleName, rule, {
                     <mask id="m"><use xlinkHref="#p" /></mask>
                     <use id="Mask" fill={semanticColor.background} xlinkHref="#p" />
                 </g>
+            `,
+        },
+        // An element with mask="url(...)" consumes the mask but is not inside
+        // it. Its fill is a real visible color — confirmed valid here because it
+        // uses a semantic token. The rule must not confuse mask="url(#m)" (an
+        // attribute) with being a descendant of a <mask> element.
+        {
+            code: `
+                <svg>
+                    <defs><mask id="m"><rect fill="white" /></mask></defs>
+                    <rect fill={semanticColor.bg} mask="url(#m)" />
+                </svg>
             `,
         },
     ],
@@ -289,6 +312,11 @@ ruleTester.run(ruleName, rule, {
             code: `StyleSheet.create({root: {backgroundImage: "linear-gradient(45deg, #ccc 25%, transparent 25%)"}})`,
             errors: [{messageId: "noHardcodedColor"}],
         },
+        // url() stripped but a real hardcoded color in the same value must still fire
+        {
+            code: `StyleSheet.create({root: {backgroundImage: "url('mask.svg'), linear-gradient(#fff, #000)"}})`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
         // ── SVG fill/stroke as direct JSX attributes ──────────────────
         {
             code: `<path fill="#ff0000" />`,
@@ -310,7 +338,7 @@ ruleTester.run(ruleName, rule, {
             code: `<stop stopColor="#ffffff" />`,
             errors: [{messageId: "noHardcodedColor"}],
         },
-        // ── <use> sibling of <mask> with hardcoded fill ───────────────
+        // ── siblings and consumers of <mask> with hardcoded fill ────────
         // <use id="Mask" fill="#1865F2"> is a sibling, not a child, of <mask>.
         // Its fill is a real visible color and must be flagged.
         {
@@ -319,6 +347,19 @@ ruleTester.run(ruleName, rule, {
                     <mask id="m"><use xlinkHref="#p" /></mask>
                     <use id="Mask" fill="#1865F2" xlinkHref="#p" />
                 </g>
+            `,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // <rect mask="url(#m)"> references the mask via an attribute but is not
+        // inside it. Its fill is a real visible color — the exact case from the
+        // ValidSvgMaskExample review comment where fill="blue" was incorrectly
+        // labelled as valid.
+        {
+            code: `
+                <svg>
+                    <defs><mask id="m"><rect fill="white" /></mask></defs>
+                    <rect fill="blue" mask="url(#m)" />
+                </svg>
             `,
             errors: [{messageId: "noHardcodedColor"}],
         },

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-hardcoded-color.test.ts
@@ -73,6 +73,30 @@ ruleTester.run(ruleName, rule, {
         {
             code: `StyleSheet.create({root: {backgroundImage: "url('foo.png')"}})`,
         },
+        // fill on mask/clipPath/pattern controls masking semantics, not color
+        {code: `<mask fill="white"><rect /></mask>`},
+        {code: `<mask fill="black"><rect /></mask>`},
+        {code: `<mask fill="#fff"><rect /></mask>`},
+        {code: `<clipPath fill="white"><rect /></clipPath>`},
+        {code: `<pattern fill="black"><rect /></pattern>`},
+        // fill on children inside mask/clipPath/pattern also has masking semantics
+        {code: `<mask><use fill="white" xlinkHref="#p" /></mask>`},
+        {code: `<mask><use fill="black" xlinkHref="#p" /></mask>`},
+        {code: `<mask><use fill="#fff" xlinkHref="#p" /></mask>`},
+        {code: `<clipPath><use fill="white" xlinkHref="#p" /></clipPath>`},
+        // <use> that is a sibling of <mask> (not inside it) still uses masking
+        // semantics when it replicates the masked shape — but only the <use>
+        // inside <mask> is excluded; the sibling <use> has a real color fill
+        // and must use a semantic token. This test confirms the ancestor check
+        // does NOT skip siblings.
+        {
+            code: `
+                <g>
+                    <mask id="m"><use xlinkHref="#p" /></mask>
+                    <use id="Mask" fill={semanticColor.background} xlinkHref="#p" />
+                </g>
+            `,
+        },
     ],
     invalid: [
         // ── Hex colors ────────────────────────────────────────────────
@@ -269,6 +293,18 @@ ruleTester.run(ruleName, rule, {
         },
         {
             code: `<stop stopColor="#ffffff" />`,
+            errors: [{messageId: "noHardcodedColor"}],
+        },
+        // ── <use> sibling of <mask> with hardcoded fill ───────────────
+        // <use id="Mask" fill="#1865F2"> is a sibling, not a child, of <mask>.
+        // Its fill is a real visible color and must be flagged.
+        {
+            code: `
+                <g>
+                    <mask id="m"><use xlinkHref="#p" /></mask>
+                    <use id="Mask" fill="#1865F2" xlinkHref="#p" />
+                </g>
+            `,
             errors: [{messageId: "noHardcodedColor"}],
         },
         // ── color prop on WB components (e.g. PhosphorIcon) ───────────

--- a/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
@@ -2,6 +2,7 @@ import {TSESLint} from "@typescript-eslint/utils";
 
 import noCustomTabRole from "./no-custom-tab-role";
 import noExcessiveBodyTextChildren from "./no-excessive-bodytext-children";
+import noHardcodedColor from "./no-hardcoded-color";
 import noInvalidBodyTextChildren from "./no-invalid-bodytext-children";
 import noInvalidBodyTextParent from "./no-invalid-bodytext-parent";
 import requireLogicalPropertiesForRtl from "./require-logical-properties-for-rtl";
@@ -9,6 +10,7 @@ import requireLogicalPropertiesForRtl from "./require-logical-properties-for-rtl
 const rules: Record<string, TSESLint.RuleModule<string, readonly unknown[]>> = {
     "no-custom-tab-role": noCustomTabRole,
     "no-excessive-bodytext-children": noExcessiveBodyTextChildren,
+    "no-hardcoded-color": noHardcodedColor,
     "no-invalid-bodytext-children": noInvalidBodyTextChildren,
     "no-invalid-bodytext-parent": noInvalidBodyTextParent,
     "require-logical-properties-for-rtl": requireLogicalPropertiesForRtl,

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
@@ -12,6 +12,17 @@ const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
 type Options = [];
 type MessageIds = "noHardcodedColor";
 
+// SVG presentation attributes (and WB color props like PhosphorIcon's `color`)
+// used directly as JSX attributes — not inside a style object.
+const JSX_COLOR_ATTR_NAMES = new Set([
+    "fill",
+    "stroke",
+    "stopColor",
+    "floodColor",
+    "lightingColor",
+    "color",
+]);
+
 // CSS properties that accept color values (camelCase).
 const COLOR_PROPERTIES = new Set([
     // Text & foreground
@@ -21,6 +32,7 @@ const COLOR_PROPERTIES = new Set([
     // Backgrounds
     "background",
     "backgroundColor",
+    "backgroundImage",
     // Borders
     "border",
     "borderColor",
@@ -357,13 +369,43 @@ export default createRule<Options, MessageIds>({
         return {
             // Inline style prop: style={{color: "#fff"}}
             // Multi-part styles prop: styles={{root: {color: "#fff"}, tab: {...}}}
+            // SVG/WB color attrs: fill="#fff", color="#3C6D4A"
             JSXAttribute(node) {
                 if (node.name.type !== "JSXIdentifier") {
                     return;
                 }
                 const propName = node.name.name;
                 const propValue = node.value;
-                if (!propValue || propValue.type !== "JSXExpressionContainer") {
+                if (!propValue) {
+                    return;
+                }
+
+                // Direct JSX color attributes: fill="red", color="#fff", etc.
+                // These can be plain string literals OR expression containers.
+                if (JSX_COLOR_ATTR_NAMES.has(propName)) {
+                    let strVal: string | null = null;
+                    if (
+                        propValue.type === "Literal" &&
+                        typeof propValue.value === "string"
+                    ) {
+                        strVal = propValue.value;
+                    } else if (
+                        propValue.type === "JSXExpressionContainer" &&
+                        propValue.expression.type !== "JSXEmptyExpression"
+                    ) {
+                        strVal = getStringValue(propValue.expression);
+                    }
+                    if (strVal !== null && containsHardcodedColor(strVal)) {
+                        context.report({
+                            node: propValue,
+                            messageId: "noHardcodedColor",
+                            data: {value: strVal},
+                        });
+                    }
+                    return;
+                }
+
+                if (propValue.type !== "JSXExpressionContainer") {
                     return;
                 }
                 if (propValue.expression.type === "JSXEmptyExpression") {

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
@@ -23,6 +23,11 @@ const JSX_COLOR_ATTR_NAMES = new Set([
     "color",
 ]);
 
+// SVG structural elements where `fill` controls masking/clipping semantics
+// (white = include, black = exclude) rather than a visible color.
+// Flagging these would produce false positives — the values must not change.
+const SVG_MASK_ELEMENTS = new Set(["mask", "clipPath", "pattern"]);
+
 // CSS properties that accept color values (camelCase).
 const COLOR_PROPERTIES = new Set([
     // Text & foreground
@@ -383,6 +388,36 @@ export default createRule<Options, MessageIds>({
                 // Direct JSX color attributes: fill="red", color="#fff", etc.
                 // These can be plain string literals OR expression containers.
                 if (JSX_COLOR_ATTR_NAMES.has(propName)) {
+                    // Skip elements whose fill controls masking semantics
+                    // (white=include, black=exclude) rather than visible color:
+                    // - The element itself is mask/clipPath/pattern
+                    // - OR any JSX ancestor is mask/clipPath/pattern (e.g.
+                    //   <mask><use fill="white" /></mask> — the <use> inherits
+                    //   the masking context and its fill is also non-color)
+                    const openingEl = node.parent;
+                    if (
+                        openingEl.type === "JSXOpeningElement" &&
+                        openingEl.name.type === "JSXIdentifier" &&
+                        SVG_MASK_ELEMENTS.has(openingEl.name.name)
+                    ) {
+                        return;
+                    }
+                    let ancestor: TSESTree.Node | undefined =
+                        node.parent.parent;
+                    while (ancestor) {
+                        if (
+                            ancestor.type === "JSXElement" &&
+                            ancestor.openingElement.name.type ===
+                                "JSXIdentifier" &&
+                            SVG_MASK_ELEMENTS.has(
+                                ancestor.openingElement.name.name,
+                            )
+                        ) {
+                            return;
+                        }
+                        ancestor = ancestor.parent;
+                    }
+
                     let strVal: string | null = null;
                     if (
                         propValue.type === "Literal" &&

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
@@ -1,0 +1,399 @@
+import {ESLintUtils} from "@typescript-eslint/utils";
+
+import type {TSESTree} from "@typescript-eslint/utils";
+
+import type {WonderBlocksPluginDocs} from "../types";
+
+const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
+    (name) =>
+        `https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/${name}.md`,
+);
+
+type Options = [];
+type MessageIds = "noHardcodedColor";
+
+// CSS properties that accept color values (camelCase).
+const COLOR_PROPERTIES = new Set([
+    // Text & foreground
+    "color",
+    "caretColor",
+    "accentColor",
+    // Backgrounds
+    "background",
+    "backgroundColor",
+    // Borders
+    "border",
+    "borderColor",
+    "borderTopColor",
+    "borderRightColor",
+    "borderBottomColor",
+    "borderLeftColor",
+    "borderInlineColor",
+    "borderInlineStartColor",
+    "borderInlineEndColor",
+    "borderBlockColor",
+    "borderBlockStartColor",
+    "borderBlockEndColor",
+    "borderTop",
+    "borderRight",
+    "borderBottom",
+    "borderLeft",
+    "borderInline",
+    "borderInlineStart",
+    "borderInlineEnd",
+    "borderBlock",
+    "borderBlockStart",
+    "borderBlockEnd",
+    // Outline
+    "outline",
+    "outlineColor",
+    // Text decorations
+    "textDecorationColor",
+    "textEmphasisColor",
+    // Multi-column
+    "columnRuleColor",
+    "columnRule",
+    // Shadows (color embedded in shorthand value)
+    "boxShadow",
+    "textShadow",
+    // SVG presentation attributes
+    "fill",
+    "stroke",
+    "stopColor",
+    "floodColor",
+    "lightingColor",
+]);
+
+// Full CSS named color list (excluding transparent/currentColor/inherit/initial/unset
+// which are valid CSS keywords for resetting or inheriting values).
+const CSS_NAMED_COLORS = [
+    "aliceblue",
+    "antiquewhite",
+    "aqua",
+    "aquamarine",
+    "azure",
+    "beige",
+    "bisque",
+    "black",
+    "blanchedalmond",
+    "blue",
+    "blueviolet",
+    "brown",
+    "burlywood",
+    "cadetblue",
+    "chartreuse",
+    "chocolate",
+    "coral",
+    "cornflowerblue",
+    "cornsilk",
+    "crimson",
+    "cyan",
+    "darkblue",
+    "darkcyan",
+    "darkgoldenrod",
+    "darkgray",
+    "darkgreen",
+    "darkgrey",
+    "darkkhaki",
+    "darkmagenta",
+    "darkolivegreen",
+    "darkorange",
+    "darkorchid",
+    "darkred",
+    "darksalmon",
+    "darkseagreen",
+    "darkslateblue",
+    "darkslategray",
+    "darkslategrey",
+    "darkturquoise",
+    "darkviolet",
+    "deeppink",
+    "deepskyblue",
+    "dimgray",
+    "dimgrey",
+    "dodgerblue",
+    "firebrick",
+    "floralwhite",
+    "forestgreen",
+    "fuchsia",
+    "gainsboro",
+    "ghostwhite",
+    "gold",
+    "goldenrod",
+    "gray",
+    "green",
+    "greenyellow",
+    "grey",
+    "honeydew",
+    "hotpink",
+    "indianred",
+    "indigo",
+    "ivory",
+    "khaki",
+    "lavender",
+    "lavenderblush",
+    "lawngreen",
+    "lemonchiffon",
+    "lightblue",
+    "lightcoral",
+    "lightcyan",
+    "lightgoldenrodyellow",
+    "lightgray",
+    "lightgreen",
+    "lightgrey",
+    "lightpink",
+    "lightsalmon",
+    "lightseagreen",
+    "lightskyblue",
+    "lightslategray",
+    "lightslategrey",
+    "lightsteelblue",
+    "lightyellow",
+    "lime",
+    "limegreen",
+    "linen",
+    "magenta",
+    "maroon",
+    "mediumaquamarine",
+    "mediumblue",
+    "mediumorchid",
+    "mediumpurple",
+    "mediumseagreen",
+    "mediumslateblue",
+    "mediumspringgreen",
+    "mediumturquoise",
+    "mediumvioletred",
+    "midnightblue",
+    "mintcream",
+    "mistyrose",
+    "moccasin",
+    "navajowhite",
+    "navy",
+    "oldlace",
+    "olive",
+    "olivedrab",
+    "orange",
+    "orangered",
+    "orchid",
+    "palegoldenrod",
+    "palegreen",
+    "paleturquoise",
+    "palevioletred",
+    "papayawhip",
+    "peachpuff",
+    "peru",
+    "pink",
+    "plum",
+    "powderblue",
+    "purple",
+    "rebeccapurple",
+    "red",
+    "rosybrown",
+    "royalblue",
+    "saddlebrown",
+    "salmon",
+    "sandybrown",
+    "seagreen",
+    "seashell",
+    "sienna",
+    "silver",
+    "skyblue",
+    "slateblue",
+    "slategray",
+    "slategrey",
+    "snow",
+    "springgreen",
+    "steelblue",
+    "tan",
+    "teal",
+    "thistle",
+    "tomato",
+    "turquoise",
+    "violet",
+    "wheat",
+    "white",
+    "whitesmoke",
+    "yellow",
+    "yellowgreen",
+];
+
+// Single regex built once from the full named-color list.
+const NAMED_COLOR_RE = new RegExp(
+    `(?:^|[\\s,(])(?:${CSS_NAMED_COLORS.join("|")})(?=$|[\\s,);])`,
+    "i",
+);
+
+// Ordered list of patterns to test against a CSS value string.
+const COLOR_VALUE_PATTERNS: ReadonlyArray<RegExp> = [
+    // Hex: #rgb, #rgba, #rrggbb, #rrggbbaa
+    /#[0-9a-fA-F]{3,8}(?![0-9a-fA-F])/,
+    // Functional notations
+    /\brgba?\s*\(/i,
+    /\bhsla?\s*\(/i,
+    /\bhwb\s*\(/i,
+    /\bcolor\s*\(/i,
+    // CSS Color Level 4 functions
+    /\b(?:ok)?(?:lab|lch)\s*\(/i,
+    // Named colors
+    NAMED_COLOR_RE,
+];
+
+function containsHardcodedColor(value: string): boolean {
+    return COLOR_VALUE_PATTERNS.some((re) => re.test(value));
+}
+
+function getStringValue(node: TSESTree.Node | null | undefined): string | null {
+    if (!node) {
+        return null;
+    }
+    if (node.type === "Literal" && typeof node.value === "string") {
+        return node.value;
+    }
+    if (node.type === "TemplateLiteral" && node.expressions.length === 0) {
+        return node.quasis.map((q) => q.value.cooked ?? "").join("");
+    }
+    return null;
+}
+
+function getKeyName(property: TSESTree.Property): string | null {
+    if (property.method || property.kind !== "init") {
+        return null;
+    }
+    if (property.key.type === "Identifier") {
+        return property.key.name;
+    }
+    if (
+        property.key.type === "Literal" &&
+        typeof property.key.value === "string"
+    ) {
+        return property.key.value;
+    }
+    return null;
+}
+
+export default createRule<Options, MessageIds>({
+    name: "no-hardcoded-color",
+    meta: {
+        docs: {
+            description:
+                "Disallow hardcoded color values to better support theming. Use semanticColor instead.",
+            recommended: true,
+        },
+        messages: {
+            noHardcodedColor:
+                "Avoid hardcoded color value '{{value}}'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode.",
+        },
+        schema: [],
+        type: "suggestion",
+    },
+    create(context) {
+        function checkProperties(
+            properties: Array<TSESTree.ObjectLiteralElement>,
+        ) {
+            for (const property of properties) {
+                if (property.type !== "Property") {
+                    continue;
+                }
+                if (property.method) {
+                    continue;
+                }
+
+                const keyName = getKeyName(property);
+
+                if (keyName && COLOR_PROPERTIES.has(keyName)) {
+                    const strVal = getStringValue(property.value);
+                    if (strVal !== null && containsHardcodedColor(strVal)) {
+                        context.report({
+                            node: property.value,
+                            messageId: "noHardcodedColor",
+                            data: {value: strVal},
+                        });
+                    }
+                }
+
+                // Recurse into nested objects (e.g. pseudo-selector keys like
+                // ":hover" or media query keys).
+                if (property.value.type === "ObjectExpression") {
+                    checkProperties(property.value.properties);
+                }
+            }
+        }
+
+        function handleStyleExpression(expr: TSESTree.Expression) {
+            if (expr.type === "ObjectExpression") {
+                checkProperties(expr.properties);
+                return;
+            }
+            if (expr.type === "ArrayExpression") {
+                for (const el of expr.elements) {
+                    if (!el) {
+                        continue;
+                    }
+                    if (el.type === "ObjectExpression") {
+                        checkProperties(el.properties);
+                    } else if (el.type === "ConditionalExpression") {
+                        if (el.consequent.type === "ObjectExpression") {
+                            checkProperties(el.consequent.properties);
+                        }
+                        if (el.alternate.type === "ObjectExpression") {
+                            checkProperties(el.alternate.properties);
+                        }
+                    } else if (
+                        el.type === "LogicalExpression" &&
+                        el.operator === "&&"
+                    ) {
+                        if (el.right.type === "ObjectExpression") {
+                            checkProperties(el.right.properties);
+                        }
+                    }
+                }
+            }
+        }
+
+        return {
+            // Inline style prop: style={{color: "#fff"}}
+            JSXAttribute(node) {
+                if (
+                    node.name.type !== "JSXIdentifier" ||
+                    node.name.name !== "style"
+                ) {
+                    return;
+                }
+                const styleValue = node.value;
+                if (
+                    !styleValue ||
+                    styleValue.type !== "JSXExpressionContainer"
+                ) {
+                    return;
+                }
+                if (styleValue.expression.type === "JSXEmptyExpression") {
+                    return;
+                }
+                handleStyleExpression(styleValue.expression);
+            },
+            // Aphrodite StyleSheet.create({...})
+            CallExpression(node) {
+                if (
+                    node.callee.type === "MemberExpression" &&
+                    node.callee.object.type === "Identifier" &&
+                    node.callee.object.name === "StyleSheet" &&
+                    node.callee.property.type === "Identifier" &&
+                    node.callee.property.name === "create"
+                ) {
+                    const stylesObject = node.arguments[0];
+                    if (stylesObject?.type === "ObjectExpression") {
+                        for (const styleProperty of stylesObject.properties) {
+                            if (
+                                styleProperty.type === "Property" &&
+                                styleProperty.value.type === "ObjectExpression"
+                            ) {
+                                checkProperties(styleProperty.value.properties);
+                            }
+                        }
+                    }
+                }
+            },
+        };
+    },
+    defaultOptions: [],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
@@ -308,7 +308,7 @@ export default createRule<Options, MessageIds>({
         },
         messages: {
             noHardcodedColor:
-                "Avoid hardcoded color value '{{value}}'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode. See https://khan.github.io/wonder-blocks/?path=/docs/packages-tokens-semantic-colors-groups--docs for available tokens.",
+                "Avoid hardcoded color value '{{value}}'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode. See https://khan.github.io/wonder-blocks/?path=/docs/foundations-using-color--docs for available tokens.",
         },
         schema: [],
         type: "suggestion",

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
@@ -64,8 +64,12 @@ const COLOR_PROPERTIES = new Set([
     "lightingColor",
 ]);
 
-// Full CSS named color list (excluding transparent/currentColor/inherit/initial/unset
-// which are valid CSS keywords for resetting or inheriting values).
+// Full CSS named color list (excluding the following CSS keywords, which are
+// valid for resetting or inheriting values and are intentionally not flagged):
+//   transparent  — explicitly no color; valid for clearing backgrounds/borders
+//   currentColor — inherits the nearest ancestor's color; valid when that
+//                  ancestor already uses a semanticColor token
+//   inherit / initial / unset / revert — CSS-wide keywords
 const CSS_NAMED_COLORS = [
     "aliceblue",
     "antiquewhite",
@@ -352,24 +356,36 @@ export default createRule<Options, MessageIds>({
 
         return {
             // Inline style prop: style={{color: "#fff"}}
+            // Multi-part styles prop: styles={{root: {color: "#fff"}, tab: {...}}}
             JSXAttribute(node) {
-                if (
-                    node.name.type !== "JSXIdentifier" ||
-                    node.name.name !== "style"
-                ) {
+                if (node.name.type !== "JSXIdentifier") {
                     return;
                 }
-                const styleValue = node.value;
-                if (
-                    !styleValue ||
-                    styleValue.type !== "JSXExpressionContainer"
-                ) {
+                const propName = node.name.name;
+                const propValue = node.value;
+                if (!propValue || propValue.type !== "JSXExpressionContainer") {
                     return;
                 }
-                if (styleValue.expression.type === "JSXEmptyExpression") {
+                if (propValue.expression.type === "JSXEmptyExpression") {
                     return;
                 }
-                handleStyleExpression(styleValue.expression);
+
+                if (propName === "style") {
+                    handleStyleExpression(propValue.expression);
+                } else if (propName === "styles") {
+                    // The `styles` prop used by WB components maps part names
+                    // to style objects: styles={{ root: {...}, tab: {...} }}
+                    const expr = propValue.expression;
+                    if (expr.type === "ObjectExpression") {
+                        for (const property of expr.properties) {
+                            if (property.type === "Property") {
+                                handleStyleExpression(
+                                    property.value as TSESTree.Expression,
+                                );
+                            }
+                        }
+                    }
+                }
             },
             // Aphrodite StyleSheet.create({...})
             CallExpression(node) {
@@ -390,6 +406,24 @@ export default createRule<Options, MessageIds>({
                                 checkProperties(styleProperty.value.properties);
                             }
                         }
+                    }
+                }
+            },
+            // Object property named "styles" with a multi-part value:
+            //   args: { styles: { root: { color: "#fff" } } }
+            // This covers Storybook args and any other non-JSX usage of the
+            // WB multi-part styles pattern.
+            "Property[key.name='styles'], Property[key.value='styles']"(
+                node: TSESTree.Property,
+            ) {
+                if (node.value.type !== "ObjectExpression") {
+                    return;
+                }
+                for (const property of node.value.properties) {
+                    if (property.type === "Property") {
+                        handleStyleExpression(
+                            property.value as TSESTree.Expression,
+                        );
                     }
                 }
             },

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-hardcoded-color.ts
@@ -81,12 +81,13 @@ const COLOR_PROPERTIES = new Set([
     "lightingColor",
 ]);
 
-// Full CSS named color list (excluding the following CSS keywords, which are
-// valid for resetting or inheriting values and are intentionally not flagged):
-//   transparent  — explicitly no color; valid for clearing backgrounds/borders
+// Full CSS named color list (including `transparent`).
+// The following CSS keywords are intentionally NOT flagged:
 //   currentColor — inherits the nearest ancestor's color; valid when that
 //                  ancestor already uses a semanticColor token
 //   inherit / initial / unset / revert — CSS-wide keywords
+// `transparent` IS flagged: use semanticColor.core.transparent instead so
+// the value participates in theming.
 const CSS_NAMED_COLORS = [
     "aliceblue",
     "antiquewhite",
@@ -227,6 +228,7 @@ const CSS_NAMED_COLORS = [
     "steelblue",
     "tan",
     "teal",
+    "transparent",
     "thistle",
     "tomato",
     "turquoise",
@@ -260,7 +262,11 @@ const COLOR_VALUE_PATTERNS: ReadonlyArray<RegExp> = [
 ];
 
 function containsHardcodedColor(value: string): boolean {
-    return COLOR_VALUE_PATTERNS.some((re) => re.test(value));
+    // Strip url(...) substrings first: fragment identifiers in SVG paint
+    // references (fill: "url(#gradient)") and image URLs may contain
+    // hex-like sequences that would otherwise false-positive.
+    const stripped = value.replace(/url\([^)]*\)/gi, "");
+    return COLOR_VALUE_PATTERNS.some((re) => re.test(stripped));
 }
 
 function getStringValue(node: TSESTree.Node | null | undefined): string | null {
@@ -302,7 +308,7 @@ export default createRule<Options, MessageIds>({
         },
         messages: {
             noHardcodedColor:
-                "Avoid hardcoded color value '{{value}}'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode.",
+                "Avoid hardcoded color value '{{value}}'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode. See https://khan.github.io/wonder-blocks/?path=/docs/packages-tokens-semantic-colors-groups--docs for available tokens.",
         },
         schema: [],
         type: "suggestion",

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -341,7 +341,7 @@ const styles = StyleSheet.create({
         width: "auto",
         overflow: "visible",
 
-        background: "transparent",
+        background: semanticColor.core.transparent,
         textDecoration: "none",
 
         /* inherit font & color from ancestor */

--- a/packages/wonder-blocks-core/src/components/__tests__/text.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/text.test.tsx
@@ -14,29 +14,12 @@ describe("Text", () => {
         expect(ref.current).toBeInstanceOf(HTMLSpanElement);
     });
 
-    test("applies style to the text wrapper", () => {
-        // Arrange
-        // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
-        render(<Text style={{color: "red"}}>Text</Text>);
-
-        // Act
-        const wrapper = screen.getByText("Text");
-
-        // Assert
-        expect(wrapper).toHaveStyle({color: "red"});
-    });
-
     test("appends the className prop to the element's class list", () => {
         // Arrange
         const className = "some-class";
 
         // Act
-        render(
-            // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
-            <Text style={{color: "red"}} className={className}>
-                Text
-            </Text>,
-        );
+        render(<Text className={className}>Text</Text>);
 
         const wrapper = screen.getByText("Text");
 

--- a/packages/wonder-blocks-core/src/components/__tests__/text.test.tsx
+++ b/packages/wonder-blocks-core/src/components/__tests__/text.test.tsx
@@ -16,6 +16,7 @@ describe("Text", () => {
 
     test("applies style to the text wrapper", () => {
         // Arrange
+        // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
         render(<Text style={{color: "red"}}>Text</Text>);
 
         // Act
@@ -31,6 +32,7 @@ describe("Text", () => {
 
         // Act
         render(
+            // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
             <Text style={{color: "red"}} className={className}>
                 Text
             </Text>,

--- a/packages/wonder-blocks-core/src/util/add-styles.typestest.tsx
+++ b/packages/wonder-blocks-core/src/util/add-styles.typestest.tsx
@@ -8,6 +8,7 @@ const styles = StyleSheet.create({
         padding: 8,
     },
     customList: {
+        // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
         border: "solid 1px blue",
     },
 });

--- a/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/field-heading.test.tsx
@@ -158,6 +158,7 @@ describe("FieldHeading", () => {
         const styles = StyleSheet.create({
             style1: {
                 flexGrow: 1,
+                // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
                 background: "blue",
             },
         });

--- a/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
+++ b/packages/wonder-blocks-form/src/components/__tests__/labeled-text-field.test.tsx
@@ -401,6 +401,7 @@ describe("LabeledTextField", () => {
         const styles = StyleSheet.create({
             style1: {
                 minInlineSize: 250,
+                // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color
                 background: "blue",
             },
         });

--- a/packages/wonder-blocks-icon/src/components/__tests__/phosphor-icon.typestest.tsx
+++ b/packages/wonder-blocks-icon/src/components/__tests__/phosphor-icon.typestest.tsx
@@ -6,16 +6,16 @@ import PlusCircleFill from "@phosphor-icons/core/fill/plus-circle-fill.svg";
 import {PhosphorIcon} from "../phosphor-icon";
 
 // Valid: small + bold
-<PhosphorIcon icon={PlusCircleBold} size="small" color="green" />;
+<PhosphorIcon icon={PlusCircleBold} size="small" color="currentColor" />;
 
 // Valid: medium + regular
-<PhosphorIcon icon={PlusCircleRegular} size="medium" color="green" />;
+<PhosphorIcon icon={PlusCircleRegular} size="medium" color="currentColor" />;
 
 // Valid: large + fill
-<PhosphorIcon icon={PlusCircleFill} size="large" color="green" />;
+<PhosphorIcon icon={PlusCircleFill} size="large" color="currentColor" />;
 
 // Valid: small + regular
-<PhosphorIcon icon={PlusCircleRegular} size="small" color="green" />;
+<PhosphorIcon icon={PlusCircleRegular} size="small" color="currentColor" />;
 
 // Valid: medium + bold
-<PhosphorIcon icon={PlusCircleBold} size="medium" color="green" />;
+<PhosphorIcon icon={PlusCircleBold} size="medium" color="currentColor" />;

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.tsx
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.tsx
@@ -1,3 +1,7 @@
+/* eslint-disable @khanacademy/wonder-blocks/no-hardcoded-color */
+// Hardcoded colors here are test fixtures used to assert which stylesheet wins
+// across breakpoints. jsdom does not resolve CSS custom properties, so
+// semanticColor tokens cannot be used for these assertions.
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {View} from "@khanacademy/wonder-blocks-core";

--- a/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.tsx
+++ b/packages/wonder-blocks-layout/src/components/__tests__/media-layout.test.tsx
@@ -1,7 +1,4 @@
-/* eslint-disable @khanacademy/wonder-blocks/no-hardcoded-color */
-// Hardcoded colors here are test fixtures used to assert which stylesheet wins
-// across breakpoints. jsdom does not resolve CSS custom properties, so
-// semanticColor tokens cannot be used for these assertions.
+/* eslint-disable @khanacademy/wonder-blocks/no-hardcoded-color -- Hardcoded colors here are test fixtures used to assert which stylesheet wins across breakpoints. jsdom does not resolve CSS custom properties, so semanticColor tokens cannot be used for these assertions. */
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import {View} from "@khanacademy/wonder-blocks-core";

--- a/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-dialog.tsx
@@ -126,8 +126,8 @@ const styles = StyleSheet.create({
     hide: {
         pointerEvents: "none",
         opacity: 0,
-        backgroundColor: "transparent",
-        color: "transparent",
+        backgroundColor: tokens.semanticColor.core.transparent,
+        color: tokens.semanticColor.core.transparent,
     },
 
     /**

--- a/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
+++ b/packages/wonder-blocks-tabs/src/components/navigation-tab-item.tsx
@@ -157,7 +157,7 @@ const styles = StyleSheet.create({
             border: "none",
             outline: "none",
             color: semanticColor.link.hover,
-            backgroundColor: "transparent",
+            backgroundColor: semanticColor.core.transparent,
         },
         // NOTE: We use :not[aria-disabled] to avoid the hover styles to be
         // applied when the interactive element is disabled.

--- a/packages/wonder-blocks-tabs/src/components/tab.tsx
+++ b/packages/wonder-blocks-tabs/src/components/tab.tsx
@@ -114,7 +114,7 @@ export const styles = StyleSheet.create({
         display: "flex",
         alignItems: "center",
         textWrap: "nowrap",
-        backgroundColor: "transparent",
+        backgroundColor: semanticColor.core.transparent,
         border: "none",
         margin: 0,
         padding: 0,

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-bubble.tsx
@@ -106,8 +106,8 @@ const styles = StyleSheet.create({
     hide: {
         pointerEvents: "none",
         opacity: 0,
-        backgroundColor: "transparent",
-        color: "transparent",
+        backgroundColor: semanticColor.core.transparent,
+        color: semanticColor.core.transparent,
     },
 
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,12 +498,21 @@ importers:
       '@khanacademy/wonder-blocks-form':
         specifier: workspace:*
         version: link:../../wonder-blocks-form
+      '@khanacademy/wonder-blocks-icon':
+        specifier: workspace:*
+        version: link:../../wonder-blocks-icon
       '@khanacademy/wonder-blocks-link':
         specifier: workspace:*
         version: link:../../wonder-blocks-link
+      '@khanacademy/wonder-blocks-tokens':
+        specifier: workspace:*
+        version: link:../../wonder-blocks-tokens
       '@khanacademy/wonder-blocks-typography':
         specifier: workspace:*
         version: link:../../wonder-blocks-typography
+      '@phosphor-icons/core':
+        specifier: 'catalog:'
+        version: 2.1.1
       '@types/react':
         specifier: '18'
         version: 18.3.18

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,6 +507,9 @@ importers:
       '@types/react':
         specifier: '18'
         version: 18.3.18
+      aphrodite:
+        specifier: 'catalog:'
+        version: 1.2.5
       react:
         specifier: ^18.2.0
         version: 18.2.0


### PR DESCRIPTION
## Summary:
Add a new lint rule to warn about hardcoded color values in RGB, RGBA, keyword, hsl, currentColor, hex, and more. This rule warns about hardcoded colors and warns to use semanticColor instead.

Note: this PR also disables the `require-logical-properties-for-rtl` rule that was rolled out without a timely integration, so other work in `frontend` could be unblocked. The rule is still available for opt-in usage, just not part of the recommended (automatic) lint rule config.

## Example lint rule failures

We have some fixes to make in WB itself for this rule to pass! (a sample of results below -- shortened for brevity)
```
 pnpm lint

> wonder-blocks@0.0.1 lint /Users/marcytodd/khan/wonder-blocks
> pnpm lint:ci .


> wonder-blocks@0.0.1 lint:ci /Users/marcytodd/khan/wonder-blocks
> eslint --ext .ts --ext .js --ext .tsx --ext .jsx "."


/Users/marcytodd/khan/wonder-blocks/__docs__/components/component-info.tsx
  41:32  error  Avoid hardcoded color value 'black'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode  @khanacademy/wonder-blocks/no-hardcoded-color

/Users/marcytodd/khan/wonder-blocks/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
  116:17  error  Avoid hardcoded color value '1px solid grey'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode  @khanacademy/wonder-blocks/no-hardcoded-color

/Users/marcytodd/khan/wonder-blocks/__docs__/wonder-blocks-form/checkbox-group.stories.tsx
  344:20  error  Avoid hardcoded color value 'solid 1px #CCC'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode  @khanacademy/wonder-blocks/no-hardcoded-color
  354:23  error  Avoid hardcoded color value 'solid 1px #CCC'. Use a semantic color token from @khanacademy/wonder-blocks-tokens instead (e.g. semanticColor.core.foreground.primary) to support theming and dark mode  @khanacademy/wonder-blocks/no-hardcoded-color
```

Issue: WB-2339

## Test plan:
1. Ensure tests pass
2. Test the rule in `frontend`

## Implementation plan:
1. Release rule in WB
2. Install in `frontend` but disable the rule everywhere due to large scope of changes
3. Enable rule in various product areas in separate PRs: `libs`, `classroom-teacher`, `classroom-learner`, `admin`, etc.