### PR TITLE
Fix arrow key navigation from search field in filterable dropdowns

### DIFF
--- a/.changeset/fix-filterable-dropdown-navigation.md
+++ b/.changeset/fix-filterable-dropdown-navigation.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fix arrow key navigation from search field in filterable dropdowns. When `isFilterable` is `true` and the dropdown opens with focus on the search field, pressing ArrowUp/ArrowDown now correctly moves focus to the dropdown items.

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/dropdown-core.test.tsx
@@ -170,6 +170,64 @@ describe("DropdownCore", () => {
         ).toHaveFocus();
     });
 
+    it("navigates from search field to items when search field is initially focused", async () => {
+        // Arrange
+        // Don't set initialFocusedIndex so focus goes to search field
+        render(
+            <DropdownCore
+                onSearchTextChanged={jest.fn()}
+                searchText=""
+                isFilterable={true}
+                items={items}
+                role="listbox"
+                open={true}
+                opener={<button />}
+                onOpenChanged={jest.fn()}
+            />,
+        );
+
+        // Act
+        // Verify search field has focus initially
+        const searchField = await screen.findByRole("textbox");
+        expect(searchField).toHaveFocus();
+
+        // Navigate down from search field to first item
+        await userEvent.keyboard("{ArrowDown}");
+
+        // Assert
+        expect(
+            await screen.findByRole("option", {name: "item 0"}),
+        ).toHaveFocus();
+    });
+
+    it("navigates from search field to last item with ArrowUp", async () => {
+        // Arrange
+        render(
+            <DropdownCore
+                onSearchTextChanged={jest.fn()}
+                searchText=""
+                isFilterable={true}
+                items={items}
+                role="listbox"
+                open={true}
+                opener={<button />}
+                onOpenChanged={jest.fn()}
+            />,
+        );
+
+        // Act
+        const searchField = await screen.findByRole("textbox");
+        expect(searchField).toHaveFocus();
+
+        // Navigate up from search field to last item
+        await userEvent.keyboard("{ArrowUp}");
+
+        // Assert
+        expect(
+            await screen.findByRole("option", {name: "item 2"}),
+        ).toHaveFocus();
+    });
+
     // NOTE(john): This fails after upgrading to user-event v14, it's not clear
     // what's wrong exactly, but tabbing no longer triggers the change, which
     // makes me think that the initial focus is different now.

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -608,16 +608,17 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusPreviousItem(): void {
-        if (
-            this.focusedIndex === 0 ||
-            (this.isSearchFieldFocused() && !this.props.enableTypeAhead)
-        ) {
-            // Move the focus to the search field if it is the first item.
-            if (this.hasSearchField() && !this.isSearchFieldFocused()) {
+        if (this.isSearchFieldFocused()) {
+            // From search field, up arrow goes to last item
+            this.focusedIndex = this.state.itemRefs.length - 1;
+        } else if (this.focusedIndex === 0) {
+            // At first item, go to search field if it exists
+            if (this.hasSearchField()) {
                 return this.focusSearchField();
             }
+            // Otherwise wrap to last item
             this.focusedIndex = this.state.itemRefs.length - 1;
-        } else if (!this.isSearchFieldFocused()) {
+        } else {
             this.focusedIndex -= 1;
         }
 
@@ -625,16 +626,17 @@ class DropdownCore extends React.Component<Props, State> {
     }
 
     focusNextItem(): void {
-        if (
-            this.focusedIndex === this.state.itemRefs.length - 1 ||
-            (this.isSearchFieldFocused() && !this.props.enableTypeAhead)
-        ) {
-            // Move the focus to the search field if it is the last item.
-            if (this.hasSearchField() && !this.isSearchFieldFocused()) {
+        if (this.isSearchFieldFocused()) {
+            // From search field, down arrow goes to first item
+            this.focusedIndex = 0;
+        } else if (this.focusedIndex === this.state.itemRefs.length - 1) {
+            // At last item, go to search field if it exists
+            if (this.hasSearchField()) {
                 return this.focusSearchField();
             }
+            // Otherwise wrap to first item
             this.focusedIndex = 0;
-        } else if (!this.isSearchFieldFocused()) {
+        } else {
             this.focusedIndex += 1;
         }
 


### PR DESCRIPTION
## Summary
Fixed arrow key navigation in filterable dropdowns when the search field has initial focus. Previously, pressing ArrowUp/ArrowDown while focused on the search field would not navigate to dropdown items.

## Changes
- **`focusPreviousItem()`**: Refactored to handle search field focus as the first condition. When the search field is focused, ArrowUp now moves focus to the last item. When at the first item, focus moves to the search field (if it exists) or wraps to the last item.
- **`focusNextItem()`**: Refactored similarly. When the search field is focused, ArrowDown now moves focus to the first item. When at the last item, focus moves to the search field (if it exists) or wraps to the first item.
- **Tests**: Added two new test cases:
  - Navigation from search field to first item with ArrowDown
  - Navigation from search field to last item with ArrowUp

## Implementation Details
The fix simplifies the navigation logic by checking `isSearchFieldFocused()` first, making the behavior more intuitive: the search field acts as a navigation point in the focus cycle rather than a barrier. The `enableTypeAhead` condition was removed as it was preventing proper navigation when the search field had focus.

https://claude.ai/code/session_019bAvtFYM2gG9E9yWXQymCm