### PR TITLE
SYL Dark - Breadcrumbs

### DIFF
--- a/.changeset/rude-terms-chew.md
+++ b/.changeset/rude-terms-chew.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-breadcrumbs": patch
 ---
 
-BreadcrumbItem: USe semantic color for fill to support syl-dark
+BreadcrumbItem: Use semantic color for fill to support syl-dark

--- a/.changeset/rude-terms-chew.md
+++ b/.changeset/rude-terms-chew.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-breadcrumbs": patch
+---
+
+BreadcrumbItem: USe semantic color for fill to support syl-dark

--- a/.changeset/rude-terms-chew.md
+++ b/.changeset/rude-terms-chew.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-breadcrumbs": patch
 ---
 
-BreadcrumbItem: Use semantic color for fill to support syl-dark
+BreadcrumbItem: Use semantic color for separator icon fill to support syl-dark

--- a/__docs__/wonder-blocks-breadcrumbs/breadcrumbs-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-breadcrumbs/breadcrumbs-testing-snapshots.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
-import {View} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
 import {
     Breadcrumbs,

--- a/__docs__/wonder-blocks-breadcrumbs/breadcrumbs-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-breadcrumbs/breadcrumbs-testing-snapshots.stories.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import Link from "@khanacademy/wonder-blocks-link";
+import {
+    Breadcrumbs,
+    BreadcrumbsItem,
+} from "@khanacademy/wonder-blocks-breadcrumbs";
+
+import {allThemeModes} from "../../.storybook/modes";
+import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
+
+const rows = [{name: "Default", props: {}}];
+
+const columns = [{name: "Default", props: {}}];
+
+type Story = StoryObj<typeof Breadcrumbs>;
+
+/**
+ * The following stories are used to generate the pseudo states for the
+ * Breadcrumbs component. This is only used for visual testing in Chromatic.
+ *
+ * Breadcrumbs is a composition-based component, so the states that matter for
+ * theming are the link states (rest/hover/press/focus), the separator color,
+ * and the current-page (plain text) item. The StateSheet renders a
+ * representative trail in each pseudo state across every theme mode.
+ */
+const meta = {
+    title: "Packages / Breadcrumbs / Testing / Snapshots / Breadcrumbs",
+    component: Breadcrumbs,
+    parameters: {
+        chromatic: {
+            modes: allThemeModes,
+        },
+    },
+    tags: ["!autodocs", "!manifest"],
+} satisfies Meta<typeof Breadcrumbs>;
+
+export default meta;
+
+export const StateSheetStory: Story = {
+    name: "StateSheet",
+    render: (args) => {
+        return (
+            <StateSheet rows={rows} columns={columns}>
+                {({className, name}) => (
+                    <View className={className} key={name}>
+                        <Breadcrumbs {...args} aria-label="Navigation Menu">
+                            <BreadcrumbsItem>
+                                <Link href="#course">Course</Link>
+                            </BreadcrumbsItem>
+                            <BreadcrumbsItem>
+                                <Link href="#unit">Unit</Link>
+                            </BreadcrumbsItem>
+                            <BreadcrumbsItem>Lesson</BreadcrumbsItem>
+                        </Breadcrumbs>
+                    </View>
+                )}
+            </StateSheet>
+        );
+    },
+    parameters: {
+        pseudo: defaultPseudoStates,
+    },
+};

--- a/__docs__/wonder-blocks-breadcrumbs/breadcrumbs-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-breadcrumbs/breadcrumbs-testing-snapshots.stories.tsx
@@ -11,7 +11,26 @@ import {
 import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 
-const rows = [{name: "Default", props: {}}];
+const rows = [
+    {
+        name: "Default",
+        props: {
+            children: [
+                <BreadcrumbsItem>
+                    <Link href="#course">Course</Link>
+                </BreadcrumbsItem>,
+                <BreadcrumbsItem>
+                    <Link href="#unit">Unit</Link>
+                </BreadcrumbsItem>,
+                <BreadcrumbsItem>Lesson</BreadcrumbsItem>,
+            ],
+        },
+    },
+    {
+        name: "Single breadcrumb",
+        props: {children: <BreadcrumbsItem>Lesson</BreadcrumbsItem>},
+    },
+];
 
 const columns = [{name: "Default", props: {}}];
 
@@ -44,18 +63,8 @@ export const StateSheetStory: Story = {
     render: (args) => {
         return (
             <StateSheet rows={rows} columns={columns}>
-                {({className, name}) => (
-                    <View className={className} key={name}>
-                        <Breadcrumbs {...args} aria-label="Navigation Menu">
-                            <BreadcrumbsItem>
-                                <Link href="#course">Course</Link>
-                            </BreadcrumbsItem>
-                            <BreadcrumbsItem>
-                                <Link href="#unit">Unit</Link>
-                            </BreadcrumbsItem>
-                            <BreadcrumbsItem>Lesson</BreadcrumbsItem>
-                        </Breadcrumbs>
-                    </View>
+                {({props, name}) => (
+                    <Breadcrumbs {...props} aria-label={name} />
                 )}
             </StateSheet>
         );

--- a/__docs__/wonder-blocks-breadcrumbs/breadcrumbs.stories.tsx
+++ b/__docs__/wonder-blocks-breadcrumbs/breadcrumbs.stories.tsx
@@ -23,6 +23,10 @@ const meta: Meta<typeof Breadcrumbs> = {
                 version={packageConfig.version}
             />
         ),
+        chromatic: {
+            // Disable snapshots since they're covered by the testing snapshots
+            disableSnapshot: true,
+        },
     },
 };
 

--- a/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
+++ b/packages/wonder-blocks-breadcrumbs/src/components/breadcrumbs-item.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import Link from "@khanacademy/wonder-blocks-link";
-import {font, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {font, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 type Props = AriaProps & {
     /**
@@ -78,6 +78,7 @@ const styles = StyleSheet.create({
 
     separator: {
         marginInlineStart: sizing.size_040,
+        fill: semanticColor.core.foreground.neutral.default,
     },
 });
 


### PR DESCRIPTION
## Summary:

Reviewing the Breadcrumbs component in SYL Dark to confirm it looks as expected, matches the design specs, and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Changes specific to the component:
- Use semanticColor token for separator styling to support syl-dark

Note: Created WB-2363 to fix the existing focus outline issue in all themes


Issue: WB-2166

## Test plan:

Review `?path=/story/packages-breadcrumbs-testing-snapshots-breadcrumbs--state-sheet-story&globals=theme:syl-dark` and confirm things look as expected and there are no a11y violations

Review visual changes in Chromatic