### PR TITLE
SYL Dark - Modals and Drawers update

### DIFF
--- a/.changeset/blue-trains-push.md
+++ b/.changeset/blue-trains-push.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": patch
+---
+
+Update modal and drawer panel background color to `semanticColor.core.background.base.default` to align with Figma specs

--- a/.changeset/tricky-lemons-tie.md
+++ b/.changeset/tricky-lemons-tie.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+SYL Dark tokens: Update background.base.subtle/default

--- a/packages/wonder-blocks-modal/src/components/flexible-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/flexible-panel.tsx
@@ -118,7 +118,7 @@ export default function FlexiblePanel({
     const mainContent = renderMainContent();
 
     const defaultBackgroundStyle = {
-        backgroundColor: semanticColor.core.background.base.subtle,
+        backgroundColor: semanticColor.core.background.base.default,
     };
 
     const combinedBackgroundStyles = {

--- a/packages/wonder-blocks-modal/src/components/modal-panel.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-panel.tsx
@@ -147,7 +147,7 @@ const styles = StyleSheet.create({
     wrapper: {
         flex: "1 1 auto",
         flexDirection: "column",
-        background: semanticColor.core.background.base.subtle,
+        background: semanticColor.core.background.base.default,
         boxSizing: "border-box",
         overflow: "hidden",
         height: "100%",

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -45,8 +45,8 @@ const core = {
     },
     background: {
         base: {
-            subtle: color.gray_05,
-            default: color.black_100,
+            subtle: color.black_100,
+            default: color.gray_05,
             strong: color.white_100,
         },
         instructive: {


### PR DESCRIPTION
## Summary:

Modals and Drawers were previously updated in https://github.com/Khan/wonder-blocks/pull/3067. Since then, design has iterated on this so we can keep using a white modal background in the light theme (`background.base.default` instead of `background.base.subtle`). ([related discussion](https://khanacademy.slack.com/archives/C07CA2YR0BZ/p1780435404040059?thread_ts=1779826920.718159&cid=C07CA2YR0BZ))

The semantic color background base tokens have been updated in `syl-dark` to better support this

Issue: WB-2166
Design: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=9603-3296&t=48QoihVmhYQeteLi-4


## Test plan:

Review the stories for OnePaneDialog, FlexibleDialog, and DrawerDialog and confirm things look as expected and there are no a11y violations (in all themes since the bg color changed)
- `?path=/story/packages-modal-drawerlauncher-drawerdialog--default&globals=theme:syl-dark`
- `?path=/story/packages-modal-flexibledialog--with-launcher&globals=theme:syl-dark`
- `?path=/story/packages-modal-onepanedialog--with-launcher&globals=theme:syl-dark`

Review visual changes in Chromatic