### PR TITLE
Add titleHeadingTag prop to PopoverContent

### DIFF
--- a/.changeset/tasty-timers-behave.md
+++ b/.changeset/tasty-timers-behave.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-popover": minor
 ---
 
-Add a new prop to the PopoverContent component that represents the heading tag for the title prop. This allows users to specify the proper heading level for their page.
+Add a new prop to the PopoverContent component that represents the heading tag for the title prop. This allows users to specify the proper heading level for their page for a11y compliance.

--- a/.changeset/tasty-timers-behave.md
+++ b/.changeset/tasty-timers-behave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-popover": minor
+---
+
+Add a new prop to the PopoverContent component that represents the heading tag for the title prop. This allows users to specify the proper heading level for their page.

--- a/__docs__/wonder-blocks-popover/popover-content.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.argtypes.tsx
@@ -66,6 +66,12 @@ export default {
         options: Object.keys(ActionsMappings) as Array<React.ReactNode>,
         mapping: ActionsMappings,
     },
+    titleHeadingTag: {
+        description:
+            "The heading level for the popover title. Defaults to `h4`.",
+        control: {type: "select"},
+        options: ["h1", "h2", "h3", "h4", "h5", "h6"],
+    },
     closeButtonVisible: {
         description: `When true, the close button is shown; otherwise, the close button is not shown.`,
         table: {

--- a/__docs__/wonder-blocks-popover/popover-content.argtypes.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.argtypes.tsx
@@ -68,7 +68,7 @@ export default {
     },
     titleHeadingTag: {
         description:
-            "The heading level for the popover title. Defaults to `h4`.",
+            "The heading level for the popover title. Defaults to `h4`. This does not affect the visual appearance of the title.",
         control: {type: "select"},
         options: ["h1", "h2", "h3", "h4", "h5", "h6"],
     },

--- a/__docs__/wonder-blocks-popover/popover-content.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.stories.tsx
@@ -84,7 +84,7 @@ export const WithIcon: StoryComponentType = {
 
 /**
  * Use the `titleHeadingTag` prop to override the heading level of the popover
- * title. The default is `h4`.
+ * title. The default is `h4`. This does not affect the visual appearance of the title.
  */
 export const WithTitleHeadingTag: StoryComponentType = {
     args: {

--- a/__docs__/wonder-blocks-popover/popover-content.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover-content.stories.tsx
@@ -83,6 +83,19 @@ export const WithIcon: StoryComponentType = {
 };
 
 /**
+ * Use the `titleHeadingTag` prop to override the heading level of the popover
+ * title. The default is `h4`.
+ */
+export const WithTitleHeadingTag: StoryComponentType = {
+    args: {
+        title: "Custom heading tag",
+        content: "This popover title is rendered as a custom heading tag.",
+        titleHeadingTag: "h2",
+    },
+    render: (args) => <PopoverContent {...args} />,
+};
+
+/**
  * Call attention to the popover using a full-bleed illustration.
  */
 export const WithIllustration: StoryComponentType = {

--- a/__docs__/wonder-blocks-popover/popover.stories.tsx
+++ b/__docs__/wonder-blocks-popover/popover.stories.tsx
@@ -884,6 +884,40 @@ export const WithCustomAriaDescribedBy: StoryComponentType = {
 };
 
 /**
+ * The `titleHeadingTag` prop allows customizing the heading level used for the
+ * popover title. It defaults to `"h4"`. This does not affect the visual appearance of the title.
+ */
+export const WithTitleHeadingTag: StoryComponentType = {
+    render: function Render() {
+        const [opened, setOpened] = React.useState(false);
+        return (
+            <Popover
+                opened={opened}
+                onClose={() => setOpened(false)}
+                content={
+                    <PopoverContent
+                        titleHeadingTag="h2"
+                        title="Title rendered as h2"
+                        content="This popover title is rendered as an h2 element instead of the default h4. This does not affect the visual appearance of the title."
+                        closeButtonVisible
+                    />
+                }
+            >
+                <Button onClick={() => setOpened(true)}>
+                    Open popover with h2 title
+                </Button>
+            </Popover>
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Popover is closed by default, so we don't need to test it.
+            disableSnapshot: true,
+        },
+    },
+};
+
+/**
  * If the Popover is placed near the edge of the viewport, default spacing of
  * 12px is applied to provide spacing between the Popover and the viewport. This
  * spacing value can be overridden using the `viewportPadding` prop.

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.tsx
@@ -92,7 +92,7 @@ describe("PopoverContent", () => {
     });
 
     it("should render the title as h4 by default", () => {
-        // Arrange
+        // Act
         render(<PopoverContent title="Title" content="content" />);
 
         // Assert
@@ -102,7 +102,7 @@ describe("PopoverContent", () => {
     });
 
     it("should render the title using the heading tag specified by titleHeadingTag", () => {
-        // Arrange
+        // Act
         render(
             <PopoverContent
                 title="Title"

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.tsx
@@ -93,12 +93,7 @@ describe("PopoverContent", () => {
 
     it("should render the title as h4 by default", () => {
         // Arrange
-        render(
-            <PopoverContent
-                title="Title"
-                content="content"
-            />,
-        );
+        render(<PopoverContent title="Title" content="content" />);
 
         // Assert
         expect(

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-content.test.tsx
@@ -90,4 +90,35 @@ describe("PopoverContent", () => {
         // Assert
         expect(screen.getByRole("img")).toHaveAttribute("alt", iconAlt);
     });
+
+    it("should render the title as h4 by default", () => {
+        // Arrange
+        render(
+            <PopoverContent
+                title="Title"
+                content="content"
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("heading", {level: 4, name: "Title"}),
+        ).toBeInTheDocument();
+    });
+
+    it("should render the title using the heading tag specified by titleHeadingTag", () => {
+        // Arrange
+        render(
+            <PopoverContent
+                title="Title"
+                content="content"
+                titleHeadingTag="h2"
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("heading", {level: 2, name: "Title"}),
+        ).toBeInTheDocument();
+    });
 });

--- a/packages/wonder-blocks-popover/src/components/__tests__/popover-content.typestest.tsx
+++ b/packages/wonder-blocks-popover/src/components/__tests__/popover-content.typestest.tsx
@@ -4,6 +4,8 @@ import PopoverContent from "../popover-content";
 
 <PopoverContent title="Title" content="Content" />;
 
+<PopoverContent title="Title" content="Content" titleHeadingTag="h2" />;
+
 <PopoverContent title="Title" content="Content" icon="close" />;
 
 <PopoverContent

--- a/packages/wonder-blocks-popover/src/components/popover-content.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content.tsx
@@ -22,6 +22,7 @@ type CommonProps = AriaProps & {
     title: string;
     /**
      * The heading tag for the popover title. Defaults to `"h4"`.
+     * This does not affect the visual appearance of the title.
      */
     titleHeadingTag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
     /**
@@ -238,7 +239,8 @@ export default class PopoverContent extends React.Component<Props> {
 
                                 <View style={styles.text}>
                                     <Heading
-                                        tag={titleHeadingTag ?? "h4"}
+                                        size="medium"
+                                        tag={titleHeadingTag}
                                         id={`${uniqueId}-title`}
                                         style={styles.title}
                                     >

--- a/packages/wonder-blocks-popover/src/components/popover-content.tsx
+++ b/packages/wonder-blocks-popover/src/components/popover-content.tsx
@@ -21,6 +21,10 @@ type CommonProps = AriaProps & {
      */
     title: string;
     /**
+     * The heading tag for the popover title. Defaults to `"h4"`.
+     */
+    titleHeadingTag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+    /**
      * User-defined actions.
      *
      * It can be either a Node or a function using the children-as-function
@@ -208,6 +212,7 @@ export default class PopoverContent extends React.Component<Props> {
             image,
             style,
             title,
+            titleHeadingTag,
             testId,
             uniqueId,
         } = this.props;
@@ -233,7 +238,7 @@ export default class PopoverContent extends React.Component<Props> {
 
                                 <View style={styles.text}>
                                     <Heading
-                                        size="medium"
+                                        tag={titleHeadingTag ?? "h4"}
                                         id={`${uniqueId}-title`}
                                         style={styles.title}
                                     >


### PR DESCRIPTION
## Summary:
Allow users of PopoverContent component to specify the heading level. This way users can choose the correct heading level that matches the visual importance for their page.

Issue: [A11Y-520](https://khanacademy.atlassian.net/browse/A11Y-520)

## Test plan:
- `pnpm test` and `pnpm typecheck` and `pnpm lint`
- manual:

### popover storybook

<img width="1662" height="769" alt="popover-story" src="https://github.com/user-attachments/assets/b1424095-ae55-4512-872b-42c4426b70b8" />


### popover content storybook and docs

<img width="1430" height="519" alt="popover-content-story" src="https://github.com/user-attachments/assets/efe61d86-eb1b-4342-9c16-5bc2c86a38d3" />

<img width="938" height="870" alt="popover-content-docs" src="https://github.com/user-attachments/assets/c26de292-4d41-40eb-a9a8-2a3020c16ff7" />


### frontend

WITH TAG - uses what is specified

<img width="1873" height="897" alt="popover-with-tag" src="https://github.com/user-attachments/assets/46358ef0-d806-4b31-81bf-96f3d6b585ab" />

WITHOUT TAG - uses default

<img width="1878" height="934" alt="popover-without-tag" src="https://github.com/user-attachments/assets/d38ce48c-4a8e-4468-806a-3fd809dd0953" />


[A11Y-520]: https://khanacademy.atlassian.net/browse/A11Y-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ