### PR TITLE
SYL Dark - Tooltip

### DIFF
--- a/.changeset/tasty-ads-add.md
+++ b/.changeset/tasty-ads-add.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+Tooltip: Use semantic color tokens for the tooltip tail when a background color is not passed in

--- a/__docs__/wonder-blocks-tooltip/tooltip-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip-testing-snapshots.stories.tsx
@@ -3,7 +3,7 @@ import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
 
@@ -72,6 +72,16 @@ const rows = [
                     </BodyText>
                 </TooltipContent>
             ),
+        },
+    },
+    {
+        name: "Custom primitive background color",
+        props: {
+            content: "Custom background color",
+            backgroundColor: "darkBlue",
+            contentStyle: {
+                color: semanticColor.core.foreground.knockout.default,
+            },
         },
     },
 ];

--- a/__docs__/wonder-blocks-tooltip/tooltip-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip-testing-snapshots.stories.tsx
@@ -79,7 +79,7 @@ const rows = [
         props: {
             content: "Custom background color",
             // TODO(WB-2125): Remove this once `backgroundColor` prop is removed
-            // in favour of a stroong tooltip variant.
+            // in favour of a strong tooltip variant.
             //
             // Note: This won't look right in syl-dark. We include this to ensure
             // existing behaviour is not broken.

--- a/__docs__/wonder-blocks-tooltip/tooltip-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip-testing-snapshots.stories.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
+
+import {allThemeModes} from "../../.storybook/modes";
+import {StateSheet} from "../components/state-sheet";
+
+type Story = StoryObj<typeof Tooltip>;
+
+/**
+ * The following stories are used to generate visual snapshots for the
+ * `Tooltip` component in Chromatic across all supported themes (including
+ * syl-dark). Each cell uses `opened={true}` so the tooltip bubble is forced
+ * open and the snapshot captures the full bubble (background, tail, shadow)
+ * around the inner `TooltipContent`.
+ */
+const meta = {
+    title: "Packages / Tooltip / Testing / Snapshots / Tooltip",
+    parameters: {
+        chromatic: {
+            modes: allThemeModes,
+            // Give PopperJS time to position the tooltip before snapshotting.
+            delay: 500,
+        },
+    },
+    tags: ["!autodocs", "!manifest"],
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+
+const rows = [
+    {
+        name: "Only text content",
+        props: {
+            content: <TooltipContent>Only the content</TooltipContent>,
+        },
+    },
+    {
+        name: "Titled content",
+        props: {
+            content: (
+                <TooltipContent title="This tooltip has a title">
+                    Some content in my tooltip
+                </TooltipContent>
+            ),
+        },
+    },
+    {
+        name: "Custom title and custom content",
+        props: {
+            content: (
+                <TooltipContent title={<BodyText>Body text title!</BodyText>}>
+                    <BodyText>Body text content!</BodyText>
+                    <BodyText>And BodyText!</BodyText>
+                </TooltipContent>
+            ),
+        },
+    },
+    {
+        name: "Rich text content",
+        props: {
+            content: (
+                <TooltipContent>
+                    <BodyText>
+                        Use <strong>bold</strong>, <em>italic</em>, or{" "}
+                        <u>underlined</u> text.
+                    </BodyText>
+                </TooltipContent>
+            ),
+        },
+    },
+];
+
+const columns = [{name: "Default", props: {}}];
+
+// Tooltip with `opened` controlled to `true` has no interactive pseudo states
+// here, so render a single "Default" state per cell instead of cycling through
+// rest/hover/press/focus.
+const states = [{name: "Default", className: "default"}];
+
+export const StateSheetStory: Story = {
+    name: "StateSheet",
+    render: () => (
+        <StateSheet
+            rows={rows}
+            columns={columns}
+            states={states}
+            title="Content variant"
+        >
+            {({props, name}) => (
+                // The bubble portals out of the cell and is positioned by
+                // Popper above the anchor, so give each cell enough room
+                // around the anchor for the bubble to render without
+                // overlapping neighboring cells.
+                <View style={styles.anchorCell} key={name}>
+                    <Tooltip
+                        {...props}
+                        opened={true}
+                        forceAnchorFocusivity={false}
+                        placement="right"
+                    >
+                        Anchor
+                    </Tooltip>
+                </View>
+            )}
+        </StateSheet>
+    ),
+};
+
+const styles = StyleSheet.create({
+    anchorCell: {
+        alignItems: "flex-start",
+        justifyContent: "center",
+        padding: sizing.size_180,
+        width: 400,
+    },
+});

--- a/__docs__/wonder-blocks-tooltip/tooltip-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-tooltip/tooltip-testing-snapshots.stories.tsx
@@ -78,6 +78,11 @@ const rows = [
         name: "Custom primitive background color",
         props: {
             content: "Custom background color",
+            // TODO(WB-2125): Remove this once `backgroundColor` prop is removed
+            // in favour of a stroong tooltip variant.
+            //
+            // Note: This won't look right in syl-dark. We include this to ensure
+            // existing behaviour is not broken.
             backgroundColor: "darkBlue",
             contentStyle: {
                 color: semanticColor.core.foreground.knockout.default,

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
@@ -88,18 +88,18 @@ describe("TooltipTail", () => {
         />
       </g>
       <polyline
-        fill="#ffffff"
+        fill="var(--wb-semanticColor-core-background-base-default)"
         points="0,0 12,12 24,0"
-        stroke="#ffffff"
+        stroke="var(--wb-semanticColor-core-background-base-default)"
       />
       <polyline
-        fill="#ffffff"
+        fill="var(--wb-semanticColor-core-background-base-default)"
         points="0,0 12,12 24,0"
-        stroke="var(--wb-semanticColor-core-shadow-transparent-mid)"
+        stroke="var(--wb-semanticColor-core-border-neutral-subtle)"
       />
       <polyline
         points="0,-0.5 24,-0.5"
-        stroke="#ffffff"
+        stroke="var(--wb-semanticColor-core-background-base-default)"
       />
     </svg>
   </div>

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -382,8 +382,8 @@ export default class TooltipTail extends React.Component<Props> {
                 {/**
                  * Draw the actual background of the tooltip arrow.
                  *
-                 * We draw the outline in white too so that when we draw the
-                 * outline, it draws over white and not the dropshadow behind.
+                 * We draw the outline in the tailFill color too so that when we draw the
+                 * outline, it draws over the tailFill color and not the dropshadow behind.
                  */}
                 <polyline
                     fill={tailFill}

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -9,13 +9,13 @@ import type {getRefFn, Placement, Offset} from "../util/types";
 
 export type Props = {
     /**
-     * Whether we should use the default white background color or switch to a
+     * Whether we should use the default background color or switch to a
      * different bg color.
      *
      * NOTE: Added to support custom popovers
      * @ignore
      */
-    color: keyof typeof color;
+    color?: keyof typeof color;
     /** The offset of the tail indicating where it should be positioned. */
     offset?: Offset;
     /** The placement of the tail with respect to the tooltip anchor. */
@@ -28,7 +28,6 @@ export type Props = {
 };
 
 type DefaultProps = {
-    color: Props["color"];
     show: Props["show"];
 };
 
@@ -51,7 +50,6 @@ let tempIdCounter = 0;
 
 export default class TooltipTail extends React.Component<Props> {
     static defaultProps: DefaultProps = {
-        color: "white",
         show: true,
     };
 
@@ -347,6 +345,12 @@ export default class TooltipTail extends React.Component<Props> {
             this._calculateDimensionsFromPlacement();
 
         const {color: arrowColor, show} = this.props;
+        // When no primitive override is passed, use the same semantic
+        // background as the bubble so the tail follows the theme
+        const tailFill =
+            arrowColor !== undefined && color[arrowColor]
+                ? color[arrowColor]
+                : semanticColor.core.background.base.default;
 
         if (!show) {
             // If we aren't showing the tail, we still need to take up space
@@ -382,8 +386,8 @@ export default class TooltipTail extends React.Component<Props> {
                  * outline, it draws over white and not the dropshadow behind.
                  */}
                 <polyline
-                    fill={color[arrowColor]}
-                    stroke={color[arrowColor]}
+                    fill={tailFill}
+                    stroke={tailFill}
                     points={points.join(" ")}
                 />
                 {/* Draw the tooltip outline around the tooltip arrow. */}
@@ -391,15 +395,12 @@ export default class TooltipTail extends React.Component<Props> {
                     // Redraw the stroke on top of the background color,
                     // so that the ends aren't extra dark where they meet
                     // the border of the tooltip.
-                    fill={color[arrowColor]}
+                    fill={tailFill}
                     points={points.join(" ")}
-                    stroke={semanticColor.core.shadow.transparent.mid}
+                    stroke={semanticColor.core.border.neutral.subtle}
                 />
                 {/* Draw a trimline to make the arrow appear flush */}
-                <polyline
-                    stroke={color[arrowColor]}
-                    points={trimlinePoints.join(" ")}
-                />
+                <polyline stroke={tailFill} points={trimlinePoints.join(" ")} />
             </svg>
         );
     }


### PR DESCRIPTION
## Summary:

Reviewing the Tooltip component in SYL Dark to confirm it looks as expected, matches the design specs, and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Changes specific to the component:
- Fixed the `TooltipTail` so that the `color` prop is optional. When no primitive color override is passed, the tail fill falls back to a semantic color token instead so it works across themes
- Use semantic color border token for the tooltip tail 

Issue: WB-2166
Design: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=5681-741&t=nbUJi6LBtja2ZGFs-4

Note: Currently, the Tooltip component supports a `backgroundColor` prop that only works with primitive colors. WB-2125 will introduce a new strong tooltip variant so that we can remove the `backgroundColor` and control which combinations of backgrounds and foregrounds can be used together in the tooltip

## Test plan:

Review the Tooltip across themes and confirm things look as expected and that there are no a11y violations related to color contrast `?path=/story/packages-tooltip-testing-snapshots-tooltip--state-sheet-story&globals=backgrounds.value:baseSubtle;backgrounds.grid:!false;theme:default`

Review visual changes in Chromatic