### PR TITLE
SYL Dark - Pill

### DIFF
--- a/.changeset/few-spies-camp.md
+++ b/.changeset/few-spies-camp.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-pill": patch
+---
+
+Pill: Use semantic color action tokens for `accent` kind to address color contrast issues in the `syl-dark` theme

--- a/__docs__/wonder-blocks-pill/pill-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-pill/pill-testing-snapshots.stories.tsx
@@ -2,7 +2,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 import * as React from "react";
 
 import Pill from "@khanacademy/wonder-blocks-pill";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -35,7 +35,7 @@ const meta = {
     component: Pill,
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -232,8 +232,12 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
 
     switch (kind) {
         case "accent":
-            backgroundColor = semanticColor.core.background.instructive.default;
-            textColor = semanticColor.core.foreground.knockout.default;
+            // Use action tokens for accent so it is similar to the button
+            // primary progressive background and foreground colors
+            backgroundColor =
+                semanticColor.action.primary.progressive.default.background;
+            textColor =
+                semanticColor.action.primary.progressive.default.foreground;
             break;
         case "info":
             backgroundColor = semanticColor.feedback.info.subtle.background;

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -270,7 +270,7 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
         kind === "transparent" || kind === "neutral"
             ? color.offBlack16 // NOTE(WB-1950): Neutral pills will be replaced with Badge and the transparent kind will be removed
             : kind === "accent"
-              ? semanticColor.core.background.instructive.strong
+              ? semanticColor.action.primary.progressive.hover.background
               : // NOTE(WB-1950): This will be simplified once we split this into Badge and Pill.
                 `color-mix(in srgb, ${color.offBlack32}, ${backgroundColor})`;
 

--- a/packages/wonder-blocks-pill/src/components/pill.tsx
+++ b/packages/wonder-blocks-pill/src/components/pill.tsx
@@ -270,7 +270,7 @@ const _generateColorStyles = (clickable: boolean, kind: PillKind) => {
         kind === "transparent" || kind === "neutral"
             ? color.offBlack16 // NOTE(WB-1950): Neutral pills will be replaced with Badge and the transparent kind will be removed
             : kind === "accent"
-              ? semanticColor.action.primary.progressive.hover.background
+              ? semanticColor.action.primary.progressive.press.background
               : // NOTE(WB-1950): This will be simplified once we split this into Badge and Pill.
                 `color-mix(in srgb, ${color.offBlack32}, ${backgroundColor})`;
 


### PR DESCRIPTION
## Summary:

Reviewing the pill component in SYL Dark to confirm it looks as expected, and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Changes include:
- Using action tokens for Pill `accent` kind 

Note: Since Pill is a deprecated component, there are no Figma specs for it. Only minimal changes were made to the component to address color contrast issues in the `syl-dark` theme

Issue: WB-2166

## Test plan:

Review the Pill component and confirm things look as expected and there are no a11y violations
`?path=/story/packages-pill-testing-snapshots-pill--state-sheet-story&globals=theme:syl-dark`

Review Chromatic snapshots