### PR TITLE
SYL Dark - Selects

### DIFF
--- a/.changeset/six-years-flow.md
+++ b/.changeset/six-years-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+SYL Dark - Update disabled semantic color core tokens

--- a/.changeset/small-steaks-talk.md
+++ b/.changeset/small-steaks-talk.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+SingleSelect and MultiSelect opener - Updating styles:
+- Use `semanticColor.core.foreground.neutral.default` for the dropdown icon in all themes
+- Fixed `placeholder` styling in selects when the field is `disabled` or `readOnly`
+- Improved the `press + focus` styling to work with `syl-dark`

--- a/__docs__/wonder-blocks-dropdown/multi-select-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select-testing-snapshots.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {MultiSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {
     longText,
@@ -20,7 +20,7 @@ export default {
     title: "Packages / Dropdown / Testing / Snapshots / MultiSelect",
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     args: {

--- a/__docs__/wonder-blocks-dropdown/single-select-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/single-select-testing-snapshots.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {SingleSelect, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {
@@ -20,7 +20,7 @@ export default {
     title: "Packages / Dropdown / Testing / Snapshots / SingleSelect",
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     args: {

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -271,11 +271,17 @@ const styles = StyleSheet.create({
             // the focus behaviour more consistent with the other field components.
             ...focusStyles.focus[":focus-visible"],
         },
+        [":focus:active" as any]: {
+            boxShadow: `${PRESS_SHADOW}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
+        },
     },
     error: {
         background: semanticColor.input.error.background,
         border: `${theme.opener.border.width.error} solid ${semanticColor.input.error.border}`,
         color: semanticColor.input.error.foreground,
+        [":focus:active" as any]: {
+            boxShadow: `${PRESS_SHADOW}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
+        },
     },
     disabled: {
         background: semanticColor.input.disabled.background,
@@ -285,7 +291,9 @@ const styles = StyleSheet.create({
         ":active": {
             boxShadow: "none",
         },
-        ":focus": focusStyles.focus[":focus-visible"],
+        [":focus:active" as any]: {
+            boxShadow: focusStyles.focus[":focus-visible"].boxShadow,
+        },
     },
     press: {
         boxShadow: PRESS_SHADOW,
@@ -304,6 +312,8 @@ const styles = StyleSheet.create({
         ":active": {
             boxShadow: "none",
         },
-        ":focus": focusStyles.focus[":focus-visible"],
+        [":focus:active" as any]: {
+            boxShadow: focusStyles.focus[":focus-visible"].boxShadow,
+        },
     },
 });

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -155,7 +155,7 @@ export default class SelectOpener extends React.Component<
 
         const iconColor = disabled
             ? semanticColor.core.foreground.disabled.default
-            : theme.opener.color.icon;
+            : semanticColor.core.foreground.neutral.default;
 
         const style = [
             styles.shared,

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -166,7 +166,8 @@ export default class SelectOpener extends React.Component<
             isPlaceholder && disabled && styles.disabledPlaceholder,
             !disabled && !readOnly && this.state.pressed && styles.press,
             readOnly && styles.readOnly,
-            readOnly && isPlaceholder && styles.readOnlyPlaceholder,
+            // Re-apply placeholder styles for readOnly + placeholder combination
+            readOnly && isPlaceholder && styles.placeholder,
         ];
 
         const allowInteraction = !disabled && !readOnly;
@@ -310,9 +311,6 @@ const styles = StyleSheet.create({
     },
     disabledPlaceholder: {
         color: semanticColor.input.disabled.placeholder,
-    },
-    readOnlyPlaceholder: {
-        color: semanticColor.input.default.placeholder,
     },
     readOnly: {
         background: semanticColor.input.readOnly.background,

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -163,8 +163,10 @@ export default class SelectOpener extends React.Component<
             disabled && styles.disabled,
             error && styles.error,
             isPlaceholder && styles.placeholder,
+            isPlaceholder && disabled && styles.disabledPlaceholder,
             !disabled && !readOnly && this.state.pressed && styles.press,
             readOnly && styles.readOnly,
+            readOnly && isPlaceholder && styles.readOnlyPlaceholder,
         ];
 
         const allowInteraction = !disabled && !readOnly;
@@ -304,6 +306,12 @@ const styles = StyleSheet.create({
         },
     },
     placeholder: {
+        color: semanticColor.input.default.placeholder,
+    },
+    disabledPlaceholder: {
+        color: semanticColor.input.disabled.placeholder,
+    },
+    readOnlyPlaceholder: {
         color: semanticColor.input.default.placeholder,
     },
     readOnly: {

--- a/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/select-opener.tsx
@@ -262,14 +262,14 @@ const styles = StyleSheet.create({
         border: `${border.width.thin} solid ${semanticColor.input.default.border}`,
         color: semanticColor.input.default.foreground,
         cursor: "pointer",
+        ":active": {
+            boxShadow: PRESS_SHADOW,
+        },
         ":focus": {
             // Using :focus instead of :focus-visible to ensure the focus ring is
             // visible when the button is focused (even when clicked). This makes
             // the focus behaviour more consistent with the other field components.
             ...focusStyles.focus[":focus-visible"],
-        },
-        ":active": {
-            boxShadow: `${PRESS_SHADOW}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
         },
     },
     error: {
@@ -285,6 +285,7 @@ const styles = StyleSheet.create({
         ":active": {
             boxShadow: "none",
         },
+        ":focus": focusStyles.focus[":focus-visible"],
     },
     press: {
         boxShadow: PRESS_SHADOW,
@@ -301,8 +302,8 @@ const styles = StyleSheet.create({
         background: semanticColor.input.readOnly.background,
         color: semanticColor.input.readOnly.text,
         ":active": {
-            // Make sure press shadow outline is not shown when it is read-only.
-            boxShadow: focusStyles.focus[":focus-visible"].boxShadow,
+            boxShadow: "none",
         },
+        ":focus": focusStyles.focus[":focus-visible"],
     },
 });

--- a/packages/wonder-blocks-dropdown/src/theme/default.ts
+++ b/packages/wonder-blocks-dropdown/src/theme/default.ts
@@ -2,7 +2,6 @@ import {
     border,
     boxShadow,
     font,
-    semanticColor,
     sizing,
 } from "@khanacademy/wonder-blocks-tokens";
 
@@ -29,9 +28,6 @@ export default {
             radius: {
                 rest: border.radius.radius_040,
             },
-        },
-        color: {
-            icon: semanticColor.core.foreground.neutral.default,
         },
         layout: {
             padding: {

--- a/packages/wonder-blocks-dropdown/src/theme/thunderblocks.ts
+++ b/packages/wonder-blocks-dropdown/src/theme/thunderblocks.ts
@@ -4,7 +4,6 @@ import {
     border,
     boxShadow,
     font,
-    semanticColor,
     sizing,
 } from "@khanacademy/wonder-blocks-tokens";
 import defaultTheme from "./default";
@@ -32,9 +31,6 @@ export default mergeTheme(defaultTheme, {
             radius: {
                 rest: border.radius.radius_080,
             },
-        },
-        color: {
-            icon: semanticColor.core.foreground.instructive.default,
         },
         layout: {
             padding: {

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -76,8 +76,9 @@ const core = {
         },
         disabled: {
             subtle: transparent,
-            default: color.gray_05,
-            strong: color.gray_20,
+            default: color.gray_10,
+            // There is no difference between subtle and default in dark mode, intentional to sync with design
+            strong: color.gray_10,
         },
         overlay: {
             default: color.black_80,
@@ -115,8 +116,8 @@ const core = {
         },
         disabled: {
             subtle: color.gray_10,
-            default: color.gray_10,
-            strong: color.gray_20,
+            default: color.gray_20,
+            strong: color.gray_30,
         },
         knockout: {
             default: color.black_100,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -141,7 +141,7 @@ const core = {
             },
             disabled: {
                 subtle: transparent,
-                default: color.gray_10,
+                default: color.gray_05,
             },
         },
     },

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -678,20 +678,20 @@ export const semanticColor = mergeTheme(thunderblocksSemanticColor, {
     input: {
         default: {
             border: core.border.neutral.default,
-            background: core.transparent,
+            background: core.background.base.default,
             foreground: core.foreground.neutral.strong,
             placeholder: core.foreground.neutral.subtle,
         },
         checked: thunderblocksSemanticColor.input.checked,
         disabled: {
             border: core.border.disabled.strong,
-            background: core.transparent,
+            background: core.background.base.default,
             foreground: core.foreground.disabled.strong,
             placeholder: core.foreground.disabled.subtle,
         },
         error: {
             border: core.border.critical.default,
-            background: core.transparent,
+            background: core.background.base.default,
             foreground: core.foreground.neutral.strong,
         },
         readOnly: {

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -678,25 +678,25 @@ export const semanticColor = mergeTheme(thunderblocksSemanticColor, {
     input: {
         default: {
             border: core.border.neutral.default,
-            background: core.background.base.default,
+            background: core.transparent,
             foreground: core.foreground.neutral.strong,
             placeholder: core.foreground.neutral.subtle,
         },
         checked: thunderblocksSemanticColor.input.checked,
         disabled: {
-            border: core.border.disabled.default,
-            background: core.background.base.default,
+            border: core.border.disabled.strong,
+            background: core.transparent,
             foreground: core.foreground.disabled.strong,
             placeholder: core.foreground.disabled.subtle,
         },
         error: {
             border: core.border.critical.default,
-            background: core.background.base.default,
+            background: core.transparent,
             foreground: core.foreground.neutral.strong,
         },
         readOnly: {
             background: core.background.disabled.default,
-            text: core.foreground.neutral.default,
+            text: core.foreground.neutral.strong,
             icon: core.foreground.neutral.subtle,
         },
     },


### PR DESCRIPTION
## Summary:

Reviewing the SelectOpener (SingleSelect and MultiSelect) components in SYL Dark to confirm they look as expected, match the design specs, and have no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for these components.

Changes include:
- Updating the disabled and readonly tokens for SYL Dark
  - Because of this, we also update the chonky button disabled shadow so it looks flat in syl-dark if the background is also `gray_05`
- Using `semanticColor.core.foreground.neutral.default` for the dropdown icon in all themes (this will be gray in all themes instead of blurple in tb/syl-dark). We remove the component level `theme.opener.color.icon` token for this
- Fixed the `placeholder` styling in selects when the field is disabled or readOnly
- Fixed the press + focused styling to work with syl-dark so that the white focus outline is included 

Issue: WB-2166
Design: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=8389-10450&t=48QoihVmhYQeteLi-4

## Test plan:

Review the following stories and confirm things look as expected and there are no a11y violations:
- `?path=/story/packages-dropdown-testing-snapshots-singleselect--state-sheet-story&globals=theme:syl-dark`
- `?path=/story/packages-dropdown-testing-snapshots-multiselect--state-sheet-story&globals=theme:syl-dark`

Review visual changes in Chromatic and make sure all changes are intentional
