### PR TITLE
SYL Dark - Update disabled semantic color core tokens

### DIFF
--- a/.changeset/six-years-flow.md
+++ b/.changeset/six-years-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+SYL Dark - Update disabled semantic color core tokens

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -76,8 +76,9 @@ const core = {
         },
         disabled: {
             subtle: transparent,
-            default: color.gray_05,
-            strong: color.gray_20,
+            default: color.gray_10,
+            // There is no difference between subtle and default in dark mode, intentional to sync with design
+            strong: color.gray_10,
         },
         overlay: {
             default: color.black_80,
@@ -115,8 +116,8 @@ const core = {
         },
         disabled: {
             subtle: color.gray_10,
-            default: color.gray_10,
-            strong: color.gray_20,
+            default: color.gray_20,
+            strong: color.gray_30,
         },
         knockout: {
             default: color.black_100,


### PR DESCRIPTION
## Summary:

Update SYL Dark disabled semantic color tokens to address an issue where the readonly state for fields in syl-dark is not visibly noticable if the background is `background.base.subtle` ([related thread](https://khanacademy.slack.com/archives/C07CA2YR0BZ/p1780070082353699?thread_ts=1779826920.718159&cid=C07CA2YR0BZ))

Issue: WB-2166

## Test plan:

Confirm changes in Chromatic