### PR TITLE
SYL Dark - LabeledField

### DIFF
--- a/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field-testing-snapshots.stories.tsx
@@ -4,7 +4,7 @@ import {StyleSheet} from "aphrodite";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import packageConfig from "../../packages/wonder-blocks-labeled-field/package.json";
 import ComponentInfo from "../components/component-info";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {PropsFor, View} from "@khanacademy/wonder-blocks-core";
 import {ScenariosLayout} from "../components/scenarios-layout";
 import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
@@ -25,7 +25,7 @@ export default {
             />
         ),
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 } as Meta<typeof LabeledField>;

--- a/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
+++ b/__docs__/wonder-blocks-labeled-field/labeled-field.stories.tsx
@@ -17,7 +17,7 @@ import {
 import SearchField from "@khanacademy/wonder-blocks-search-field";
 import Button from "@khanacademy/wonder-blocks-button";
 import Banner from "@khanacademy/wonder-blocks-banner";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import {Heading} from "@khanacademy/wonder-blocks-typography";
 
 /**
@@ -529,7 +529,7 @@ export const Fields: StoryComponentType = {
             // Keep snapshots enabled for this story because it shows all the fields
             // with LabeledField
             disableSnapshot: false,
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 };
@@ -622,7 +622,7 @@ export const ValidationAfterSubmission: AllFieldsStoryComponentType = {
     parameters: {
         chromatic: {
             disableSnapshot: false,
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 };


### PR DESCRIPTION
## Summary:

Reviewing the LabeledField component in SYL Dark to confirm it looks as expected, matches the design specs, and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Note: The disabled state for LabeledField has color contrast checks failing, however, this is expected since it is related to a disabled state (related [thread](https://khanacademy.slack.com/archives/C07CA2YR0BZ/p1780688093330229?thread_ts=1780688032.984739&cid=C07CA2YR0BZ)) 

Issue: WB-2166
Design: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=5302-354&m=dev

## Test plan:

Review the following and confirm things look as expected and there are no a11y violations:
  - `?path=/story/packages-labeledfield-testing-snapshots-labeledfield--scenarios&globals=theme:syl-dark`
  - `?path=/story/packages-labeledfield--fields&globals=theme:syl-dark`