### PR TITLE
ActivityButton: Fix initial animation on Chrome

### DIFF
--- a/.changeset/breezy-deers-heal.md
+++ b/.changeset/breezy-deers-heal.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-button": patch
+---
+
+Update how pressed styles are applied to ActivityButton to avoid initial flash on Chrome.

--- a/packages/wonder-blocks-button/src/components/activity-button.tsx
+++ b/packages/wonder-blocks-button/src/components/activity-button.tsx
@@ -51,7 +51,6 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
     const sharedStyles = [
         buttonStyles.button,
         disabled && buttonStyles.disabled,
-        !disabled && pressed && buttonStyles.pressed,
         // Enables programmatic focus.
         !disabled && !pressed && focused && buttonStyles.focused,
         stylesProp?.root,
@@ -60,7 +59,6 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
     const chonkyStyles = [
         buttonStyles.chonky,
         disabled && buttonStyles.chonkyDisabled,
-        !disabled && pressed && buttonStyles.chonkyPressed,
         stylesProp?.box,
     ];
 
@@ -72,6 +70,8 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
             ref={ref}
             style={sharedStyles}
             type={type}
+            // NOTE: attribute selector (always in stylesheet) avoids lazy CSS injection on mousedown that interrupts Chrome's :active transition.
+            data-state={pressed ? "pressed" : undefined}
         >
             <>
                 {/* NOTE: Using a regular className to be able to use descendant selectors to account for the hover and press states */}
@@ -378,7 +378,8 @@ const _generateStyles = (
                 transform: `translateY(calc((${theme.root.shadow.y.hover} - ${theme.root.shadow.y.rest}) * -1))`,
             },
 
-            [":is(:active) .chonky" as any]: chonkyPressed,
+            [":is(:active, [data-state='pressed']) .chonky" as any]:
+                chonkyPressed,
 
             // :focus-visible -> Provide focus styles for keyboard users only.
             ...focusStyles.focus,
@@ -398,13 +399,9 @@ const _generateStyles = (
             // Reset hover and active styles on the chonky element.
             [":is(:hover) .chonky" as any]: disabledStatesStyles,
             [":is(:hover) .chonky" as any]: chonkyDisabled,
-            [":is(:active) .chonky" as any]: chonkyDisabled,
+            [":is(:active, [data-state='pressed']) .chonky" as any]:
+                chonkyDisabled,
         },
-        // Enable keyboard support for press styles.
-        pressed: {
-            [".chonky" as any]: chonkyPressed,
-        },
-
         chonky: {
             // layout
             // Spacing between the icon(s) and the label.
@@ -430,7 +427,6 @@ const _generateStyles = (
                 transition: "none",
             },
         },
-        chonkyPressed,
         chonkyDisabled,
     } as const;
 

--- a/packages/wonder-blocks-button/src/components/activity-button.tsx
+++ b/packages/wonder-blocks-button/src/components/activity-button.tsx
@@ -421,7 +421,10 @@ const _generateStyles = (
             // Gives the button a "chonky" look and feel.
             boxShadow: `0 ${theme.root.shadow.y.rest} 0 0 ${themeVariant.shadow[kind].rest}`,
             // motion
-            transition: "all 0.12s ease-out",
+            transitionProperty:
+                "transform, box-shadow, background, border-color, color",
+            transitionDuration: "0.12s",
+            transitionTimingFunction: "ease-out",
 
             ["@media not (hover: hover)" as any]: {
                 transition: "none",

--- a/packages/wonder-blocks-button/src/components/activity-button.tsx
+++ b/packages/wonder-blocks-button/src/components/activity-button.tsx
@@ -378,6 +378,9 @@ const _generateStyles = (
                 transform: `translateY(calc((${theme.root.shadow.y.hover} - ${theme.root.shadow.y.rest}) * -1))`,
             },
 
+            // TODO: remove the data attribute and apply these styles using CSS
+            // modules once WB-2328 is merged. Be sure to test this fix still
+            // works: https://github.com/Khan/wonder-blocks/pull/3107
             [":is(:active, [data-state='pressed']) .chonky" as any]:
                 chonkyPressed,
 
@@ -399,6 +402,9 @@ const _generateStyles = (
             // Reset hover and active styles on the chonky element.
             [":is(:hover) .chonky" as any]: disabledStatesStyles,
             [":is(:hover) .chonky" as any]: chonkyDisabled,
+            // TODO: remove the data attribute and apply these styles using CSS
+            // modules once WB-2328 is merged. Be sure to test this fix still
+            // works: https://github.com/Khan/wonder-blocks/pull/3107
             [":is(:active, [data-state='pressed']) .chonky" as any]:
                 chonkyDisabled,
         },


### PR DESCRIPTION
## Summary:
Because Aphrodite lazily injects CSS, there could be a race in Chrome when applying the pressed styles for the first time and the animation that gets applied.

This adds the pressed styles to the main button styles so they're applied on first render. The pressed styles are now applied based on a data attributed that gets applied when the button is pressed.


https://github.com/user-attachments/assets/9d851371-0509-4b0d-8a3b-d0c7a45b47ce



## Test plan:
- pnpm start
- Open storybook in Chrome
- View the Activity Button story
- Reload the page
- Click the button and make sure it animates normally (without any flashing)