### PR TITLE
Add links to tokenValue docs from semantic color token docs

### DIFF
--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -75,6 +75,7 @@ how to use these colors depending on the context.
     />
 </View>
 
+
 ### Core
 
 Core colors are used for the most common elements in the UI. These colors are
@@ -238,6 +239,15 @@ it.
 Standalone colors used only for communicating mastery.
 
 <Canvas of={SemanticColorGroups.Mastery} layout="fullscreen" />
+
+
+## Getting raw token values
+
+Semantic colors are exported as CSS `var(--...)` references so the active theme
+can switch values through the CSS cascade. This is great for styling, but less
+useful when something expects a concrete hex value (e.g. a third-party library).
+Use the [tokenValue](./?path=/docs/packages-tokens-utilities-tokenvalue--docs)
+utility to resolve a token to its computed raw value at runtime.
 
 ## Accessibility
 

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -249,6 +249,17 @@ useful when something expects a concrete hex value (e.g. a third-party library).
 Use the [tokenValue](./?path=/docs/packages-tokens-utilities-tokenvalue--docs)
 utility to resolve a token to its computed raw value at runtime.
 
+<Banner
+    kind="info"
+    text={
+        <>
+            Use <code>tokenValue</code> only for edge cases where a concrete raw
+            value is required. Favour using tokens directly wherever possible,
+            since resolving raw values can break theming if overused.
+        </>
+    }
+/>
+
 ## Accessibility
 
 When using color, it is important to consider accessibility. The contrast

--- a/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
@@ -39,6 +39,12 @@ import {ColorSwatch} from "../components/color-swatch";
  *     color: semanticColor.core.foreground.neutral.strong,
  * };
  * ```
+ *
+ * Semantic colors are exported as CSS `var(--...)` references so the active
+ * theme can switch values through the CSS cascade. If you need the computed raw
+ * value of a token at runtime (e.g. for a third-party library), use the
+ * [`tokenValue`](./?path=/docs/packages-tokens-utilities-tokenvalue--docs)
+ * utility.
  */
 export default {
     title: "Packages / Tokens / Semantic Color",

--- a/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/semantic-color.stories.tsx
@@ -45,6 +45,10 @@ import {ColorSwatch} from "../components/color-swatch";
  * value of a token at runtime (e.g. for a third-party library), use the
  * [`tokenValue`](./?path=/docs/packages-tokens-utilities-tokenvalue--docs)
  * utility.
+ *
+ * Use `tokenValue` only for edge cases where a concrete raw value is required.
+ * Favour using tokens directly wherever possible, since resolving raw values
+ * can break theming if overused.
  */
 export default {
     title: "Packages / Tokens / Semantic Color",

--- a/__docs__/wonder-blocks-tokens/token-value.mdx
+++ b/__docs__/wonder-blocks-tokens/token-value.mdx
@@ -26,6 +26,18 @@ value such as `#1865f2` or `rgba(24, 101, 242, 0.5)`.
 
 The `tokenValue` helper resolves a token to its computed raw value at runtime.
 
+<Banner
+    kind="info"
+    text={
+        <>
+            Use <code>tokenValue</code> only for edge cases where a concrete raw
+            value is required. Favour using tokens directly wherever possible,
+            since resolving raw values can break theming if overused.
+        </>
+    }
+/>
+
+<br />
 ## Usage
 
 ```js


### PR DESCRIPTION
## Summary:

Add links to the `tokenValue` docs from the semantic color docs, as [suggested by Ned](https://khanacademy.slack.com/archives/C4PE1QM5Y/p1779990860497309?thread_ts=1779990329.832639&cid=C4PE1QM5Y)! 


Issue: WB-2356

## Test plan:

Review the Using Color and Semantic Color Token docs:
- `?path=/docs/packages-tokens-semantic-color--docs#usage`
- `?path=/docs/foundations-using-color--docs#getting-raw-token-values`