### PR TITLE
SYL Dark - Toolbar

### DIFF
--- a/.changeset/cool-wasps-check.md
+++ b/.changeset/cool-wasps-check.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-toolbar": patch
+---
+
+Use semantic color tokens for Toolbar `color="dark"` variant

--- a/__docs__/wonder-blocks-toolbar/toolbar-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar-testing-snapshots.stories.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+import {View} from "@khanacademy/wonder-blocks-core";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+
+import Toolbar from "@khanacademy/wonder-blocks-toolbar";
+import {ScenariosLayout} from "../components/scenarios-layout";
+import {leftContentMappings, rightContentMappings} from "./toolbar.argtypes";
+import {allThemeModes} from "../../.storybook/modes";
+
+/**
+ * The following stories are used to generate the snapshots for the Toolbar
+ * component. This is only used for visual testing in Chromatic.
+ */
+export default {
+    title: "Packages / Toolbar / Testing / Snapshots / Toolbar",
+    component: Toolbar,
+    parameters: {
+        chromatic: {
+            modes: allThemeModes,
+        },
+    },
+    globals: {
+        backgrounds: {
+            value: "baseSubtle",
+        },
+    },
+    tags: ["!autodocs", "!manifest"],
+} as Meta<typeof Toolbar>;
+
+type Story = StoryObj<typeof Toolbar>;
+
+/**
+ * The following story shows how the component handles specific scenarios.
+ */
+export const Scenarios: Story = {
+    render() {
+        const scenarios = [
+            {
+                name: "Default",
+                props: {
+                    title: "Counting with small numbers",
+                    leftContent: leftContentMappings.dismissButton,
+                    rightContent: rightContentMappings.nextVideoButton,
+                },
+            },
+            {
+                name: "Small",
+                props: {
+                    size: "small",
+                    leftContent: leftContentMappings.multipleContent,
+                    rightContent: rightContentMappings.tertiaryButton,
+                },
+            },
+            {
+                name: "Medium",
+                props: {
+                    leftContent: leftContentMappings.hintButton,
+                    rightContent: rightContentMappings.primaryButton,
+                },
+            },
+            {
+                name: "With Title",
+                props: {
+                    leftContent: leftContentMappings.dismissButton,
+                    title: "Counting with small numbers",
+                },
+            },
+            {
+                name: "Dark",
+                props: {
+                    color: "dark",
+                    title: "Title",
+                    leftContent: leftContentMappings.lightButton,
+                    rightContent: rightContentMappings.lightButton,
+                },
+            },
+            {
+                name: "With Multiple Elements",
+                props: {
+                    rightContent: rightContentMappings.multipleContent,
+                },
+            },
+            {
+                name: "Header Overflow Text",
+                props: {
+                    leftContent: leftContentMappings.dismissButton,
+                    subtitle: "1 of 14 questions answered",
+                    title: "Patterns of migration and communal bird-feeding given the serious situation of things that will make this string long and obnoxious",
+                    rightContent: rightContentMappings.link,
+                },
+            },
+            {
+                name: "Custom Toolbar",
+                props: {
+                    leftContent: leftContentMappings.exitWithTitle,
+                    rightContent: rightContentMappings.primaryButton,
+                    title: (
+                        <View
+                            style={{
+                                width: 300,
+                                maxInlineSize: "100%",
+                                height: sizing.size_080,
+                                background: semanticColor.mastery.primary,
+                            }}
+                        />
+                    ),
+                },
+            },
+        ];
+
+        return (
+            <ScenariosLayout
+                scenarios={scenarios}
+                styles={{root: {alignItems: "stretch"}}}
+            >
+                {(props) => <Toolbar {...props} />}
+            </ScenariosLayout>
+        );
+    },
+};

--- a/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
+++ b/__docs__/wonder-blocks-toolbar/toolbar.stories.tsx
@@ -37,6 +37,10 @@ export default {
                 excludeDecorators: true,
             },
         },
+        chromatic: {
+            // Disable snapshots because it is covered by testing snapshots
+            disableSnapshot: true,
+        },
     },
     decorators: [
         (Story: any): React.ReactElement<React.ComponentProps<typeof View>> => (
@@ -189,6 +193,7 @@ Responsive.parameters = {
             medium: allModes.medium,
             large: allModes.large,
         },
+        disableSnapshot: false,
     },
 };
 

--- a/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
+++ b/packages/wonder-blocks-toolbar/src/components/toolbar.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
-import {color, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {Heading, BodyText} from "@khanacademy/wonder-blocks-typography";
 import type {AriaProps} from "@khanacademy/wonder-blocks-core";
 
@@ -150,8 +150,8 @@ const sharedStyles = StyleSheet.create({
     },
     // TODO(WB-1852): Remove light variant.
     dark: {
-        background: color.darkBlue,
-        boxShadow: `0 1px 0 0 ${color.white64}`,
+        background: semanticColor.core.background.base.strong,
+        boxShadow: `0 1px 0 0 ${semanticColor.core.foreground.knockout.default}`,
         color: semanticColor.core.foreground.knockout.default,
     },
     leftColumn: {


### PR DESCRIPTION
## Summary:

Reviewing the Toolbar component in SYL Dark to confirm it looks as expected, matches the design specs, and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Changes specific to the component:
- Use semantic color tokens for the dark variant (note: support for the dark variant is to be removed in WB-1852)

Issue: WB-2166

Design: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=8389-10552&t=48QoihVmhYQeteLi-4 (note there isn't a 1:1 mapping with Figma currently so for now, we make sure the current Toolbar use cases look okay in dark mode)

## Test plan:

Review `?path=/story/packages-toolbar-testing-snapshots-toolbar--scenarios&globals=theme:syl-dark` and confirm things look as expected and there are no a11y violations

Review visual changes in Chromatic