### PR TITLE
SYL Dark - Icons package (PhosphorIcon, Icon, StreakIcon, GemIcon)

### DIFF
--- a/.changeset/famous-beers-attack.md
+++ b/.changeset/famous-beers-attack.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon": patch
+---
+
+Use hex colors in StreakIcon and GemIcon so it looks the same across all themes

--- a/__docs__/wonder-blocks-icon/custom-icon-components-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon/custom-icon-components-testing-snapshots.stories.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import {StyleSheet} from "aphrodite";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+import {GemIcon, StreakIcon} from "@khanacademy/wonder-blocks-icon";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+
+import {commonStates, StateSheet} from "../components/state-sheet";
+import {allThemeModes} from "../../.storybook/modes";
+
+/**
+ * The following stories are used to generate visual regression snapshots
+ * for the custom icon components (GemIcon, StreakIcon) across themes.
+ *
+ * Custom icon components use semantic color tokens for the different parts of
+ * the icon, so they are the most theme-sensitive icons to verify in syl-dark.
+ */
+export default {
+    title: "Packages / Icon / Testing / Snapshots / Custom Icon Components",
+    component: GemIcon,
+    parameters: {
+        chromatic: {
+            modes: allThemeModes,
+        },
+    },
+    tags: ["!autodocs", "!manifest"],
+} as Meta<typeof GemIcon>;
+
+type Story = StoryObj<typeof GemIcon>;
+
+// Custom icons can be styled using the `style` prop.
+const customStyle = {
+    backgroundColor: semanticColor.core.background.base.subtle,
+    padding: sizing.size_040,
+    borderRadius: border.radius.radius_040,
+    border: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
+};
+
+const columns = [
+    {name: "Default", props: {}},
+    {name: "Custom style", props: {style: customStyle}},
+];
+
+const rows = [
+    {name: "GemIcon", props: {Component: GemIcon}},
+    {name: "StreakIcon", props: {Component: StreakIcon}},
+];
+
+export const StateSheetStory: Story = {
+    name: "StateSheet",
+    render: () => (
+        <StateSheet
+            rows={rows}
+            columns={columns}
+            states={[commonStates.rest]}
+            title="Icon / Style"
+        >
+            {({props}) => (
+                // Custom icons expand to fill their parent, so we set a
+                // fixed size on the container.
+                <View style={styles.iconContainer}>
+                    <props.Component {...props} />
+                </View>
+            )}
+        </StateSheet>
+    ),
+};
+
+const styles = StyleSheet.create({
+    iconContainer: {
+        height: sizing.size_400,
+        width: sizing.size_400,
+    },
+});

--- a/__docs__/wonder-blocks-icon/custom-icon-components.stories.tsx
+++ b/__docs__/wonder-blocks-icon/custom-icon-components.stories.tsx
@@ -5,7 +5,7 @@ import packageConfig from "../../packages/wonder-blocks-icon/package.json";
 import {GemIcon, Icon, StreakIcon} from "@khanacademy/wonder-blocks-icon";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {themeModes} from "../../.storybook/modes";
+import AriaArgTypes from "../wonder-blocks-core/aria.argtypes";
 
 /**
  * Custom icon components that render an inline svg. Use with the `Icon`
@@ -24,12 +24,13 @@ export default {
             />
         ),
         chromatic: {
+            // Disable snapshots since they're covered by the testing snapshots
             disableSnapshot: true,
-            modes: themeModes,
         },
     },
     component: GemIcon,
     argTypes: {
+        ...AriaArgTypes,
         style: {
             table: {
                 type: {
@@ -69,12 +70,6 @@ export const AllCustomIcons: StoryComponentType = {
             {/* Add other custom icons here */}
         </View>
     ),
-    parameters: {
-        chromatic: {
-            // Include snapshots for all the custom icons
-            disableSnapshot: false,
-        },
-    },
 };
 
 /**

--- a/__docs__/wonder-blocks-icon/icon-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon/icon-testing-snapshots.stories.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+import {GemIcon, Icon, StreakIcon} from "@khanacademy/wonder-blocks-icon";
+
+import {commonStates, StateSheet} from "../components/state-sheet";
+import {
+    multiColoredIcon,
+    singleColoredIcon,
+} from "../components/icons-for-testing";
+import {allThemeModes} from "../../.storybook/modes";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+
+/**
+ * The following stories are used to generate visual regression snapshots
+ * for the Icon component across themes.
+ */
+export default {
+    title: "Packages / Icon / Testing / Snapshots / Icon",
+    component: Icon,
+    parameters: {
+        chromatic: {
+            modes: allThemeModes,
+        },
+    },
+    tags: ["!autodocs", "!manifest"],
+} as Meta<typeof Icon>;
+
+type Story = StoryObj<typeof Icon>;
+
+const sizes = ["small", "medium", "large", "xlarge"] as const;
+
+const columns = sizes.map((size) => ({
+    name: size,
+    props: {size},
+}));
+
+// The compatible elements that can be rendered inside the `Icon` component.
+const rows = [
+    {
+        name: "Img src (svg)",
+        props: {children: <img src="logo.svg" alt="Wonder Blocks" />},
+    },
+    {
+        name: "Img src (png)",
+        props: {children: <img src="avatar.png" alt="Example avatar" />},
+    },
+    {
+        name: "Inline single-color svg with default color",
+        props: {children: singleColoredIcon},
+    },
+    {
+        name: "Inline single-color svg with semantic color",
+        props: {
+            children: singleColoredIcon,
+            style: {color: semanticColor.core.foreground.instructive.default},
+        },
+    },
+    {name: "Inline multi-color svg", props: {children: multiColoredIcon}},
+    {
+        name: "Custom (GemIcon)",
+        props: {children: <GemIcon aria-label="Gem" />},
+    },
+    {
+        name: "Custom (StreakIcon)",
+        props: {children: <StreakIcon aria-label="Streak" />},
+    },
+];
+
+export const StateSheetStory: Story = {
+    name: "StateSheet",
+    render: () => (
+        <StateSheet
+            rows={rows}
+            columns={columns}
+            states={[commonStates.rest]}
+            title="Content / Size"
+        >
+            {({props}) => <Icon {...props} />}
+        </StateSheet>
+    ),
+};

--- a/__docs__/wonder-blocks-icon/icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/icon.stories.tsx
@@ -12,7 +12,6 @@ import {
     multiColoredIcon,
     singleColoredIcon,
 } from "../components/icons-for-testing";
-import {themeModes} from "../../.storybook/modes";
 
 export default {
     title: "Packages / Icon / Icon",
@@ -28,7 +27,8 @@ export default {
             />
         ),
         chromatic: {
-            modes: themeModes,
+            // Disable snapshots since they're covered by the testing snapshots
+            disableSnapshot: true,
         },
     },
 } as Meta<typeof Icon>;
@@ -78,6 +78,12 @@ export const CustomStyles: StoryComponentType = {
         style: {
             borderRadius: border.radius.radius_full,
             overflow: "hidden",
+        },
+    },
+    parameters: {
+        chromatic: {
+            // Enable snapshot for custom styles coverage
+            disableSnapshot: false,
         },
     },
 };

--- a/__docs__/wonder-blocks-icon/phosphor-icon-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon-testing-snapshots.stories.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
+
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+
+import {commonStates, StateSheet} from "../components/state-sheet";
+import {allThemeModes} from "../../.storybook/modes";
+import crownIcon from "./icons/crown.svg";
+
+/**
+ * The following stories are used to generate visual regression snapshots
+ * for the PhosphorIcon component across themes.
+ */
+export default {
+    title: "Packages / Icon / Testing / Snapshots / PhosphorIcon",
+    component: PhosphorIcon,
+    parameters: {
+        chromatic: {
+            modes: allThemeModes,
+        },
+    },
+    tags: ["!autodocs", "!manifest"],
+} as Meta<typeof PhosphorIcon>;
+
+type Story = StoryObj<typeof PhosphorIcon>;
+
+const sizes = ["small", "medium", "large", "xlarge"] as const;
+
+const columns = sizes.map((size) => ({
+    name: size,
+    props: {size},
+}));
+
+const rows = [
+    {name: "Default color", props: {icon: magnifyingGlassIcon}},
+    {
+        name: "Semantic color",
+        props: {
+            icon: magnifyingGlassIcon,
+            color: semanticColor.core.foreground.critical.default,
+        },
+    },
+    {
+        name: "Custom icon",
+        props: {
+            icon: crownIcon,
+        },
+    },
+];
+
+export const StateSheetStory: Story = {
+    name: "StateSheet",
+    render: () => (
+        <StateSheet
+            rows={rows}
+            columns={columns}
+            states={[commonStates.rest]}
+            title="Color / Size"
+        >
+            {({props}) => <PhosphorIcon {...props} />}
+        </StateSheet>
+    ),
+};

--- a/__docs__/wonder-blocks-icon/phosphor-icon-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon-testing-snapshots.stories.tsx
@@ -40,13 +40,20 @@ const rows = [
         name: "Semantic color",
         props: {
             icon: magnifyingGlassIcon,
-            color: semanticColor.core.foreground.critical.default,
+            color: semanticColor.core.foreground.instructive.default,
         },
     },
     {
         name: "Custom icon",
         props: {
             icon: crownIcon,
+        },
+    },
+    {
+        name: "Custom icon with semantic color",
+        props: {
+            icon: crownIcon,
+            color: semanticColor.core.foreground.instructive.default,
         },
     },
 ];

--- a/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
@@ -62,7 +62,7 @@ export default {
         ),
         chromatic: {
             // Disable snapshots since they're covered by the testing snapshots
-            disableSnapshots: true,
+            disableSnapshot: true,
         },
     },
     argTypes: PhosphorIconArgtypes,
@@ -244,11 +244,6 @@ export const Variants: StoryComponentType = {
                 <tbody>{iconsWithLabels}</tbody>
             </StyledTable>
         );
-    },
-    parameters: {
-        chromatic: {
-            disableSnapshot: true,
-        },
     },
     decorators: [
         (Story) => (

--- a/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
+++ b/__docs__/wonder-blocks-icon/phosphor-icon.stories.tsx
@@ -60,6 +60,10 @@ export default {
                 version={packageConfig.version}
             />
         ),
+        chromatic: {
+            // Disable snapshots since they're covered by the testing snapshots
+            disableSnapshots: true,
+        },
     },
     argTypes: PhosphorIconArgtypes,
 } satisfies Meta<typeof PhosphorIcon>;
@@ -285,6 +289,12 @@ export const Inline: StoryComponentType = {
             </Body>
         );
     },
+    parameters: {
+        chromatic: {
+            // Enable snapshot for inline alignment coverage
+            disableSnapshot: false,
+        },
+    },
 };
 
 /**
@@ -375,13 +385,6 @@ export const DescriptiveIcon: StoryComponentType = {
         role: "img",
         "aria-label": "Search",
     },
-    parameters: {
-        chromatic: {
-            // This story is not meant to be visually tested, so we disable
-            // snapshots.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -393,12 +396,5 @@ export const DecorativeIcon: StoryComponentType = {
         icon: IconMappings.magnifyingGlassBold,
         size: "small",
         "aria-hidden": true,
-    },
-    parameters: {
-        chromatic: {
-            // This story is not meant to be visually tested, so we disable
-            // snapshots.
-            disableSnapshot: true,
-        },
     },
 };

--- a/packages/wonder-blocks-icon/src/components/custom-icon-components/gem-icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/custom-icon-components/gem-icon.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {CustomIconProps} from "../../types";
 import {useImageRoleAttributes} from "../../hooks/use-image-role-attributes";
 

--- a/packages/wonder-blocks-icon/src/components/custom-icon-components/gem-icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/custom-icon-components/gem-icon.tsx
@@ -42,11 +42,13 @@ const GemIcon = React.forwardRef<SVGSVGElement, CustomIconProps>(
             >
                 <path
                     d="M1.246 5.38105L2.36444 3.66654C2.63609 3.25012 3.0934 3 3.58311 3H12.4169C12.9066 3 13.3639 3.25012 13.6356 3.66654L14.754 5.38105C15.1278 5.95411 15.0708 6.71389 14.6158 7.22195L9.08044 13.4027C8.49982 14.051 7.50018 14.051 6.91956 13.4027L1.38423 7.22195C0.929229 6.71389 0.872177 5.95411 1.246 5.38105Z"
-                    fill={semanticColor.learning.foreground.gems.default}
+                    // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color -- Explicitly using color instead of semantic color because we want the icon to be the same across themes.
+                    fill="#E83FA4"
                 />
                 <path
                     d="M9.45654 7.01492L8.34027 10.0102C8.07911 10.711 8.97464 11.2595 9.48018 10.7084L12.6345 7.26989C13.0351 6.83317 12.7253 6.12858 12.1327 6.12858H10.7327C10.164 6.12858 9.65515 6.48199 9.45654 7.01492Z"
-                    fill={semanticColor.learning.foreground.gems.subtle}
+                    // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color -- Explicitly using color instead of semantic color because we want the icon to be the same across themes.
+                    fill="#F9BBE1"
                 />
             </StyledSvg>
         );

--- a/packages/wonder-blocks-icon/src/components/custom-icon-components/streak-icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/custom-icon-components/streak-icon.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {addStyle} from "@khanacademy/wonder-blocks-core";
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {CustomIconProps} from "../../types";
 import {useImageRoleAttributes} from "../../hooks/use-image-role-attributes";
 

--- a/packages/wonder-blocks-icon/src/components/custom-icon-components/streak-icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/custom-icon-components/streak-icon.tsx
@@ -42,11 +42,13 @@ const StreakIcon = React.forwardRef<SVGSVGElement, CustomIconProps>(
             >
                 <path
                     d="M9.14653 0.628361C9.07012 0.571421 8.97956 0.531782 8.88248 0.512785C8.78539 0.493787 8.68464 0.49599 8.5887 0.519205C8.49277 0.542421 8.40447 0.585969 8.33125 0.64618C8.25802 0.70639 8.20202 0.781496 8.16797 0.865168L5.47556 5.06034L4.59152 3.43463C4.52866 3.37998 4.45359 3.33789 4.37125 3.31114C4.28892 3.28438 4.2012 3.27357 4.11387 3.27941C4.02653 3.28525 3.94157 3.30761 3.86458 3.34502C3.78759 3.38243 3.72032 3.43403 3.66719 3.49644C1.98899 5.46729 1.13672 7.44994 1.13672 9.38884C1.13672 11.0096 1.85506 12.564 3.13372 13.7101C4.41238 14.8561 6.14661 15.5 7.9549 15.5C9.7632 15.5 11.4974 14.8561 12.7761 13.7101C14.0547 12.564 14.7731 11.0096 14.7731 9.38884C14.7731 5.26034 10.8379 1.88879 9.14653 0.628361Z"
-                    fill={semanticColor.learning.foreground.streaks.default}
+                    // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color -- Explicitly using color instead of semantic color because we want the icon to be the same across themes.
+                    fill="#F8551A"
                 />
                 <path
                     d="M10.8067 10.5315C10.8067 12.0965 9.53809 13.3651 7.97318 13.3651C6.40826 13.3651 5.13965 12.0965 5.13965 10.5315C5.13965 8.96663 7.2648 6.28125 7.97318 6.28125C8.68156 6.28125 10.8067 8.96663 10.8067 10.5315Z"
-                    fill={semanticColor.learning.foreground.streaks.subtle}
+                    // eslint-disable-next-line @khanacademy/wonder-blocks/no-hardcoded-color -- Explicitly using color instead of semantic color because we want the icon to be the same across themes.
+                    fill="#FEBFB1"
                 />
             </StyledSvg>
         );


### PR DESCRIPTION
## Summary:

Reviewing the `Icon`, `PhosphorIcon`, and custom icon (`GemIcon`, `StreakIcon`) components in SYL Dark to confirm they look as expected, match the design specs, and have no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for these components.

Changes include:
- Use the hex colors for gem and streak icons since we want them to look the same across themes

Issue: WB-2158

## Test plan:

Review the following stories and confirm things look as expected and there are no a11y violations (theme preselected to SYL Dark):

- Icon: `?path=/story/packages-icon-testing-snapshots-icon--state-sheet-story&globals=theme:syl-dark`
- PhosphorIcon: `?path=/story/packages-icon-testing-snapshots-phosphoricon--state-sheet-story&globals=theme:syl-dark`
- Custom Icon Components: `?path=/story/packages-icon-testing-snapshots-custom-icon-components--state-sheet-story&globals=theme:syl-dark`

Review visual changes in Chromatic