### PR TITLE
SYL Dark - Switch

### DIFF
--- a/.changeset/famous-dodos-smell.md
+++ b/.changeset/famous-dodos-smell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-switch": patch
+---
+
+Update token usage to support SYL Dark. Update disabled styling

--- a/__docs__/wonder-blocks-switch/switch-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-switch/switch-testing-snapshots.stories.tsx
@@ -8,7 +8,7 @@ import Switch from "@khanacademy/wonder-blocks-switch";
 import {defaultPseudoStates, StateSheet} from "../components/state-sheet";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
-import {themeModes} from "../../.storybook/modes";
+import {allThemeModes} from "../../.storybook/modes";
 
 const rows = [
     {name: "Off", props: {checked: false}},
@@ -52,7 +52,7 @@ const meta = {
     },
     parameters: {
         chromatic: {
-            modes: themeModes,
+            modes: allThemeModes,
         },
     },
     tags: ["!autodocs", "!manifest"],

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -100,9 +100,11 @@ const sharedStyles = StyleSheet.create({
         cursor: "not-allowed",
         ":hover": {
             outline: "none",
+            boxShadow: "none",
         },
         ":active": {
             outline: "none",
+            boxShadow: "none",
         },
     },
     disabledFocus: {

--- a/packages/wonder-blocks-switch/src/components/switch.tsx
+++ b/packages/wonder-blocks-switch/src/components/switch.tsx
@@ -57,21 +57,24 @@ const baseStyles = {
         bg: {
             switch: {
                 off: semanticColor.core.border.neutral.default,
-                disabledOff: semanticColor.core.border.disabled.strong,
+                disabledOff: semanticColor.core.background.disabled.strong,
                 activeOff: semanticColor.core.border.neutral.strong,
                 on: semanticColor.core.background.instructive.default,
-                disabledOn: semanticColor.core.border.instructive.subtle,
+                disabledOn: semanticColor.core.background.disabled.strong,
                 activeOn: semanticColor.core.background.instructive.strong,
             },
             slider: {
-                on: semanticColor.core.foreground.knockout.default,
-                off: semanticColor.core.foreground.knockout.default,
+                on: semanticColor.action.primary.progressive.default.foreground,
+                disabledOn: semanticColor.core.foreground.disabled.default,
+                off: semanticColor.action.primary.progressive.default
+                    .foreground,
+                disabledOff: semanticColor.core.foreground.disabled.default,
             },
             icon: {
                 on: semanticColor.core.foreground.instructive.default,
-                disabledOn: semanticColor.core.border.instructive.subtle,
+                disabledOn: semanticColor.core.foreground.disabled.subtle,
                 off: semanticColor.core.border.neutral.default,
-                disabledOff: semanticColor.core.foreground.disabled.default,
+                disabledOff: semanticColor.core.foreground.disabled.subtle,
             },
         },
     },
@@ -247,6 +250,9 @@ const _generateStyles = (
                 // Positions the slider at the far end of the track:
                 // track width - slider width - edge offset
                 insetInlineStart: `calc(100% - ${sizing.size_200} - ${sizing.size_020})`,
+                backgroundColor: disabled
+                    ? baseStyles.color.bg.slider.disabledOn
+                    : baseStyles.color.bg.slider.on,
             },
             icon: {
                 color: disabled
@@ -274,7 +280,9 @@ const _generateStyles = (
                 ...sharedSwitchStyles,
             },
             slider: {
-                backgroundColor: baseStyles.color.bg.slider.off,
+                backgroundColor: disabled
+                    ? baseStyles.color.bg.slider.disabledOff
+                    : baseStyles.color.bg.slider.off,
             },
             icon: {
                 color: disabled


### PR DESCRIPTION
## Summary:

Reviewing the Switch component in SYL Dark to confirm it looks as expected, matches the design specs, and has no a11y color violations. We also enable Chromatic snapshots for the syl-dark theme for the component.

Changes specific to the component:
- Update token usage in Switch (updated styling for the disabled state and use the `action.primary.progressive.default.foreground` token for the slider so that it can continue to be white in syl-dark

Issue: WB-2166
Design: https://www.figma.com/design/04ptAsL2PE4e8KGfYewta3/bea-syl-dark?node-id=2044-9&m=dev

## Test plan:

Review `?path=/story/packages-switch-testing-snapshots-switch--state-sheet-story&globals=theme:syl-dark` and confirm things look as expected and there are no a11y violations

Review visual changes in Chromatic