### PR TITLE
SYL Dark - SearchField

### DIFF
--- a/.changeset/tiny-kids-deliver.md
+++ b/.changeset/tiny-kids-deliver.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-search-field": patch
+---
+
+SearchField: Use `semanticColor.core.foreground.neutral.subtle` for the search icon. Use `semanticColor.core.foreground.critical.default` for search icon when it is in an error state

--- a/.changeset/tiny-kids-deliver.md
+++ b/.changeset/tiny-kids-deliver.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-search-field": patch
 ---
 
-SearchField: Use `semanticColor.core.foreground.neutral.subtle` for the search icon. Use `semanticColor.core.foreground.critical.default` for search icon when it is in an error state
+SearchField: Update token usage for search icon for rest, disabled, and error states.

--- a/__docs__/wonder-blocks-search-field/search-field-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field-testing-snapshots.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {Meta, StoryObj} from "@storybook/react-vite";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-search-field/package.json";
 import SearchField from "@khanacademy/wonder-blocks-search-field";
@@ -22,7 +22,7 @@ export default {
             />
         ),
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
 } as Meta<typeof SearchField>;

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -55,6 +55,7 @@ export default {
             />
         ),
         chromatic: {
+            // Disabling snapshots because this is covered by the testing snapshots
             disableSnapshot: true,
         },
     },

--- a/__docs__/wonder-blocks-search-field/search-field.stories.tsx
+++ b/__docs__/wonder-blocks-search-field/search-field.stories.tsx
@@ -54,6 +54,9 @@ export default {
                 version={packageConfig.version}
             />
         ),
+        chromatic: {
+            disableSnapshot: true,
+        },
     },
     argTypes: SearchFieldArgtypes,
 } as Meta<typeof SearchField>;
@@ -142,13 +145,6 @@ export const WithLabeledField: StoryComponentType = {
                 errorMessage={errorMessage}
             />
         );
-    },
-    parameters: {
-        chromatic: {
-            // Disabling because this is for documentation purposes and is
-            // covered by the LabeledField stories
-            disableSnapshot: true,
-        },
     },
 };
 
@@ -254,12 +250,6 @@ export const Error: StoryComponentType = {
         error: true,
     },
     render: Template,
-    parameters: {
-        chromatic: {
-            // Disabling because this is covered by the All Variants stories
-            disableSnapshot: true,
-        },
-    },
 };
 
 /**
@@ -297,11 +287,5 @@ export const Validation: StoryComponentType = {
                 />
             </View>
         );
-    },
-    parameters: {
-        chromatic: {
-            // Disabling because this doesn't test anything visual.
-            disableSnapshot: true,
-        },
     },
 };

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -206,12 +206,11 @@ const SearchField: React.ForwardRefExoticComponent<
                         size="small"
                         color={
                             disabled
-                                ? semanticColor.core.foreground.disabled.default
+                                ? semanticColor.core.foreground.disabled.strong
                                 : error
                                   ? semanticColor.core.foreground.critical
                                         .default
-                                  : semanticColor.core.foreground.neutral
-                                        .default
+                                  : semanticColor.core.foreground.neutral.subtle
                         }
                         style={styles.searchIcon}
                         aria-hidden="true"

--- a/packages/wonder-blocks-search-field/src/components/search-field.tsx
+++ b/packages/wonder-blocks-search-field/src/components/search-field.tsx
@@ -207,7 +207,11 @@ const SearchField: React.ForwardRefExoticComponent<
                         color={
                             disabled
                                 ? semanticColor.core.foreground.disabled.default
-                                : semanticColor.core.foreground.neutral.default
+                                : error
+                                  ? semanticColor.core.foreground.critical
+                                        .default
+                                  : semanticColor.core.foreground.neutral
+                                        .default
                         }
                         style={styles.searchIcon}
                         aria-hidden="true"


### PR DESCRIPTION
## Summary:

Reviewing the SearchField component in SYL Dark to confirm it looks as expected, matches the design specs, and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Changes specific to the component:
- Update the token usage for the search icon to match the Figma specs (updated in all themes)

Issue: WB-2166
Design: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=11380-41761&m=dev

## Test plan:

Review `?path=/story/packages-searchfield-testing-snapshots-searchfield--state-sheet-story&globals=theme:syl-dark` and confirm things look as expected and there are no a11y violations

Review visual changes in Chromatic (especially the search icon in the field)