### PR TITLE
Link: Accept the `state` prop from the React router Link component.

### DIFF
--- a/.changeset/twenty-worms-shake.md
+++ b/.changeset/twenty-worms-shake.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/wonder-blocks-clickable": minor
+"@khanacademy/wonder-blocks-link": minor
+---
+
+Accepts the `state` prop from the React router Link component.

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -575,6 +575,24 @@ export const WithTitle: StoryComponentType = {
 };
 
 /**
+ * Link can take a `state` prop that adds persistent client side routing state
+ * to the next location. See https://reactrouter.com/api/components/Link#state
+ */
+export const WithState: StoryComponentType = {
+    render: () => (
+        <MemoryRouter>
+            <CompatRouter>
+                <View>
+                    <Link href="/foo" state={{from: "wonder-blocks-link"}}>
+                        Link with state
+                    </Link>
+                </View>
+            </CompatRouter>
+        </MemoryRouter>
+    ),
+};
+
+/**
  * When in the right-to-left direction, the `startIcon` and `endIcon` are
  * flipped. This example has text in Arabic, a right-to-left language.
  */

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -161,9 +161,8 @@ interface CommonProps extends ExposedEventHandlers {
     /**
      * Adds state to the destination's location, accessible via
      * `useLocation().state` on the target route. Only has effect for
-     * client-side navigation.
-     *
-     * @see https://reactrouter.com/6.30.0/components/link#state
+     * when the underlying react-router `Link` is used. See
+     * https://reactrouter.com/api/components/Link#state
      */
     state?: unknown;
 }

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -158,6 +158,14 @@ interface CommonProps extends ExposedEventHandlers {
      * @see https://reactrouter.com/6.30.0/components/link#viewtransition
      */
     viewTransition?: boolean;
+    /**
+     * Adds state to the destination's location, accessible via
+     * `useLocation().state` on the target route. Only has effect for
+     * client-side navigation.
+     *
+     * @see https://reactrouter.com/6.30.0/components/link#state
+     */
+    state?: unknown;
 }
 
 type Props =
@@ -385,6 +393,7 @@ export default class ClickableBehavior extends React.Component<
                     // @see https://remix.run/docs/en/main/hooks/use-navigate#options
                     navigate(href, {
                         viewTransition: this.props.viewTransition,
+                        state: this.props.state,
                     });
                     this.setState({waiting: false});
                 } else {

--- a/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
+++ b/packages/wonder-blocks-clickable/src/components/clickable-behavior.ts
@@ -159,10 +159,8 @@ interface CommonProps extends ExposedEventHandlers {
      */
     viewTransition?: boolean;
     /**
-     * Adds state to the destination's location, accessible via
-     * `useLocation().state` on the target route. Only has effect for
-     * when the underlying react-router `Link` is used. See
-     * https://reactrouter.com/api/components/Link#state
+     * Adds persistent client side routing state to the next location.
+     * See https://reactrouter.com/api/components/Link#state
      */
     state?: unknown;
 }

--- a/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
+++ b/packages/wonder-blocks-link/src/components/__tests__/link.test.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import {MemoryRouter} from "react-router-dom";
-import {CompatRouter, Route, Routes} from "react-router-dom-v5-compat";
+import {
+    CompatRouter,
+    Route,
+    Routes,
+    useLocation,
+} from "react-router-dom-v5-compat";
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
@@ -248,6 +253,41 @@ describe("Link", () => {
 
             // Assert
             expect(safeWithNavMock).not.toHaveBeenCalled();
+        });
+
+        test("forwards `state` to the destination route's location", async () => {
+            // Arrange
+            function StateReader() {
+                const location = useLocation();
+                return (
+                    <div data-testid="state">
+                        {(location.state as {from?: string})?.from}
+                    </div>
+                );
+            }
+            render(
+                <MemoryRouter>
+                    <CompatRouter>
+                        <div>
+                            <Link href="/foo" state={{from: "home"}}>
+                                Click me!
+                            </Link>
+                            <Routes>
+                                <Route path="/foo" element={<StateReader />} />
+                            </Routes>
+                        </div>
+                    </CompatRouter>
+                </MemoryRouter>,
+            );
+
+            // Act
+            const link = await screen.findByText("Click me!");
+            await userEvent.click(link);
+
+            // Assert
+            expect(await screen.findByTestId("state")).toHaveTextContent(
+                "home",
+            );
         });
     });
 

--- a/packages/wonder-blocks-link/src/components/link-core.tsx
+++ b/packages/wonder-blocks-link/src/components/link-core.tsx
@@ -52,6 +52,7 @@ const LinkCore = React.forwardRef(function LinkCore(
         endIcon,
         labels,
         viewTransition,
+        state,
         ...restProps
     } = props;
 
@@ -123,6 +124,7 @@ const LinkCore = React.forwardRef(function LinkCore(
             to={href}
             ref={ref as React.ForwardedRef<typeof Link>}
             viewTransition={viewTransition}
+            state={state}
         >
             {linkContent}
         </StyledLink>

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -142,6 +142,16 @@ type CommonProps = AriaProps & {
      * @see https://reactrouter.com/6.30.0/components/link#viewtransition
      */
     viewTransition?: boolean;
+
+    /**
+     * Adds state to the destination's location, accessible via
+     * `useLocation().state` on the target route. Only has effect for
+     * client-side navigation (i.e. when the underlying react-router `Link` is
+     * used).
+     *
+     * @see https://reactrouter.com/6.30.0/components/link#state
+     */
+    state?: unknown;
 };
 
 export type SharedProps =
@@ -210,6 +220,7 @@ const Link = React.forwardRef(function Link(
         target = undefined,
         inline = false,
         viewTransition = false,
+        state,
         ...sharedProps
     } = props;
 
@@ -233,12 +244,13 @@ const Link = React.forwardRef(function Link(
                 onKeyDown={onKeyDown}
                 onKeyUp={onKeyUp}
                 viewTransition={viewTransition}
+                state={state}
             >
-                {(state, {...childrenProps}) => {
+                {(clickableState, {...childrenProps}) => {
                     return (
                         <LinkCore
                             {...sharedProps}
-                            {...state}
+                            {...clickableState}
                             {...childrenProps}
                             skipClientNav={skipClientNav}
                             href={href}
@@ -247,6 +259,7 @@ const Link = React.forwardRef(function Link(
                             inline={inline}
                             ref={ref}
                             viewTransition={viewTransition}
+                            state={state}
                         >
                             {children}
                         </LinkCore>
@@ -266,12 +279,13 @@ const Link = React.forwardRef(function Link(
                 onKeyDown={onKeyDown}
                 onKeyUp={onKeyUp}
                 viewTransition={viewTransition}
+                state={state}
             >
-                {(state, {...childrenProps}) => {
+                {(clickableState, {...childrenProps}) => {
                     return (
                         <LinkCore
                             {...sharedProps}
-                            {...state}
+                            {...clickableState}
                             {...childrenProps}
                             skipClientNav={skipClientNav}
                             href={href}
@@ -280,6 +294,7 @@ const Link = React.forwardRef(function Link(
                             inline={inline}
                             ref={ref}
                             viewTransition={viewTransition}
+                            state={state}
                         >
                             {children}
                         </LinkCore>

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -146,10 +146,8 @@ type CommonProps = AriaProps & {
     /**
      * Adds state to the destination's location, accessible via
      * `useLocation().state` on the target route. Only has effect for
-     * client-side navigation (i.e. when the underlying react-router `Link` is
-     * used).
-     *
-     * @see https://reactrouter.com/6.30.0/components/link#state
+     * when the underlying react-router `Link` is used. See
+     * https://reactrouter.com/api/components/Link#state
      */
     state?: unknown;
 };

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -144,10 +144,9 @@ type CommonProps = AriaProps & {
     viewTransition?: boolean;
 
     /**
-     * Adds state to the destination's location, accessible via
-     * `useLocation().state` on the target route. Only has effect for
-     * when the underlying react-router `Link` is used. See
-     * https://reactrouter.com/api/components/Link#state
+     * Adds persistent client side routing state to the next location.
+     * Only has effect when the underlying react-router `Link` is used.
+     * See https://reactrouter.com/api/components/Link#state
      */
     state?: unknown;
 };


### PR DESCRIPTION
## Summary:
Sometimes when we navigate, we want to set `state` on the React router navigation. We can do this with some hooks provided by React router, but if we are trying to use a Link to do the navigation then this gets tricky. React router's [Link component](https://reactrouter.com/api/components/Link#state) accempts a `state` prop. This exposes that same prop on our own Link component.

Issue: TUT-4070

## Test plan:
- Ensure tests pass