### PR TITLE
Add Helvetica and Corbel fallbacks to default sans font token

### DIFF
--- a/.changeset/fluffy-mangos-grow.md
+++ b/.changeset/fluffy-mangos-grow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Add `Helvetica` and `Corbel` fallback fonts to the `default` theme's `font.family.sans` token

--- a/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
+++ b/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
@@ -125,7 +125,7 @@ import {font} from "@khanacademy/wonder-blocks-tokens";
 
 | Token | CSS Variable | Default | Thunderblocks |
 | --- | --- | --- | --- |
-| \`font.family.sans\` | \`--wb-font-family-sans\` | \`Lato, "Noto Sans", sans-serif\` | \`Plus Jakarta Sans, "Noto Sans", sans-serif\` |
+| \`font.family.sans\` | \`--wb-font-family-sans\` | \`"Lato", "Noto Sans", "Helvetica", "Corbel", sans-serif\` | \`Plus Jakarta Sans, "Noto Sans", sans-serif\` |
 | \`font.family.serif\` | \`--wb-font-family-serif\` | \`"Noto Serif", serif\` | \`"Noto Serif", serif\` |
 | \`font.family.mono\` | \`--wb-font-family-mono\` | \`Inconsolata, monospace\` | \`Inconsolata, monospace\` |
 | \`font.weight.light\` | \`--wb-font-weight-light\` | \`300\` | \`300\` |

--- a/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
+++ b/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
@@ -177,7 +177,7 @@ import {font} from "@khanacademy/wonder-blocks-tokens";
 
 | Token | CSS Variable | Default | Thunderblocks | Syl Dark |
 | --- | --- | --- | --- | --- |
-| \`font.family.sans\` | \`--wb-font-family-sans\` | \`Lato, "Noto Sans", sans-serif\` | \`Plus Jakarta Sans, "Noto Sans", sans-serif\` | \`Plus Jakarta Sans, "Noto Sans", sans-serif\` |
+| \`font.family.sans\` | \`--wb-font-family-sans\` | \`"Lato", "Noto Sans", "Helvetica", "Corbel", sans-serif\` | \`Plus Jakarta Sans, "Noto Sans", sans-serif\` | \`Plus Jakarta Sans, "Noto Sans", sans-serif\` |
 | \`font.family.serif\` | \`--wb-font-family-serif\` | \`"Noto Serif", serif\` | \`"Noto Serif", serif\` | \`"Noto Serif", serif\` |
 | \`font.family.mono\` | \`--wb-font-family-mono\` | \`Inconsolata, monospace\` | \`Inconsolata, monospace\` | \`Inconsolata, monospace\` |
 | \`font.weight.light\` | \`--wb-font-weight-light\` | \`300\` | \`300\` | \`300\` |

--- a/packages/wonder-blocks-tokens/src/theme/primitive/font.ts
+++ b/packages/wonder-blocks-tokens/src/theme/primitive/font.ts
@@ -1,7 +1,7 @@
 import {sizing} from "./sizing";
 
 export const fontFamily = {
-    sans: 'Lato, "Noto Sans", sans-serif',
+    sans: '"Lato", "Noto Sans", "Helvetica", "Corbel", sans-serif',
     serif: '"Noto Serif", serif',
     mono: "Inconsolata, monospace",
 };


### PR DESCRIPTION
## Summary

Updates the `default` theme's `font.family.sans` token to include additional system font fallbacks.

**Before:**
```
Lato, "Noto Sans", sans-serif
```

**After:**
```
"Lato", "Noto Sans", "Helvetica", "Corbel", sans-serif
```

###  Why

Adds `Helvetica` and `Corbel` as fallback fonts for parity with the [current font value used in frontend](https://github.com/Khan/frontend/blob/b1193413e526b4b39a22646a41eaf8ad71749afd/libs/app-shell/src/styles/classic.css#L16). After this, we can use the css variable token for setting the body font!

Note: This only affects the `default` theme; the Thunderblocks `font.family.sans` token is unchanged. I created https://khanacademy.atlassian.net/browse/WB-2378 to re-evaluate fallback fonts if needed (for now, we are making this update for parity!) 

Issue: FEI-7881 

## Test Plan:

Confirm the `default` theme `font.family.sans` token is updated to include the fallback fonts. Confirm token is not updated in other themes