### PR TITLE
SYL Dark - TextField & TextArea

### DIFF
--- a/.changeset/fuzzy-grapes-train.md
+++ b/.changeset/fuzzy-grapes-train.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-form": patch
+---
+
+TextField and TextArea: Improved the `press + focus` styling to work with `syl-dark`

--- a/.changeset/large-jobs-talk.md
+++ b/.changeset/large-jobs-talk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Combobox: Reset boxshadow of TextField

--- a/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area-testing-snapshots.stories.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {TextArea} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {
@@ -13,7 +14,7 @@ import {
     repeatText,
 } from "../components/text-for-testing";
 import {AllVariants} from "../components/all-variants";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 /**
  * The following stories are used to generate the pseudo states for the
@@ -23,7 +24,7 @@ export default {
     title: "Packages / Form / Testing / Snapshots / TextArea",
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     tags: ["!autodocs", "!manifest"],
@@ -246,6 +247,49 @@ export const Scenarios: Story = {
                     maxRows: 2,
                 },
             },
+            {
+                name: "Wrap: default (soft)",
+                props: {value: longText},
+            },
+            {
+                name: "Wrap: soft",
+                props: {wrap: "soft", value: longText},
+            },
+            {
+                name: "Wrap: hard",
+                props: {wrap: "hard", value: longText},
+            },
+            {
+                name: "Wrap: off",
+                props: {wrap: "off", value: longText},
+            },
+            {
+                name: "Resize type: both (default)",
+                props: {resizeType: "both", value: "Resizable text"},
+            },
+            {
+                name: "Resize type: horizontal",
+                props: {resizeType: "horizontal", value: "Resizable text"},
+            },
+            {
+                name: "Resize type: vertical",
+                props: {resizeType: "vertical", value: "Resizable text"},
+            },
+            {
+                name: "Resize type: none",
+                props: {resizeType: "none", value: "Resizable text"},
+            },
+            {
+                name: "Custom style",
+                props: {style: styles.customField, value: "Custom style"},
+            },
+            {
+                name: "Custom root style",
+                props: {
+                    rootStyle: styles.customRoot,
+                    value: "Custom root style",
+                },
+            },
         ];
         return (
             <ScenariosLayout
@@ -262,3 +306,20 @@ export const Scenarios: Story = {
         );
     },
 };
+
+const styles = StyleSheet.create({
+    customField: {
+        backgroundColor: semanticColor.status.notice.background,
+        color: semanticColor.status.notice.foreground,
+        border: "none",
+        maxInlineSize: 250,
+        "::placeholder": {
+            color: semanticColor.core.foreground.neutral.default,
+        },
+    },
+    customRoot: {
+        padding: sizing.size_120,
+        borderRadius: sizing.size_080,
+        backgroundColor: semanticColor.status.notice.background,
+    },
+});

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -54,6 +54,10 @@ export default {
                 ],
             },
         },
+        chromatic: {
+            // Disabling snapshots because this is covered by the testing snapshots
+            disableSnapshots: true,
+        },
     },
     argTypes: TextAreaArgTypes,
 } as Meta<typeof TextArea>;
@@ -138,13 +142,6 @@ export const WithLabeledField: StoryComponentType = {
             />
         );
     },
-    parameters: {
-        chromatic: {
-            // Disabling because this is for documentation purposes and is
-            // covered by the LabeledField stories
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -155,12 +152,6 @@ export const Controlled: ControlledStoryComponentType = {
     render: ControlledTextArea,
     args: {
         label: "Controlled",
-    },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
     },
 };
 
@@ -227,12 +218,6 @@ export const AutoResize: StoryComponentType = {
             </View>
         );
     },
-    parameters: {
-        chromatic: {
-            // Disabling because it is covered by scenarios
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -296,12 +281,6 @@ export const Error: ControlledStoryComponentType = {
         error: true,
         label: "Error using error prop",
     },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -322,12 +301,6 @@ export const ErrorFromValidation: ControlledStoryComponentType = {
         label: "Error from validation",
     },
     render: ControlledTextArea,
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -396,13 +369,6 @@ export const ErrorFromPropAndValidation = (args: PropsFor<typeof TextArea>) => {
     );
 };
 
-ErrorFromPropAndValidation.parameters = {
-    chromatic: {
-        // Disabling because this doesn't test anything visual.
-        disableSnapshot: true,
-    },
-};
-
 /**
  * The `instantValidation` prop controls when validation is triggered. Validation
  * is triggered if the `validate` or `required` props are set.
@@ -467,12 +433,6 @@ export const InstantValidation: StoryComponentType = {
             </View>
         );
     },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -486,12 +446,6 @@ export const Required: StoryComponentType = {
         required: true,
     },
     render: ControlledTextArea,
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -511,12 +465,6 @@ export const Rows: StoryComponentType = {
 export const AutoComplete: StoryComponentType = {
     args: {
         autoComplete: "on",
-    },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
     },
 };
 
@@ -571,12 +519,6 @@ export const AutoFocus = () => {
         </View>
     );
 };
-AutoFocus.parameters = {
-    chromatic: {
-        // Disabling because this doesn't test anything visual.
-        disableSnapshot: true,
-    },
-};
 
 /**
  * Spell check can be enabled for the TextArea. It will be checked for spelling
@@ -591,23 +533,11 @@ export const SpellCheckEnabled: StoryComponentType = {
         value: "This exampull will be checkd fur spellung when you try to edit it.",
     },
 };
-SpellCheckEnabled.parameters = {
-    chromatic: {
-        // Disabling because this doesn't test anything visual.
-        disableSnapshot: true,
-    },
-};
 
 export const SpellCheckDisabled: StoryComponentType = {
     args: {
         spellCheck: false,
         value: "This exampull will nut be checkd fur spellung when you try to edit it.",
-    },
-};
-SpellCheckDisabled.parameters = {
-    chromatic: {
-        // Disabling because this doesn't test anything visual.
-        disableSnapshot: true,
     },
 };
 
@@ -694,12 +624,6 @@ export const MinMaxLength: StoryComponentType = {
         minLength: 2,
         maxLength: 4,
         value: "Text",
-    },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
     },
 };
 
@@ -804,10 +728,4 @@ export const WithRef = () => {
             <Button onClick={handleClick}>Focus using ref</Button>
         </View>
     );
-};
-WithRef.parameters = {
-    chromatic: {
-        // Disabling because this doesn't test anything visual.
-        disableSnapshot: true,
-    },
 };

--- a/__docs__/wonder-blocks-form/text-area.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-area.stories.tsx
@@ -56,7 +56,7 @@ export default {
         },
         chromatic: {
             // Disabling snapshots because this is covered by the testing snapshots
-            disableSnapshots: true,
+            disableSnapshot: true,
         },
     },
     argTypes: TextAreaArgTypes,

--- a/__docs__/wonder-blocks-form/text-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field-testing-snapshots.stories.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
@@ -144,6 +146,30 @@ export const Scenarios: Story = {
                 name: "With Placeholder (long, no word breaks)",
                 props: {placeholder: longTextWithNoWordBreak},
             },
+            {
+                name: "Type: number",
+                props: {type: "number", value: "1234.5"},
+            },
+            {
+                name: "Type: whole-number",
+                props: {type: "whole-number", value: "1234"},
+            },
+            {
+                name: "Type: password",
+                props: {type: "password", value: "password"},
+            },
+            {
+                name: "Type: email",
+                props: {type: "email", value: "email@example.com"},
+            },
+            {
+                name: "Type: tel",
+                props: {type: "tel", value: "123-456-7890"},
+            },
+            {
+                name: "Custom style",
+                props: {style: styles.customField, value: "Custom style"},
+            },
         ];
         return (
             <ScenariosLayout scenarios={scenarios}>
@@ -157,3 +183,15 @@ export const Scenarios: Story = {
         );
     },
 };
+
+const styles = StyleSheet.create({
+    customField: {
+        backgroundColor: semanticColor.status.notice.background,
+        color: semanticColor.status.notice.foreground,
+        border: "none",
+        maxInlineSize: 250,
+        "::placeholder": {
+            color: semanticColor.core.foreground.neutral.default,
+        },
+    },
+});

--- a/__docs__/wonder-blocks-form/text-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field-testing-snapshots.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {
@@ -20,7 +20,7 @@ export default {
     title: "Packages / Form / Testing / Snapshots / TextField",
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     tags: ["!autodocs", "!manifest"],

--- a/__docs__/wonder-blocks-form/text-field.stories.tsx
+++ b/__docs__/wonder-blocks-form/text-field.stories.tsx
@@ -37,6 +37,10 @@ export default {
                 version={packageConfig.version}
             />
         ),
+        chromatic: {
+            // Disabling snapshots because this is covered by the testing snapshots
+            disableSnapshot: true,
+        },
     },
     argTypes: TextFieldArgTypes,
 } as Meta<typeof TextField>;
@@ -104,13 +108,6 @@ export const WithLabeledField: StoryComponentType = {
                 contextLabel="required"
             />
         );
-    },
-    parameters: {
-        chromatic: {
-            // Disabling because this is for documentation purposes and is
-            // covered by the LabeledField stories
-            disableSnapshot: true,
-        },
     },
 };
 
@@ -183,12 +180,6 @@ export const Required: StoryComponentType = {
         required: true,
     },
     render: ControlledTextField,
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -451,12 +442,6 @@ export const Error: ControlledStoryComponentType = {
         value: "khan",
         label: "Error state using error prop",
     },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -476,12 +461,6 @@ export const ErrorFromValidation: ControlledStoryComponentType = {
         label: "Error state from validation",
         validate: validateEmail,
         value: "khan",
-    },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
     },
 };
 
@@ -553,13 +532,6 @@ export const ErrorFromPropAndValidation = (
     );
 };
 
-ErrorFromPropAndValidation.parameters = {
-    chromatic: {
-        // Disabling because this doesn't test anything visual.
-        disableSnapshot: true,
-    },
-};
-
 /**
  * The `instantValidation` prop controls when validation is triggered. Validation
  * is triggered if the `validate` or `required` props are set.
@@ -624,12 +596,6 @@ export const InstantValidation: StoryComponentType = {
                 />
             </View>
         );
-    },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
     },
 };
 
@@ -737,13 +703,6 @@ export const Ref: StoryComponentType = {
             </View>
         );
     },
-    parameters: {
-        chromatic: {
-            // Disabling snapshot because this is testing interaction,
-            // not visuals.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -778,13 +737,6 @@ export const ReadOnly: StoryComponentType = {
                 readOnly={true}
             />
         );
-    },
-    parameters: {
-        chromatic: {
-            // Disabling snapshot because this is testing interaction,
-            // not visuals.
-            disableSnapshot: true,
-        },
     },
 };
 
@@ -849,13 +801,6 @@ export const WithAutofocus: StoryComponentType = {
             </View>
         );
     },
-    parameters: {
-        chromatic: {
-            // Disabling snapshot because this is testing interaction,
-            // not visuals.
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -896,13 +841,6 @@ export const AutoComplete: StoryComponentType = {
                 <Button type="submit">Submit</Button>
             </form>
         );
-    },
-    parameters: {
-        chromatic: {
-            // Disabling snapshot because this is testing interaction,
-            // not visuals.
-            disableSnapshot: true,
-        },
     },
 };
 

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -774,6 +774,12 @@ const styles = StyleSheet.create({
         [":active:not([aria-disabled='true']):not([readonly])" as any]: {
             boxShadow: "none",
         },
+        // Matches the TextField's selector so this reset takes precedence over
+        // the box shadow it applies.
+        [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
+            {
+                boxShadow: "none",
+            },
     },
     /**
      * Listbox custom styles

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -476,6 +476,8 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
 );
 
+const ACTIVE_BOX_SHADOW = `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}`;
+
 const styles = StyleSheet.create({
     textarea: {
         borderRadius: theme.field.border.radius,
@@ -499,16 +501,17 @@ const styles = StyleSheet.create({
             color: semanticColor.input.default.placeholder,
         },
         ...focusStyles.focus,
+        // TODO(WB-2365): Use rounded corners for the active state instead
         // Don't show active styles if field is disabled or readonly
         [":active:not([aria-disabled='true']):not([readonly])" as any]: {
             // Use box shadow to make the border in the press state look thicker
             // without changing the border
-            boxShadow: `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}`,
+            boxShadow: ACTIVE_BOX_SHADOW,
         },
         // Focus + Active (and not disabled and not readonly)
         [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
             {
-                boxShadow: `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
+                boxShadow: `${ACTIVE_BOX_SHADOW}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
             },
     },
     disabled: {

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -533,7 +533,7 @@ const styles = StyleSheet.create({
         // Focus + Active (and not disabled and not readonly)
         [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
             {
-                boxShadow: focusStyles.focus[":focus-visible"].boxShadow,
+                boxShadow: `${ACTIVE_BOX_SHADOW}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
             },
     },
 });

--- a/packages/wonder-blocks-form/src/components/text-area.tsx
+++ b/packages/wonder-blocks-form/src/components/text-area.tsx
@@ -505,6 +505,11 @@ const styles = StyleSheet.create({
             // without changing the border
             boxShadow: `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}`,
         },
+        // Focus + Active (and not disabled and not readonly)
+        [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
+            {
+                boxShadow: `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
+            },
     },
     disabled: {
         background: semanticColor.input.disabled.background,
@@ -522,6 +527,11 @@ const styles = StyleSheet.create({
         "::placeholder": {
             color: semanticColor.input.default.placeholder,
         },
+        // Focus + Active (and not disabled and not readonly)
+        [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
+            {
+                boxShadow: focusStyles.focus[":focus-visible"].boxShadow,
+            },
     },
 });
 

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -295,6 +295,8 @@ const TextField = (props: PropsWithForwardRef) => {
     );
 };
 
+const ACTIVE_BOX_SHADOW = `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}`;
+
 const styles = StyleSheet.create({
     input: {
         width: "100%",
@@ -317,16 +319,17 @@ const styles = StyleSheet.create({
             color: semanticColor.input.default.placeholder,
         },
         ...focusStyles.focus,
+        // TODO(WB-2365): Use rounded corners for the active state instead
         // Don't show active styles if field is disabled or readonly
         [":active:not([aria-disabled='true']):not([readonly])" as any]: {
             // Use box shadow to make the border in the press state look thicker
             // without changing the border
-            boxShadow: `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}`,
+            boxShadow: ACTIVE_BOX_SHADOW,
         },
         // Focus + Active (and not disabled and not readonly)
         [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
             {
-                boxShadow: `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
+                boxShadow: `${ACTIVE_BOX_SHADOW}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
             },
     },
     error: {

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -342,7 +342,7 @@ const styles = StyleSheet.create({
         // Focus + Active (and not disabled and not readonly)
         [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
             {
-                boxShadow: focusStyles.focus[":focus-visible"].boxShadow,
+                boxShadow: `${ACTIVE_BOX_SHADOW}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
             },
     },
     disabled: {

--- a/packages/wonder-blocks-form/src/components/text-field.tsx
+++ b/packages/wonder-blocks-form/src/components/text-field.tsx
@@ -323,6 +323,11 @@ const styles = StyleSheet.create({
             // without changing the border
             boxShadow: `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}`,
         },
+        // Focus + Active (and not disabled and not readonly)
+        [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
+            {
+                boxShadow: `0 0 0 ${theme.field.border.width.press} ${semanticColor.input.default.border}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
+            },
     },
     error: {
         background: semanticColor.input.error.background,
@@ -331,6 +336,11 @@ const styles = StyleSheet.create({
         "::placeholder": {
             color: semanticColor.input.default.placeholder,
         },
+        // Focus + Active (and not disabled and not readonly)
+        [":focus-visible:active:not([aria-disabled='true']):not([readonly])" as any]:
+            {
+                boxShadow: focusStyles.focus[":focus-visible"].boxShadow,
+            },
     },
     disabled: {
         background: semanticColor.input.disabled.background,


### PR DESCRIPTION
## Summary:

Reviewing the TextField and TextArea components in SYL Dark to confirm they look as expected, match the design specs, and have no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for both components.

Changes specific to the components:
- Fix active + focus styling for TextField and TextArea
- Add scenarios to the snapshot so that we can disable all the individual stories for TextField and TextArea

Issue: WB-2166
Designs:
- TextField: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=5302-354&t=01mP0aI1pJeyviBy-4 
- TextArea: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=2087-26&t=01mP0aI1pJeyviBy-4

## Test plan:

Review the following stories and confirm things look as expected and there are no a11y violations. 
- TextField — Scenarios: `?path=/story/packages-form-testing-snapshots-textfield--scenarios&globals=theme:syl-dark`
  - TextField — StateSheet: `?path=/story/packages-form-testing-snapshots-textfield--state-sheet-story&globals=theme:syl-dark`
  - TextArea — Scenarios: `?path=/story/packages-form-testing-snapshots-textarea--scenarios&globals=theme:syl-dark`
  - TextArea — StateSheet: `?path=/story/packages-form-testing-snapshots-textarea--state-sheet-story&globals=theme:syl-dark`

Review visual changes in Chromatic