### PR TITLE
SYL Dark - Combobox 

### DIFF
--- a/.changeset/silent-mugs-guess.md
+++ b/.changeset/silent-mugs-guess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Combobox: Remove state styling for the dropdown button and the internal text field

--- a/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
@@ -2,15 +2,14 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
-import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
-import {themeModes} from "../../.storybook/modes";
+import {PropsFor} from "@khanacademy/wonder-blocks-core";
+import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {
     longText,
     longTextWithNoWordBreak,
 } from "../components/text-for-testing";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -20,7 +19,7 @@ export default {
     title: "Packages / Dropdown / Testing / Snapshots / Combobox",
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     args: {
@@ -88,7 +87,12 @@ export const StateSheetStory: Story = {
         );
     },
     parameters: {
-        pseudo: defaultPseudoStates,
+        pseudo: {
+            ...defaultPseudoStates,
+            // Using the focus selector instead so that the focus outline is
+            // shown when the combobox is clicked
+            focus: [...defaultPseudoStates.focusVisible],
+        },
     },
 };
 
@@ -118,7 +122,6 @@ export const Scenarios: Story = {
                     ],
                     opened: true,
                 },
-                decorator: <View style={{marginBlockEnd: sizing.size_480}} />,
             },
             {
                 name: "Long option item label with no word break",
@@ -135,7 +138,6 @@ export const Scenarios: Story = {
                     ],
                     opened: true,
                 },
-                decorator: <View style={{marginBlockEnd: sizing.size_480}} />,
             },
             {
                 name: "Long placeholder",
@@ -254,19 +256,6 @@ export const Scenarios: Story = {
     globals: {
         viewport: {
             value: "small",
-        },
-    },
-    parameters: {
-        a11y: {
-            config: {
-                rules: [
-                    {
-                        // TODO(WB-2359): Fix this a11y violation
-                        id: "aria-valid-attr-value",
-                        enabled: false,
-                    },
-                ],
-            },
         },
     },
 };

--- a/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/combobox-testing-snapshots.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {Combobox, OptionItem} from "@khanacademy/wonder-blocks-dropdown";
-import {PropsFor} from "@khanacademy/wonder-blocks-core";
+import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
@@ -10,6 +10,7 @@ import {
     longText,
     longTextWithNoWordBreak,
 } from "../components/text-for-testing";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -87,12 +88,7 @@ export const StateSheetStory: Story = {
         );
     },
     parameters: {
-        pseudo: {
-            ...defaultPseudoStates,
-            // Using the focus selector instead so that the focus outline is
-            // shown when the combobox is clicked
-            focus: [...defaultPseudoStates.focusVisible],
-        },
+        pseudo: defaultPseudoStates,
     },
 };
 
@@ -122,6 +118,7 @@ export const Scenarios: Story = {
                     ],
                     opened: true,
                 },
+                decorator: <View style={{marginBlockEnd: sizing.size_480}} />,
             },
             {
                 name: "Long option item label with no word break",
@@ -138,6 +135,7 @@ export const Scenarios: Story = {
                     ],
                     opened: true,
                 },
+                decorator: <View style={{marginBlockEnd: sizing.size_480}} />,
             },
             {
                 name: "Long placeholder",
@@ -256,6 +254,19 @@ export const Scenarios: Story = {
     globals: {
         viewport: {
             value: "small",
+        },
+    },
+    parameters: {
+        a11y: {
+            config: {
+                rules: [
+                    {
+                        // TODO(WB-2359): Fix this a11y violation
+                        id: "aria-valid-attr-value",
+                        enabled: false,
+                    },
+                ],
+            },
         },
     },
 };

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -643,7 +643,11 @@ export default function Combobox({
                     actionType="neutral"
                     kind="tertiary"
                     size="medium"
-                    style={[styles.button, openState && styles.buttonOpen]}
+                    style={[
+                        styles.button,
+                        styles.openButtonResetStates,
+                        openState && styles.buttonOpen,
+                    ]}
                     tabIndex={-1}
                     aria-controls={uniqueId}
                     aria-expanded={openState}
@@ -790,6 +794,25 @@ const styles = StyleSheet.create({
     },
     buttonOpen: {
         transform: "rotate(180deg)",
+    },
+    /**
+     * The dropdown toggle button is not directly focusable (`tabIndex={-1}`)
+     * and its state is already communicated by the combobox input, so we
+     * remove the IconButton's hover, focus, and press styles to keep it
+     * visually static. Values are reset to match the tertiary/neutral rest
+     * state.
+     */
+    openButtonResetStates: {
+        ":hover": {
+            borderColor: semanticColor.core.transparent,
+        },
+        ":active": {
+            borderColor: semanticColor.core.transparent,
+        },
+        ":focus-visible": {
+            outline: "none",
+            boxShadow: "none",
+        },
     },
     /**
      * Clear selection button

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -761,9 +761,18 @@ const styles = StyleSheet.create({
         width: "auto",
         display: "inline-grid",
         gridArea: "1 / 2",
+        // The combobox wrapper handles the focus and press indicators, so we
+        // reset the TextField's own focus and press states to avoid showing a
+        // duplicate focus ring / press border on the inner input.
         ":focus-visible": {
             outline: "none",
             border: "none",
+            boxShadow: "none",
+        },
+        // Matches the TextField's press selector so this reset takes
+        // precedence over the press box shadow it applies.
+        [":active:not([aria-disabled='true']):not([readonly])" as any]: {
+            boxShadow: "none",
         },
     },
     /**


### PR DESCRIPTION
## Summary:

Reviewing the Combobox components in SYL Dark to confirm it looks okay and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for this component.

Changes include:
- Removing state styling for the internal IconButton and TextField components used 
- Note: I've created WB-2359 for improving the styles of Combobox (ie. using pseudoclasses for states, handling edge cases, etc). This is lower priority right now since these are pre-existing in all themes and Combobox isn't used in frontend yet! 

Issue: WB-2166

## Test plan:

Review the Combobox statesheet and confirm the additional state styles for the opener IconButton and TextField are no longer visible: `?path=/story/packages-dropdown-testing-snapshots-combobox--state-sheet-story`

Confirm the Combobox as a whole looks the same as before when interacting with it manually 