### PR TITLE
Fix NVDA double-announcing modal content by removing role=log from live regions

### DIFF
--- a/.changeset/happy-bobcats-tickle.md
+++ b/.changeset/happy-bobcats-tickle.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-announcer": patch
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Fix NVDA double-announcing modal content by omitting role="log" on live region elements

--- a/packages/wonder-blocks-announcer/src/__tests__/announce-message.test.tsx
+++ b/packages/wonder-blocks-announcer/src/__tests__/announce-message.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {render, screen, waitFor} from "@testing-library/react";
+import {render, screen, waitFor, within} from "@testing-library/react";
 import Announcer, {REMOVAL_TIMEOUT_DELAY} from "../announcer";
 import {AnnounceMessageButton} from "./components/announce-message-button";
 import {announceMessage} from "../announce-message";
@@ -43,8 +43,10 @@ describe("Announcer.announceMessage", () => {
 
         // ASSERT: expect live regions to exist
         const wrapperElement = screen.getByTestId("wbAnnounce");
-        const regionElements = wrapperElement.querySelectorAll("[aria-live]");
         expect(wrapperElement).toBeInTheDocument();
+        const regionElements = within(wrapperElement).getAllByTestId(
+            /^wbARegion-(polite|assertive)\d$/,
+        );
         expect(regionElements).toHaveLength(4);
     });
 

--- a/packages/wonder-blocks-announcer/src/__tests__/announce-message.test.tsx
+++ b/packages/wonder-blocks-announcer/src/__tests__/announce-message.test.tsx
@@ -43,7 +43,7 @@ describe("Announcer.announceMessage", () => {
 
         // ASSERT: expect live regions to exist
         const wrapperElement = screen.getByTestId("wbAnnounce");
-        const regionElements = screen.queryAllByRole("log");
+        const regionElements = wrapperElement.querySelectorAll("[aria-live]");
         expect(wrapperElement).toBeInTheDocument();
         expect(regionElements).toHaveLength(4);
     });

--- a/packages/wonder-blocks-announcer/src/__tests__/util/dom.test.ts
+++ b/packages/wonder-blocks-announcer/src/__tests__/util/dom.test.ts
@@ -81,24 +81,11 @@ describe("Announcer utility functions", () => {
 
                 // Assert
                 expect(region.getAttribute("aria-live")).toBe(politenessLevel);
-                expect(region.getAttribute("role")).toBe("log");
+                expect(region.getAttribute("role")).toBeNull();
                 expect(dictionary.size).toBe(1);
             },
         );
 
-        test("it allows the role to be overridden", () => {
-            const dictionary = new Map();
-            const region = createRegion(
-                "polite",
-                0,
-                "document",
-                dictionary,
-                "timer",
-            );
-
-            expect(region.getAttribute("aria-live")).toBe("polite");
-            expect(region.getAttribute("role")).toBe("timer");
-        });
     });
 
     describe("removeMessage", () => {

--- a/packages/wonder-blocks-announcer/src/__tests__/util/dom.test.ts
+++ b/packages/wonder-blocks-announcer/src/__tests__/util/dom.test.ts
@@ -85,7 +85,6 @@ describe("Announcer utility functions", () => {
                 expect(dictionary.size).toBe(1);
             },
         );
-
     });
 
     describe("removeMessage", () => {

--- a/packages/wonder-blocks-announcer/src/util/dom.ts
+++ b/packages/wonder-blocks-announcer/src/util/dom.ts
@@ -45,7 +45,6 @@ export function createDuplicateRegions(
             i,
             layerId,
             dictionary,
-            "log",
             idSuffix,
         );
         wrapper.appendChild(region);
@@ -68,11 +67,9 @@ export function createRegion(
     index: number,
     layerId: LayerContext,
     dictionary: RegionDictionary,
-    role = "log",
     idSuffix: string = "",
 ) {
     const region = document.createElement("div");
-    region.setAttribute("role", role);
     region.setAttribute("aria-live", level);
     region.classList.add("wbARegion");
     // Omit "document" from page-level ids, but include "modal"

--- a/packages/wonder-blocks-announcer/src/util/dom.ts
+++ b/packages/wonder-blocks-announcer/src/util/dom.ts
@@ -40,13 +40,7 @@ export function createDuplicateRegions(
     idSuffix: string = "",
 ): HTMLElement[] {
     const result = new Array(regionCount).fill(0).map((el, i) => {
-        const region = createRegion(
-            level,
-            i,
-            layerId,
-            dictionary,
-            idSuffix,
-        );
+        const region = createRegion(level, i, layerId, dictionary, idSuffix);
         wrapper.appendChild(region);
         return region;
     });

--- a/packages/wonder-blocks-modal/src/hooks/__tests__/use-modal-announcer.test.tsx
+++ b/packages/wonder-blocks-modal/src/hooks/__tests__/use-modal-announcer.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {render} from "@testing-library/react";
+import {render, screen, within} from "@testing-library/react";
 
 import * as Announcer from "@khanacademy/wonder-blocks-announcer";
 
@@ -118,16 +118,19 @@ describe("useModalAnnouncer — live region DOM structure", () => {
 
     it("attaches live regions inside the dialog without a role attribute", () => {
         // Arrange — no mock so the real announcer writes to the DOM
-        const {getByRole} = render(<TestDialog />);
+        render(<TestDialog />);
 
         // Act
-        const dialog = getByRole("dialog");
-        const liveRegions = dialog.querySelectorAll("[aria-live]");
+        const dialog = screen.getByRole("dialog");
+        const liveRegions = within(dialog).getAllByTestId(
+            /wbARegion-modal-(polite|assertive)\d/,
+        );
 
         // Assert
         expect(liveRegions.length).toBeGreaterThan(0);
         liveRegions.forEach((region) => {
-            expect(region.getAttribute("role")).toBeNull();
+            expect(region).toHaveAttribute("aria-live");
+            expect(region).not.toHaveAttribute("role");
         });
     });
 });

--- a/packages/wonder-blocks-modal/src/hooks/__tests__/use-modal-announcer.test.tsx
+++ b/packages/wonder-blocks-modal/src/hooks/__tests__/use-modal-announcer.test.tsx
@@ -110,3 +110,24 @@ describe("useModalAnnouncer", () => {
         expect(refCallback).toHaveBeenCalledWith(expect.any(HTMLElement));
     });
 });
+
+describe("useModalAnnouncer — live region DOM structure", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("attaches live regions inside the dialog without a role attribute", () => {
+        // Arrange — no mock so the real announcer writes to the DOM
+        const {getByRole} = render(<TestDialog />);
+
+        // Act
+        const dialog = getByRole("dialog");
+        const liveRegions = dialog.querySelectorAll("[aria-live]");
+
+        // Assert
+        expect(liveRegions.length).toBeGreaterThan(0);
+        liveRegions.forEach((region) => {
+            expect(region.getAttribute("role")).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

NVDA was announcing the close button and dialog heading twice on modal open, then reading the entire table inside.

WB's announcer injects 4 live regions inside role="dialog" aria-modal="true" elements on mount. These regions had both role="log" and an explicit aria-live attribute. Per [WAI-ARIA 1.2 §log](https://www.w3.org/TR/wai-aria-1.2/#log) and [WCAG ARIA23](https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA23), role="log" carries an implicit aria-live="polite". On the assertive regions this is directly contradictory (role="log" → polite, aria-live="assertive" → interrupt). NVDA processes these as two separate live region signals and re-reads the dialog; JAWS and VoiceOver normalize them into one before announcing.

 Fix: 
 Remove role="log" from [createRegion](https://github.com/Khan/wonder-blocks/pull/3064/changes#diff-e9d4d52aff8fee6949bd08141400d6110027183111adfdabc336c05509405b9bL43) in [dom.ts](https://github.com/Khan/wonder-blocks/pull/3064/changes#diff-e9d4d52aff8fee6949bd08141400d6110027183111adfdabc336c05509405b9b)[dom.ts](https://github.com/Khan/wonder-blocks/pull/packages/wonder-blocks-announcer/src/util/dom.ts). Plain aria-live is sufficient.


Issue: CLASS-14343

## Test plan: