### PR TITLE
Add snapshots for Combobox

### DIFF
--- a/.changeset/smooth-goats-beam.md
+++ b/.changeset/smooth-goats-beam.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Combobox: Add support for `aria-label`

--- a/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
@@ -1,0 +1,264 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
+import {PropsFor} from "@khanacademy/wonder-blocks-core";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {allThemeModes} from "../../.storybook/modes";
+import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
+import {ScenariosLayout} from "../components/scenarios-layout";
+import {
+    longText,
+    longTextWithNoWordBreak,
+} from "../components/text-for-testing";
+
+/**
+ * The following stories are used to generate the pseudo states for the
+ * combobox component. This is only used for visual testing in Chromatic.
+ */
+export default {
+    title: "Packages / Dropdown / Testing / Snapshots / Combobox",
+    parameters: {
+        chromatic: {
+            modes: allThemeModes,
+        },
+    },
+    args: {
+        children: [
+            <OptionItem label="item 1" value="1" key="1" />,
+            <OptionItem label="item 2" value="2" key="2" />,
+            <OptionItem label="item 3" value="3" key="3" />,
+        ],
+        selectionType: "single",
+        value: "",
+        onChange: () => {},
+    },
+    tags: ["!autodocs", "!manifest"],
+} as Meta<typeof Combobox>;
+
+type Story = StoryObj<typeof Combobox>;
+
+const rows = [
+    {
+        name: "Default",
+        props: {"aria-label": "Example", style: {minInlineSize: 200}},
+    },
+    {
+        name: "Placeholder",
+        props: {"aria-label": "Example", placeholder: "Placeholder", value: ""},
+    },
+    {
+        name: "With Value",
+        props: {"aria-label": "Example", value: "1"},
+    },
+    {
+        name: "Multiple (2 selected)",
+        props: {
+            "aria-label": "Example",
+            selectionType: "multiple" as const,
+            value: ["1", "2"],
+        },
+    },
+];
+
+const columns = [
+    {
+        name: "Default",
+        props: {},
+    },
+    {
+        name: "Disabled",
+        props: {disabled: true},
+    },
+    {
+        name: "Error",
+        props: {error: true},
+    },
+];
+
+export const StateSheetStory: Story = {
+    name: "StateSheet",
+    render: (args) => {
+        return (
+            <StateSheet rows={rows} columns={columns}>
+                {({props, name}) => (
+                    <Combobox {...args} {...props} key={name} />
+                )}
+            </StateSheet>
+        );
+    },
+    parameters: {
+        pseudo: {
+            ...defaultPseudoStates,
+            // Using the focus selector instead so that the focus outline is
+            // shown when the combobox is clicked
+            focus: [...defaultPseudoStates.focusVisible],
+        },
+    },
+};
+
+const ControlledCombobox = (props: PropsFor<typeof Combobox>) => {
+    const [value, setValue] = React.useState(props.value);
+
+    return <Combobox {...props} value={value} onChange={setValue} />;
+};
+
+// A larger set of options used for the multiple-selection scenarios.
+const manyItems = Array.from({length: 10}, (_, index) => {
+    const value = `${index + 1}`;
+    return <OptionItem label={`item ${value}`} value={value} key={value} />;
+});
+
+export const Scenarios: Story = {
+    render: () => {
+        const scenarios = [
+            {
+                name: "Long option item label",
+                props: {
+                    selectionType: "single" as const,
+                    value: "",
+                    placeholder: "Placeholder",
+                    children: [
+                        <OptionItem label={longText} value="1" key="1" />,
+                    ],
+                    opened: true,
+                    style: {paddingBlockEnd: sizing.size_560},
+                },
+            },
+            {
+                name: "Long option item label with no word break",
+                props: {
+                    selectionType: "single" as const,
+                    value: "",
+                    placeholder: "Placeholder",
+                    children: [
+                        <OptionItem
+                            label={longTextWithNoWordBreak}
+                            value="1"
+                            key="1"
+                        />,
+                    ],
+                    opened: true,
+                    style: {paddingBlockEnd: sizing.size_560},
+                },
+            },
+            {
+                name: "Long placeholder",
+                props: {
+                    selectionType: "single",
+                    value: "",
+                    placeholder: longText,
+                    children: [],
+                },
+            },
+            {
+                name: "Long placeholder with no word break",
+                props: {
+                    selectionType: "single" as const,
+                    value: "",
+                    placeholder: longTextWithNoWordBreak,
+                    children: [],
+                },
+            },
+            {
+                name: "Long selected option label",
+                props: {
+                    selectionType: "single" as const,
+                    placeholder: "Placeholder",
+                    children: [
+                        <OptionItem label={longText} value="1" key="1" />,
+                        <OptionItem label={longText} value="2" key="2" />,
+                        <OptionItem label={longText} value="3" key="3" />,
+                    ],
+                    value: "1",
+                },
+            },
+            {
+                name: "Long selected option label with no word break",
+                props: {
+                    selectionType: "single" as const,
+                    placeholder: "Placeholder",
+                    children: [
+                        <OptionItem
+                            label={longTextWithNoWordBreak}
+                            value="1"
+                            key="1"
+                        />,
+                        <OptionItem
+                            label={longTextWithNoWordBreak}
+                            value="2"
+                            key="2"
+                        />,
+                        <OptionItem
+                            label={longTextWithNoWordBreak}
+                            value="3"
+                            key="3"
+                        />,
+                    ],
+                    value: "1",
+                },
+            },
+            {
+                name: "0 selected",
+                props: {
+                    selectionType: "multiple" as const,
+                    placeholder: "Placeholder",
+                    children: manyItems,
+                    value: [],
+                },
+            },
+            {
+                name: "1 selected",
+                props: {
+                    selectionType: "multiple" as const,
+                    placeholder: "Placeholder",
+                    children: manyItems,
+                    value: ["1"],
+                },
+            },
+            {
+                name: "2 selected",
+                props: {
+                    selectionType: "multiple" as const,
+                    placeholder: "Placeholder",
+                    children: manyItems,
+                    value: ["1", "2"],
+                },
+            },
+            {
+                name: "4 selected",
+                props: {
+                    selectionType: "multiple" as const,
+                    placeholder: "Placeholder",
+                    children: manyItems,
+                    value: ["1", "2", "3", "4"],
+                },
+            },
+            {
+                name: "10 selected",
+                props: {
+                    selectionType: "multiple" as const,
+                    placeholder: "Placeholder",
+                    children: manyItems,
+                    value: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+                },
+            },
+        ];
+        return (
+            <ScenariosLayout scenarios={scenarios}>
+                {(props, name) => (
+                    <ControlledCombobox
+                        {...props}
+                        key={name}
+                        aria-label={name}
+                    />
+                )}
+            </ScenariosLayout>
+        );
+    },
+    globals: {
+        viewport: {
+            value: "small",
+        },
+    },
+};

--- a/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
-import {PropsFor} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {themeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
@@ -10,6 +10,7 @@ import {
     longText,
     longTextWithNoWordBreak,
 } from "../components/text-for-testing";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -117,6 +118,7 @@ export const Scenarios: Story = {
                     ],
                     opened: true,
                 },
+                decorator: <View style={{marginBlockEnd: sizing.size_480}} />,
             },
             {
                 name: "Long option item label with no word break",
@@ -133,6 +135,7 @@ export const Scenarios: Story = {
                     ],
                     opened: true,
                 },
+                decorator: <View style={{marginBlockEnd: sizing.size_480}} />,
             },
             {
                 name: "Long placeholder",

--- a/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
@@ -3,7 +3,6 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PropsFor} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {themeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
@@ -122,7 +121,6 @@ export const Scenarios: Story = {
                         <OptionItem label={longText} value="1" key="1" />,
                     ],
                     opened: true,
-                    style: {paddingBlockEnd: sizing.size_560},
                 },
             },
             {
@@ -139,7 +137,6 @@ export const Scenarios: Story = {
                         />,
                     ],
                     opened: true,
-                    style: {paddingBlockEnd: sizing.size_560},
                 },
             },
             {

--- a/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
@@ -4,7 +4,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {PropsFor} from "@khanacademy/wonder-blocks-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
-import {allThemeModes} from "../../.storybook/modes";
+import {themeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {
@@ -20,7 +20,7 @@ export default {
     title: "Packages / Dropdown / Testing / Snapshots / Combobox",
     parameters: {
         chromatic: {
-            modes: allThemeModes,
+            modes: themeModes,
         },
     },
     args: {

--- a/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
@@ -87,12 +87,7 @@ export const StateSheetStory: Story = {
         );
     },
     parameters: {
-        pseudo: {
-            ...defaultPseudoStates,
-            // Using the focus selector instead so that the focus outline is
-            // shown when the combobox is clicked
-            focus: [...defaultPseudoStates.focusVisible],
-        },
+        pseudo: defaultPseudoStates,
     },
 };
 

--- a/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
@@ -256,4 +256,17 @@ export const Scenarios: Story = {
             value: "small",
         },
     },
+    parameters: {
+        a11y: {
+            config: {
+                rules: [
+                    {
+                        // TODO(WB-2359): Fix this a11y violation
+                        id: "aria-valid-attr-value",
+                        enabled: false,
+                    },
+                ],
+            },
+        },
+    },
 };

--- a/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox.stories.tsx
@@ -65,6 +65,7 @@ const defaultArgs = {
     testId: "",
     autoComplete: "none",
     loading: false,
+    "aria-label": "", // Setting to empty string to avoid SB control showing as an object to represent undefined
 };
 
 export default {

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -131,6 +131,11 @@ type Props = {
     startIcon?: React.ReactElement<
         React.ComponentProps<typeof PhosphorIcon>
     > | null;
+
+    /**
+     * An optional aria-label to display on the combobox.
+     */
+    "aria-label"?: string;
 };
 
 /**
@@ -160,6 +165,7 @@ export default function Combobox({
     startIcon,
     testId,
     value = "",
+    "aria-label": ariaLabel,
 }: Props) {
     // eslint-disable-next-line import/no-deprecated
     const generatedUniqueId = useId();
@@ -580,6 +586,7 @@ export default function Combobox({
                 {maybeRenderStartIcon()}
 
                 <TextField
+                    aria-label={ariaLabel}
                     id={textFieldId}
                     testId={testId}
                     style={styles.combobox}


### PR DESCRIPTION
## Summary:

Adding visual test coverage for Combobox. Will address the styling and add `syl-dark` coverage in a follow up PR!

To avoid new a11y violations in Storybook for the new stories, I also added support for an `aria-label` prop for the Combobox component so we can use it in the StateSheet. 

Note: There are some styling issues with different states. I'll fix the color related ones in the next PR, and created WB-2359 for other improvements (in the post clean up epic. Combobox is not used in `frontend` currently so it is lower priority currently!). Combobox also currently provides state styles programmatically so focus styles will not be shown in the StateSheet snapshot for now

Issue: WB-2166

## Test plan:

Review Chromatic snapshots. Confirm Combobox can receive an aria-label