### PR TITLE
fix(icon-button): don't activate disabled buttons via keyboard (TUT-3716)

### DIFF
--- a/.changeset/tut-3716-disabled-icon-button-keyboard.md
+++ b/.changeset/tut-3716-disabled-icon-button-keyboard.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": patch
+---
+
+`IconButton`, `ActivityIconButton`, `ConversationIconButton`, and `NodeIconButton` no longer activate (fire `onClick` or enter the pressed state) when they are `disabled` and the Enter/Space key is used. Keyboard activation now respects the `disabled` state, matching the existing mouse-click behavior. Default key handling (e.g. preventing a disabled `type="submit"` button from submitting its form) is preserved.

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-unstyled.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-unstyled.test.tsx
@@ -365,6 +365,82 @@ describe("IconButtonUnstyled", () => {
                 expect(onPressMock).toHaveBeenLastCalledWith(false);
             });
         });
+
+        describe("when disabled", () => {
+            describe.each([
+                {key: "Enter", label: "Enter"},
+                {key: " ", label: "Space"},
+            ])("$label key", ({key}) => {
+                it("should not trigger onClick", () => {
+                    // Arrange
+                    const onClickMock = jest.fn();
+
+                    render(
+                        <IconButtonUnstyled
+                            aria-label="search"
+                            onClick={onClickMock}
+                            disabled={true}
+                            testId="icon-button"
+                        >
+                            <PhosphorIcon icon={magnifyingGlassIcon} />
+                        </IconButtonUnstyled>,
+                    );
+
+                    // Act
+                    const button = screen.getByRole("button");
+                    // NOTE: we need to use fireEvent here because await userEvent doesn't
+                    // support keyUp/Down events and we use these handlers to override
+                    // the default behavior of the button.
+                    // eslint-disable-next-line testing-library/prefer-user-event
+                    fireEvent.keyDown(button, {
+                        key,
+                    });
+                    // eslint-disable-next-line testing-library/prefer-user-event
+                    fireEvent.keyUp(button, {
+                        key,
+                    });
+
+                    // Assert
+                    expect(onClickMock).not.toHaveBeenCalled();
+                });
+
+                it("should not enter the pressed state", () => {
+                    // Arrange
+                    const onPressMock = jest.fn();
+
+                    render(
+                        <IconButtonUnstyled
+                            aria-label="search"
+                            onPress={onPressMock}
+                            disabled={true}
+                            testId="icon-button"
+                        >
+                            <PhosphorIcon icon={magnifyingGlassIcon} />
+                        </IconButtonUnstyled>,
+                    );
+
+                    // Act
+                    const button = screen.getByRole("button");
+                    // NOTE: we need to use fireEvent here because await userEvent doesn't
+                    // support keyUp/Down events and we use these handlers to override
+                    // the default behavior of the button.
+                    // eslint-disable-next-line testing-library/prefer-user-event
+                    fireEvent.keyDown(button, {
+                        key,
+                    });
+                    // eslint-disable-next-line testing-library/prefer-user-event
+                    fireEvent.keyUp(button, {
+                        key,
+                    });
+
+                    // Assert
+                    // The button must never signal an active press while
+                    // disabled. `onPress(false)` may still fire on release as
+                    // a no-op cleanup, but `onPress(true)` must not.
+                    expect(onPressMock).not.toHaveBeenCalledWith(true);
+                });
+            });
+        });
     });
 
     describe("type", () => {

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-unstyled.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-unstyled.tsx
@@ -67,23 +67,25 @@ export const IconButtonUnstyled: React.ForwardRefExoticComponent<
             // for links, which is to activate the link on `Enter`.
             if (!href && (key === keys.enter || key === keys.space)) {
                 e.preventDefault();
-                onPress?.(true);
+                if (!disabled) {
+                    onPress?.(true);
+                }
             }
         },
-        [href, onPress],
+        [disabled, href, onPress],
     );
 
     const handleKeyUp = React.useCallback(
         (e: React.KeyboardEvent) => {
             const key = e.key;
             if (!href && (key === keys.enter || key === keys.space)) {
-                if (restProps.onClick) {
+                if (!disabled && restProps.onClick) {
                     restProps.onClick(e);
                 }
                 onPress?.(false);
             }
         },
-        [href, onPress, restProps],
+        [disabled, href, onPress, restProps],
     );
 
     const commonProps = {


### PR DESCRIPTION
## Summary

`IconButtonUnstyled`'s `keydown`/`keyup` handlers invoked `onClick` (and `onPress`) even when the button was `disabled` from the keyboard. 

Because disabled icon buttons render as a focusable `<button aria-disabled="true">` (not a native `disabled` button), a user could tab to a disabled `IconButton`, `ActivityIconButton`, `ConversationIconButton`, or `NodeIconButton` and press **Enter** or **Space** to trigger it.

The mouse path was already guarded (`onClick={disabled ? undefined : restProps.onClick}`); only the keyboard handlers were missing the check.

## Fix

Gate both keyboard handlers on `!disabled` (and add `disabled` to their dependency arrays) so keyboard activation matches the existing mouse-click behavior.

## Testing

- Added `when disabled` cases under the existing "Keyboard Navigation" tests in `icon-button-unstyled.test.tsx`, asserting that Enter/Space fire neither `onClick` nor `onPress` when disabled (these fail without the fix).
- Existing keyboard tests confirm the enabled path is unchanged.
- Confirmed via linking the frontend to this fixed wonderblocks and checking within Storybook.

See https://khanacademy.atlassian.net/browse/TUT-3716


Issue: TUT-3716