### PR TITLE
WB-2346: Deprecate opened prop in WB Modal to address focus management gotchas

### DIFF
--- a/.changeset/forty-glasses-pretend.md
+++ b/.changeset/forty-glasses-pretend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": minor
+---
+
+Deprecate open prop in WB Modal to address focus management gotchas

--- a/__docs__/wonder-blocks-announcer/announcer.stories.tsx
+++ b/__docs__/wonder-blocks-announcer/announcer.stories.tsx
@@ -241,9 +241,8 @@ export const AnnouncerInModal: StoryComponentType = {
                     <Button onClick={handleOpen}>Open Modal to Test</Button>
                 )}
                 <ModalLauncher
-                    opened={isOpen}
                     onClose={handleClose}
-                    modal={ModalContent}
+                    modal={isOpen ? ModalContent : null}
                 />
             </View>
         );

--- a/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/action-menu.stories.tsx
@@ -635,35 +635,38 @@ export const OpeningModal: StoryComponentType = {
                     onClose={() => {
                         setOpened(false);
                     }}
-                    opened={opened}
-                    modal={({closeModal}) => (
-                        <OnePaneDialog
-                            title="Are you sure?"
-                            content="This is just a test"
-                            style={{maxBlockSize: "fit-content"}}
-                            footer={
-                                <View
-                                    style={{
-                                        flexDirection: "row",
-                                        gap: sizing.size_160,
-                                    }}
-                                >
-                                    <Button
-                                        kind="tertiary"
-                                        onClick={closeModal}
-                                    >
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        actionType="destructive"
-                                        onClick={closeModal}
-                                    >
-                                        Delete
-                                    </Button>
-                                </View>
-                            }
-                        />
-                    )}
+                    modal={
+                        opened
+                            ? ({closeModal}) => (
+                                  <OnePaneDialog
+                                      title="Are you sure?"
+                                      content="This is just a test"
+                                      style={{maxBlockSize: "fit-content"}}
+                                      footer={
+                                          <View
+                                              style={{
+                                                  flexDirection: "row",
+                                                  gap: sizing.size_160,
+                                              }}
+                                          >
+                                              <Button
+                                                  kind="tertiary"
+                                                  onClick={closeModal}
+                                              >
+                                                  Cancel
+                                              </Button>
+                                              <Button
+                                                  actionType="destructive"
+                                                  onClick={closeModal}
+                                              >
+                                                  Delete
+                                              </Button>
+                                          </View>
+                                      }
+                                  />
+                              )
+                            : null
+                    }
                 />
             </>
         );

--- a/__docs__/wonder-blocks-modal/drawer-launcher-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-modal/drawer-launcher-testing-snapshots.stories.tsx
@@ -52,7 +52,6 @@ export const InlineStart: StoryComponentType = {
         <DrawerLauncher
             modal={DefaultModal}
             alignment="inlineStart"
-            opened={true}
             animated={false}
             onClose={() => {}}
         />
@@ -70,7 +69,6 @@ export const InlineEnd: StoryComponentType = {
         <DrawerLauncher
             modal={DefaultModal}
             alignment="inlineEnd"
-            opened={true}
             animated={false}
             onClose={() => {}}
         />
@@ -114,7 +112,6 @@ export const InlineEndCustomStyle: StoryComponentType = {
                 />
             }
             alignment="inlineEnd"
-            opened={true}
             animated={false}
             onClose={() => {}}
         />
@@ -132,7 +129,6 @@ export const BlockEnd: StoryComponentType = {
         <DrawerLauncher
             modal={DefaultModal}
             alignment="blockEnd"
-            opened={true}
             animated={false}
             onClose={() => {}}
         />

--- a/__docs__/wonder-blocks-modal/drawer-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/drawer-launcher.stories.tsx
@@ -76,10 +76,9 @@ import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 <DrawerLauncher
      onClose={handleClose}
-     opened={opened}
      animated={animated}
      alignment="inlineStart"
-     modal={({closeModal}) => (
+     modal={isOpen ? ({closeModal}) => (
          <DrawerDialog
              title="Assign Mastery Mission"
              content={
@@ -90,7 +89,7 @@ import {BodyText} from "@khanacademy/wonder-blocks-typography";
                  </View>
              }
          />
-     )}
+     ) : null}
 />
 \`\`\``,
             },
@@ -419,18 +418,21 @@ export const TriggeringProgrammatically: StoryComponentType = {
 
                 <DrawerLauncher
                     onClose={handleClose}
-                    opened={opened}
                     alignment={args.alignment}
-                    modal={({closeModal}) => (
-                        <DrawerDialog
-                            title="Triggered from action menu"
-                            content={
-                                <View>
-                                    <BodyText>Hello, world</BodyText>
-                                </View>
-                            }
-                        />
-                    )}
+                    modal={
+                        opened
+                            ? ({closeModal}) => (
+                                  <DrawerDialog
+                                      title="Triggered from action menu"
+                                      content={
+                                          <View>
+                                              <BodyText>Hello, world</BodyText>
+                                          </View>
+                                      }
+                                  />
+                              )
+                            : null
+                    }
                     // Note that this modal launcher has no children.
                 />
             </View>
@@ -489,9 +491,8 @@ export const WithClosedFocusId: StoryComponentType = {
                 <DrawerLauncher
                     alignment={args.alignment}
                     onClose={() => handleClose()}
-                    opened={opened}
                     closedFocusId="button-to-focus-on"
-                    modal={DefaultModal}
+                    modal={opened ? DefaultModal : null}
                 />
             </View>
         );

--- a/__docs__/wonder-blocks-modal/modal-launcher-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher-testing-snapshots.stories.tsx
@@ -35,10 +35,8 @@ export const WithOnePaneDialog = {
                         footer={<Button>Action</Button>}
                     />
                 }
-                opened={true}
-            >
-                {({openModal}) => <Button onClick={openModal}>Open</Button>}
-            </ModalLauncher>
+                onClose={() => {}}
+            />
         );
     },
 };
@@ -53,10 +51,8 @@ export const WithFlexibleDialog = {
                         content={<div>{reallyLongText}</div>}
                     />
                 }
-                opened={true}
-            >
-                {({openModal}) => <Button onClick={openModal}>Open</Button>}
-            </ModalLauncher>
+                onClose={() => {}}
+            />
         );
     },
 };

--- a/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/modal-launcher.stories.tsx
@@ -263,20 +263,27 @@ export const TriggeringProgrammatically: StoryComponentType = () => {
 
             <ModalLauncher
                 onClose={handleClose}
-                opened={opened}
-                modal={({closeModal}) => (
-                    <OnePaneDialog
-                        title="Triggered from action menu"
-                        content={
-                            <View>
-                                <Heading size="xxlarge">Hello, world</Heading>
-                            </View>
-                        }
-                        footer={
-                            <Button onClick={closeModal}>Close Modal</Button>
-                        }
-                    />
-                )}
+                modal={
+                    opened
+                        ? ({closeModal}) => (
+                              <OnePaneDialog
+                                  title="Triggered from action menu"
+                                  content={
+                                      <View>
+                                          <Heading size="xxlarge">
+                                              Hello, world
+                                          </Heading>
+                                      </View>
+                                  }
+                                  footer={
+                                      <Button onClick={closeModal}>
+                                          Close Modal
+                                      </Button>
+                                  }
+                              />
+                          )
+                        : null
+                }
                 // Note that this modal launcher has no children.
             />
         </View>
@@ -403,16 +410,14 @@ export const WithOpenedTrue = () => {
 
             {/* Edit Modal */}
             <ModalLauncher
-                opened={openedModal === "EDIT"}
                 onClose={handleClose}
-                modal={editDialog}
+                modal={openedModal === "EDIT" ? editDialog : null}
             />
 
             {/* Delete Modal */}
             <ModalLauncher
-                opened={openedModal === "DELETE"}
                 onClose={handleClose}
-                modal={deleteDialog}
+                modal={openedModal === "DELETE" ? deleteDialog : null}
             />
         </View>
     );
@@ -438,9 +443,8 @@ export const WithClosedFocusId: StoryComponentType = () => {
             </ActionMenu>
             <ModalLauncher
                 onClose={() => handleClose()}
-                opened={opened}
                 closedFocusId="button-to-focus-on"
-                modal={DefaultModal}
+                modal={opened ? DefaultModal : null}
             />
         </View>
     );
@@ -566,25 +570,29 @@ export const FocusManagementPattern: StoryComponentType = {
         }: CompletionModalProps) => {
             return (
                 <ModalLauncher
-                    opened={isOpen}
                     onClose={handleClose}
                     closedFocusId={returnFocusToId || undefined}
-                    modal={() => (
-                        <OnePaneDialog
-                            title="Unit: Sample Unit"
-                            content={
-                                <View style={styles.modalContent}>
-                                    <BodyText>
-                                        This is a reproduction of the focus
-                                        management pattern. When this modal is
-                                        closed, focus should return to the
-                                        button that opened it.
-                                    </BodyText>
-                                </View>
-                            }
-                            style={styles.modal}
-                        />
-                    )}
+                    modal={
+                        isOpen
+                            ? () => (
+                                  <OnePaneDialog
+                                      title="Unit: Sample Unit"
+                                      content={
+                                          <View style={styles.modalContent}>
+                                              <BodyText>
+                                                  This is a reproduction of the
+                                                  focus management pattern. When
+                                                  this modal is closed, focus
+                                                  should return to the button
+                                                  that opened it.
+                                              </BodyText>
+                                          </View>
+                                      }
+                                      style={styles.modal}
+                                  />
+                              )
+                            : null
+                    }
                 />
             );
         };
@@ -623,13 +631,11 @@ export const FocusManagementPattern: StoryComponentType = {
                             );
                         })}
                     </View>
-                    {selectedItem && (
-                        <CompletionModal
-                            isOpen={true}
-                            handleClose={handleCloseModal}
-                            returnFocusToId={modalTriggerId}
-                        />
-                    )}
+                    <CompletionModal
+                        isOpen={selectedItem !== null}
+                        handleClose={handleCloseModal}
+                        returnFocusToId={modalTriggerId}
+                    />
                 </View>
             );
         };
@@ -837,14 +843,13 @@ export const ConditionalDialogsWithFocusManagement: StoryComponentType = () => {
 
             {/* Single ModalLauncher with conditional dialogs */}
             <ModalLauncher
-                opened={openedModal !== null}
                 onClose={handleClose}
                 closedFocusId={
                     openedModal === "WRAPPED"
                         ? "alternative-modal-trigger"
                         : undefined
                 }
-                modal={conditionalDialog}
+                modal={openedModal !== null ? conditionalDialog : null}
             />
         </View>
     );

--- a/packages/wonder-blocks-modal/src/components/__tests__/drawer-launcher.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/drawer-launcher.test.tsx
@@ -27,6 +27,99 @@ describe("DrawerLauncher", () => {
         jest.clearAllMocks();
     });
 
+    test("using deprecated `opened` prop logs a deprecation warning", () => {
+        // Arrange
+        const warnSpy = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {});
+
+        // Act
+        render(
+            <DrawerLauncher
+                alignment="inlineEnd"
+                modal={exampleModal}
+                opened={false}
+                onClose={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining("`opened` prop is deprecated"),
+        );
+    });
+
+    test("deprecated `opened` prop: starts closed when false", () => {
+        // Arrange
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+
+        // Act
+        render(
+            <DrawerLauncher
+                alignment="inlineEnd"
+                animated={false}
+                modal={exampleModal}
+                opened={false}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.queryByTestId("modal-launcher-portal"),
+        ).not.toBeInTheDocument();
+    });
+
+    test("deprecated `opened` prop: shows portal when opened becomes true", async () => {
+        // Arrange
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        const UnderTest = ({isOpen}: {isOpen: boolean}) => (
+            <DrawerLauncher
+                alignment="inlineEnd"
+                animated={false}
+                modal={exampleModal}
+                opened={isOpen}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />
+        );
+        const {rerender} = render(<UnderTest isOpen={false} />);
+
+        // Act
+        rerender(<UnderTest isOpen={true} />);
+
+        // Assert
+        expect(
+            await screen.findByTestId("modal-launcher-portal"),
+        ).toBeInTheDocument();
+    });
+
+    test("deprecated `opened` prop: hides portal when opened becomes false", async () => {
+        // Arrange
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        const UnderTest = ({isOpen}: {isOpen: boolean}) => (
+            <DrawerLauncher
+                alignment="inlineEnd"
+                animated={false}
+                modal={exampleModal}
+                opened={isOpen}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />
+        );
+        const {rerender} = render(<UnderTest isOpen={true} />);
+        await screen.findByTestId("modal-launcher-portal");
+
+        // Act
+        rerender(<UnderTest isOpen={false} />);
+
+        // Assert
+        expect(
+            screen.queryByTestId("modal-launcher-portal"),
+        ).not.toBeInTheDocument();
+    });
+
     test("Children can launch the modal", async () => {
         // Arrange
         render(
@@ -42,13 +135,31 @@ describe("DrawerLauncher", () => {
         // Act
         await userEvent.click(await screen.findByRole("button"));
 
-        const portal = await screen.findByTestId("modal-launcher-portal");
-
         // Assert
-        expect(portal).toBeInTheDocument();
+        expect(
+            await screen.findByTestId("modal-launcher-portal"),
+        ).toBeInTheDocument();
     });
 
-    test("Modal can be manually opened and closed via modal prop", async () => {
+    test("starts closed when modal prop is null", () => {
+        // Arrange
+        render(
+            <DrawerLauncher
+                alignment="inlineEnd"
+                animated={false}
+                modal={null}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.queryByTestId("modal-launcher-portal"),
+        ).not.toBeInTheDocument();
+    });
+
+    test("shows portal when modal prop becomes non-null", async () => {
         // Arrange
         const UnderTest = ({isOpen}: {isOpen: boolean}) => (
             <DrawerLauncher
@@ -62,15 +173,32 @@ describe("DrawerLauncher", () => {
         const {rerender} = render(<UnderTest isOpen={false} />);
 
         // Act
-        expect(
-            screen.queryByTestId("modal-launcher-portal"),
-        ).not.toBeInTheDocument();
         rerender(<UnderTest isOpen={true} />);
+
+        // Assert
         expect(
             await screen.findByTestId("modal-launcher-portal"),
         ).toBeInTheDocument();
+    });
+
+    test("hides portal when modal prop returns to null", async () => {
+        // Arrange
+        const UnderTest = ({isOpen}: {isOpen: boolean}) => (
+            <DrawerLauncher
+                alignment="inlineEnd"
+                animated={false}
+                modal={isOpen ? exampleModal : null}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />
+        );
+        const {rerender} = render(<UnderTest isOpen={true} />);
+        await screen.findByTestId("modal-launcher-portal");
+
+        // Act
         rerender(<UnderTest isOpen={false} />);
-        // Without animation the portal should be gone immediately
+
+        // Assert
         expect(
             screen.queryByTestId("modal-launcher-portal"),
         ).not.toBeInTheDocument();
@@ -88,11 +216,7 @@ describe("DrawerLauncher", () => {
                 }
             />
         );
-
         const onCloseMock = jest.fn();
-
-        // Mount the modal launcher. This shouldn't trigger any closing yet,
-        // because we shouldn't be calling the `modal` function yet.
         render(
             <DrawerLauncher
                 alignment="inlineEnd"
@@ -104,10 +228,7 @@ describe("DrawerLauncher", () => {
                 {({openModal}: any) => <button onClick={openModal} />}
             </DrawerLauncher>,
         );
-
         await userEvent.click(await screen.findByRole("button"));
-
-        // wait until the modal is open
         await screen.findByRole("dialog");
 
         // Act
@@ -130,20 +251,16 @@ describe("DrawerLauncher", () => {
                 {({openModal}: any) => <button onClick={openModal} />}
             </DrawerLauncher>,
         );
-
-        // Launch the modal.
         await userEvent.click(await screen.findByRole("button"));
-
-        // wait until the modal is open
         await screen.findByRole("dialog");
 
         // Act
-        // Simulate an Escape keypress.
         await userEvent.keyboard("{Escape}");
 
         // Assert
-        // Confirm that the modal is no longer mounted.
-        await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+        await waitFor(() =>
+            expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+        );
     });
 
     test("Disable scrolling when the modal is open", async () => {
@@ -155,14 +272,10 @@ describe("DrawerLauncher", () => {
         );
 
         // Act
-        // Launch the modal.
         await userEvent.click(await screen.findByRole("button"));
-
-        // wait until the modal is open
         await screen.findByRole("dialog");
 
         // Assert
-        // Now that the modal is open, there should be a ScrollDisabler.
         expect(document.body).toHaveStyle("overflow: hidden");
     });
 
@@ -177,26 +290,21 @@ describe("DrawerLauncher", () => {
                 {({openModal}: any) => <button onClick={openModal} />}
             </DrawerLauncher>,
         );
-
-        // Launch the modal.
         await userEvent.click(await screen.findByRole("button"));
-
         await screen.findByRole("dialog");
 
-        // Close the modal.
+        // Act
         await userEvent.click(
             await screen.findByRole("button", {name: "Close modal"}),
         );
 
         // Assert
-        // Now that the modal is closed, there should be no ScrollDisabler.
         expect(document.body).not.toHaveStyle("overflow: hidden");
     });
 
     test("If backdropDismissEnabled set to false, clicking the backdrop does not trigger `onClose`", async () => {
         // Arrange
         const onClose = jest.fn();
-
         render(
             <DrawerLauncher
                 alignment="inlineEnd"
@@ -208,8 +316,9 @@ describe("DrawerLauncher", () => {
         );
 
         // Act
-        const backdrop = await screen.findByTestId("modal-launcher-backdrop");
-        await userEvent.click(backdrop);
+        await userEvent.click(
+            await screen.findByTestId("modal-launcher-backdrop"),
+        );
 
         // Assert
         expect(onClose).not.toHaveBeenCalled();
@@ -236,21 +345,16 @@ describe("DrawerLauncher", () => {
                 )}
             </DrawerLauncher>,
         );
-
-        // focus on the open modal button
         await userEvent.tab();
 
         // Act
-        // Launch the modal.
         await userEvent.keyboard("{enter}");
-
-        // wait until the modal is open
         await screen.findByRole("dialog");
 
         // Assert
-        await waitFor(async () =>
+        await waitFor(() =>
             expect(
-                await screen.findByRole("button", {name: "Close modal"}),
+                screen.getByRole("button", {name: "Close modal"}),
             ).toHaveFocus(),
         );
     });
@@ -307,24 +411,16 @@ describe("DrawerLauncher", () => {
                 </MemoryRouter>
             );
         };
-
         render(<DrawerLauncherWrapper />);
-
         const lastButton = await screen.findByTestId("launcher-button");
-
-        // Launch the modal.
         await userEvent.click(lastButton);
+        await screen.findByRole("dialog");
 
         // Act
-        // Close modal
-        const modalCloseButton =
-            await screen.findByTestId("modal-close-button");
-        await userEvent.click(modalCloseButton);
+        await userEvent.click(await screen.findByTestId("modal-close-button"));
 
         // Assert
-        await waitFor(() => {
-            expect(lastButton).toHaveFocus();
-        });
+        await waitFor(() => expect(lastButton).toHaveFocus());
     });
 
     test("if `closedFocusId` is passed, shift focus to specified element after the modal closes", async () => {
@@ -356,7 +452,6 @@ describe("DrawerLauncher", () => {
                                           title="Triggered from action menu"
                                           content={
                                               <View>
-                                                  {" "}
                                                   <Button
                                                       testId="modal-close-button"
                                                       onClick={closeModal}
@@ -373,24 +468,17 @@ describe("DrawerLauncher", () => {
                 </View>
             );
         };
-
         render(<DrawerLauncherWrapper />);
-
-        // Launch modal
-        const launcherButton = await screen.findByTestId("launcher-button");
-        await userEvent.click(launcherButton);
+        await userEvent.click(await screen.findByTestId("launcher-button"));
+        await screen.findByRole("dialog");
 
         // Act
-        // Close modal
-        const modalCloseButton =
-            await screen.findByTestId("modal-close-button");
-        await userEvent.click(modalCloseButton);
+        await userEvent.click(await screen.findByTestId("modal-close-button"));
 
         // Assert
-        const focusedButton = await screen.findByTestId("focused-button");
-        await waitFor(() => {
-            expect(focusedButton).toHaveFocus();
-        });
+        await waitFor(() =>
+            expect(screen.getByTestId("focused-button")).toHaveFocus(),
+        );
     });
 
     test("testId should be added to the Backdrop", async () => {
@@ -404,11 +492,10 @@ describe("DrawerLauncher", () => {
             />,
         );
 
-        // Act
-        const backdrop = await screen.findByTestId("test-id-example");
-
         // Assert
-        expect(backdrop).toBeInTheDocument();
+        expect(
+            await screen.findByTestId("test-id-example"),
+        ).toBeInTheDocument();
     });
 
     describe("Slide animations", () => {
@@ -419,7 +506,7 @@ describe("DrawerLauncher", () => {
                 <DrawerLauncher
                     alignment="inlineEnd"
                     animated={true}
-                    timingDuration={100} // Short duration for test
+                    timingDuration={100}
                     modal={
                         <FlexibleDialog
                             title="Animation test"
@@ -431,12 +518,11 @@ describe("DrawerLauncher", () => {
             );
 
             // Act
-            const closeButton = await screen.findByRole("button", {
-                name: "Close modal",
-            });
-            await userEvent.click(closeButton);
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
-            // Assert - onClose is called immediately in controlled mode
+            // Assert
             expect(onCloseMock).toHaveBeenCalled();
         });
 
@@ -458,10 +544,9 @@ describe("DrawerLauncher", () => {
             );
 
             // Act
-            const closeButton = await screen.findByRole("button", {
-                name: "Close modal",
-            });
-            await userEvent.click(closeButton);
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
             // Assert
             expect(onCloseMock).toHaveBeenCalled();
@@ -474,7 +559,7 @@ describe("DrawerLauncher", () => {
                 <DrawerLauncher
                     alignment="inlineEnd"
                     animated={true}
-                    timingDuration={100} // Short duration for test
+                    timingDuration={100}
                     modal={
                         <FlexibleDialog
                             title="Animation test"
@@ -487,10 +572,9 @@ describe("DrawerLauncher", () => {
             );
 
             // Act
-            const backdrop = await screen.findByTestId("modal-backdrop");
-            await userEvent.click(backdrop);
+            await userEvent.click(await screen.findByTestId("modal-backdrop"));
 
-            // Assert - onClose is called immediately in controlled mode
+            // Assert
             expect(onCloseMock).toHaveBeenCalled();
         });
 
@@ -501,7 +585,7 @@ describe("DrawerLauncher", () => {
                 <DrawerLauncher
                     alignment="inlineEnd"
                     animated={true}
-                    timingDuration={100} // Short duration for test
+                    timingDuration={100}
                     modal={
                         <FlexibleDialog
                             title="Animation test"
@@ -515,7 +599,7 @@ describe("DrawerLauncher", () => {
             // Act
             await userEvent.keyboard("{Escape}");
 
-            // Assert - onClose is called immediately in controlled mode
+            // Assert
             expect(onCloseMock).toHaveBeenCalled();
         });
 
@@ -536,22 +620,16 @@ describe("DrawerLauncher", () => {
                     {({openModal}: any) => <button onClick={openModal} />}
                 </DrawerLauncher>,
             );
+            await userEvent.click(await screen.findByRole("button"));
+            const dialog = await screen.findByRole("dialog");
 
             // Act
-            // Launch the modal.
-            await userEvent.click(await screen.findByRole("button"));
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
-            // Verify modal is in the DOM and scroll is disabled
-            const dialog = await screen.findByRole("dialog");
-            expect(dialog).toBeInTheDocument();
-
-            const closeButton = await screen.findByRole("button", {
-                name: "Close modal",
-            });
-            await userEvent.click(closeButton);
-
-            // Assert - with no animation, removal should be immediate
-            await expect(dialog).not.toBeInTheDocument();
+            // Assert
+            expect(dialog).not.toBeInTheDocument();
         });
 
         test("Scroll is re-enabled after closing uncontrolled modal", async () => {
@@ -571,20 +649,16 @@ describe("DrawerLauncher", () => {
                     {({openModal}: any) => <button onClick={openModal} />}
                 </DrawerLauncher>,
             );
+            await userEvent.click(await screen.findByRole("button"));
+            await screen.findByRole("dialog");
 
             // Act
-            // Launch the modal.
-            await userEvent.click(await screen.findByRole("button"));
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
-            expect(document.body).toHaveStyle("overflow: hidden");
-
-            const closeButton = await screen.findByRole("button", {
-                name: "Close modal",
-            });
-            await userEvent.click(closeButton);
-
-            // Assert - with no animation, removal should be immediate
-            await expect(document.body).not.toHaveStyle("overflow: hidden");
+            // Assert
+            expect(document.body).not.toHaveStyle("overflow: hidden");
         });
 
         test("Controlled modal is removed from DOM after closing without animation", async () => {
@@ -609,16 +683,14 @@ describe("DrawerLauncher", () => {
                     />
                 );
             };
-
             render(<TestComponent />);
 
             // Act
-            const closeButton = await screen.findByRole("button", {
-                name: "Close modal",
-            });
-            await userEvent.click(closeButton);
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
-            // Assert - with no animation, removal should be immediate
+            // Assert
             expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
         });
 
@@ -644,19 +716,15 @@ describe("DrawerLauncher", () => {
                     />
                 );
             };
+            render(<TestComponent />);
+            await screen.findByRole("dialog");
 
             // Act
-            render(<TestComponent />);
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
             // Assert
-            expect(document.body).toHaveStyle("overflow: hidden");
-
-            const closeButton = await screen.findByRole("button", {
-                name: "Close modal",
-            });
-            await userEvent.click(closeButton);
-
-            // Assert - with no animation, removal should be immediate
             expect(document.body).not.toHaveStyle("overflow: hidden");
         });
 
@@ -668,7 +736,7 @@ describe("DrawerLauncher", () => {
                     <DrawerLauncher
                         alignment="inlineEnd"
                         animated={true}
-                        timingDuration={100} // Short duration for test
+                        timingDuration={100}
                         modal={
                             isOpen ? (
                                 <FlexibleDialog
@@ -683,23 +751,20 @@ describe("DrawerLauncher", () => {
                     />
                 );
             };
-
             render(<TestComponent />);
 
             // Act
-            const closeButton = await screen.findByRole("button", {
-                name: "Close modal",
-            });
-            await userEvent.click(closeButton);
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
-            // Assert - with animation, need to wait for cleanup
+            // Assert
             await waitFor(
-                () => {
+                () =>
                     expect(
                         screen.queryByRole("dialog"),
-                    ).not.toBeInTheDocument();
-                },
-                {timeout: 200}, // A bit longer than animation duration
+                    ).not.toBeInTheDocument(),
+                {timeout: 200},
             );
         });
 
@@ -711,7 +776,7 @@ describe("DrawerLauncher", () => {
                     <DrawerLauncher
                         alignment="inlineEnd"
                         animated={true}
-                        timingDuration={100} // Short duration for test
+                        timingDuration={100}
                         modal={
                             isOpen ? (
                                 <FlexibleDialog
@@ -726,23 +791,17 @@ describe("DrawerLauncher", () => {
                     />
                 );
             };
-
             render(<TestComponent />);
-
-            // Verify modal is in the DOM and scroll is disabled
-            expect(document.body).toHaveStyle("overflow: hidden");
+            await screen.findByRole("dialog");
 
             // Act
-            const closeButton = await screen.findByRole("button", {
-                name: "Close modal",
-            });
-            await userEvent.click(closeButton);
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
-            // Assert - with animation, need to wait for cleanup
+            // Assert
             await waitFor(
-                () => {
-                    expect(document.body).not.toHaveStyle("overflow: hidden");
-                },
+                () => expect(document.body).not.toHaveStyle("overflow: hidden"),
                 {timeout: 200},
             );
         });

--- a/packages/wonder-blocks-modal/src/components/__tests__/drawer-launcher.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/drawer-launcher.test.tsx
@@ -48,28 +48,29 @@ describe("DrawerLauncher", () => {
         expect(portal).toBeInTheDocument();
     });
 
-    test("Modal can be manually opened and closed", async () => {
+    test("Modal can be manually opened and closed via modal prop", async () => {
         // Arrange
-        const UnderTest = ({opened}: {opened: boolean}) => (
+        const UnderTest = ({isOpen}: {isOpen: boolean}) => (
             <DrawerLauncher
                 alignment="inlineEnd"
-                modal={exampleModal}
-                opened={opened}
+                animated={false}
+                modal={isOpen ? exampleModal : null}
                 onClose={() => {}}
                 testId="modal-launcher-portal"
             />
         );
-        const {rerender} = render(<UnderTest opened={false} />);
+        const {rerender} = render(<UnderTest isOpen={false} />);
 
         // Act
         expect(
             screen.queryByTestId("modal-launcher-portal"),
         ).not.toBeInTheDocument();
-        rerender(<UnderTest opened={true} />);
+        rerender(<UnderTest isOpen={true} />);
         expect(
             await screen.findByTestId("modal-launcher-portal"),
         ).toBeInTheDocument();
-        rerender(<UnderTest opened={false} />);
+        rerender(<UnderTest isOpen={false} />);
+        // Without animation the portal should be gone immediately
         expect(
             screen.queryByTestId("modal-launcher-portal"),
         ).not.toBeInTheDocument();
@@ -201,7 +202,6 @@ describe("DrawerLauncher", () => {
                 alignment="inlineEnd"
                 onClose={onClose}
                 modal={exampleModal}
-                opened={true}
                 backdropDismissEnabled={false}
                 testId="modal-launcher-backdrop"
             />,
@@ -258,15 +258,7 @@ describe("DrawerLauncher", () => {
     test("if modal is closed, return focus to the last element focused outside the modal", async () => {
         // Arrange
         const DrawerLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(false);
-
-            const handleOpen = () => {
-                setOpened(true);
-            };
-
-            const handleClose = () => {
-                setOpened(false);
-            };
+            const [isOpen, setIsOpen] = React.useState(false);
 
             return (
                 <MemoryRouter>
@@ -277,30 +269,38 @@ describe("DrawerLauncher", () => {
                             </Button>
                             <Button
                                 testId="launcher-button"
-                                onClick={() => handleOpen()}
+                                onClick={() => setIsOpen(true)}
                             >
                                 Open modal
                             </Button>
                             <DrawerLauncher
                                 alignment="inlineStart"
-                                onClose={() => handleClose()}
-                                opened={opened}
-                                modal={({closeModal}: any) => (
-                                    <FlexibleDialog
-                                        title="Regular modal"
-                                        content={
-                                            <View>
-                                                <BodyText>Hello World</BodyText>
-                                                <Button
-                                                    testId="modal-close-button"
-                                                    onClick={closeModal}
-                                                >
-                                                    Close Modal
-                                                </Button>
-                                            </View>
-                                        }
-                                    />
-                                )}
+                                animated={false}
+                                onClose={() => setIsOpen(false)}
+                                modal={
+                                    isOpen
+                                        ? ({closeModal}: any) => (
+                                              <FlexibleDialog
+                                                  title="Regular modal"
+                                                  content={
+                                                      <View>
+                                                          <BodyText>
+                                                              Hello World
+                                                          </BodyText>
+                                                          <Button
+                                                              testId="modal-close-button"
+                                                              onClick={
+                                                                  closeModal
+                                                              }
+                                                          >
+                                                              Close Modal
+                                                          </Button>
+                                                      </View>
+                                                  }
+                                              />
+                                          )
+                                        : null
+                                }
                             />
                         </View>
                     </CompatRouter>
@@ -330,15 +330,7 @@ describe("DrawerLauncher", () => {
     test("if `closedFocusId` is passed, shift focus to specified element after the modal closes", async () => {
         // Arrange
         const DrawerLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(false);
-
-            const handleOpen = () => {
-                setOpened(true);
-            };
-
-            const handleClose = () => {
-                setOpened(false);
-            };
+            const [isOpen, setIsOpen] = React.useState(false);
 
             return (
                 <View>
@@ -348,31 +340,35 @@ describe("DrawerLauncher", () => {
                     </Button>
                     <Button
                         testId="launcher-button"
-                        onClick={() => handleOpen()}
+                        onClick={() => setIsOpen(true)}
                     >
                         Open modal
                     </Button>
                     <DrawerLauncher
                         alignment="inlineStart"
-                        onClose={() => handleClose()}
-                        opened={opened}
+                        animated={false}
+                        onClose={() => setIsOpen(false)}
                         closedFocusId="button-to-focus-on"
-                        modal={({closeModal}: any) => (
-                            <FlexibleDialog
-                                title="Triggered from action menu"
-                                content={
-                                    <View>
-                                        {" "}
-                                        <Button
-                                            testId="modal-close-button"
-                                            onClick={closeModal}
-                                        >
-                                            Close Modal
-                                        </Button>
-                                    </View>
-                                }
-                            />
-                        )}
+                        modal={
+                            isOpen
+                                ? ({closeModal}: any) => (
+                                      <FlexibleDialog
+                                          title="Triggered from action menu"
+                                          content={
+                                              <View>
+                                                  {" "}
+                                                  <Button
+                                                      testId="modal-close-button"
+                                                      onClick={closeModal}
+                                                  >
+                                                      Close Modal
+                                                  </Button>
+                                              </View>
+                                          }
+                                      />
+                                  )
+                                : null
+                        }
                     />
                 </View>
             );
@@ -402,7 +398,6 @@ describe("DrawerLauncher", () => {
         render(
             <DrawerLauncher
                 alignment="inlineEnd"
-                opened={true}
                 onClose={jest.fn()}
                 modal={<div role="dialog">dialog</div>}
                 testId="test-id-example"
@@ -417,7 +412,7 @@ describe("DrawerLauncher", () => {
     });
 
     describe("Slide animations", () => {
-        test("Modal closes with animation when animated=true", async () => {
+        test("Modal closes and notifies parent when animated=true", async () => {
             // Arrange
             const onCloseMock = jest.fn();
             render(
@@ -431,7 +426,6 @@ describe("DrawerLauncher", () => {
                             content={<div data-testid="modal-content" />}
                         />
                     }
-                    opened={true}
                     onClose={onCloseMock}
                 />,
             );
@@ -442,15 +436,8 @@ describe("DrawerLauncher", () => {
             });
             await userEvent.click(closeButton);
 
-            // Assert
-            expect(onCloseMock).not.toHaveBeenCalled();
-            // Wait for animation
-            await waitFor(
-                () => {
-                    expect(onCloseMock).toHaveBeenCalled();
-                },
-                {timeout: 200}, // A bit longer than animation duration
-            );
+            // Assert - onClose is called immediately in controlled mode
+            expect(onCloseMock).toHaveBeenCalled();
         });
 
         test("Modal closes immediately when animated=false", async () => {
@@ -466,7 +453,6 @@ describe("DrawerLauncher", () => {
                             content={<div data-testid="modal-content" />}
                         />
                     }
-                    opened={true}
                     onClose={onCloseMock}
                 />,
             );
@@ -481,7 +467,7 @@ describe("DrawerLauncher", () => {
             expect(onCloseMock).toHaveBeenCalled();
         });
 
-        test("Modal shows exit animation when closing via backdrop click", async () => {
+        test("Modal notifies parent when closing via backdrop click", async () => {
             // Arrange
             const onCloseMock = jest.fn();
             render(
@@ -495,7 +481,6 @@ describe("DrawerLauncher", () => {
                             content={<div data-testid="modal-content" />}
                         />
                     }
-                    opened={true}
                     onClose={onCloseMock}
                     testId="modal-backdrop"
                 />,
@@ -505,18 +490,11 @@ describe("DrawerLauncher", () => {
             const backdrop = await screen.findByTestId("modal-backdrop");
             await userEvent.click(backdrop);
 
-            // Assert
-            expect(onCloseMock).not.toHaveBeenCalled();
-            // Wait for animation
-            await waitFor(
-                () => {
-                    expect(onCloseMock).toHaveBeenCalled();
-                },
-                {timeout: 200}, // A bit longer than animation duration
-            );
+            // Assert - onClose is called immediately in controlled mode
+            expect(onCloseMock).toHaveBeenCalled();
         });
 
-        test("Modal shows exit animation when closing via escape key", async () => {
+        test("Modal notifies parent when closing via escape key", async () => {
             // Arrange
             const onCloseMock = jest.fn();
             render(
@@ -530,7 +508,6 @@ describe("DrawerLauncher", () => {
                             content={<div data-testid="modal-content" />}
                         />
                     }
-                    opened={true}
                     onClose={onCloseMock}
                 />,
             );
@@ -538,15 +515,8 @@ describe("DrawerLauncher", () => {
             // Act
             await userEvent.keyboard("{Escape}");
 
-            // Assert
-            expect(onCloseMock).not.toHaveBeenCalled();
-            // Wait for animation
-            await waitFor(
-                () => {
-                    expect(onCloseMock).toHaveBeenCalled();
-                },
-                {timeout: 200}, // A bit longer than animation duration
-            );
+            // Assert - onClose is called immediately in controlled mode
+            expect(onCloseMock).toHaveBeenCalled();
         });
 
         test("Uncontrolled modal is removed from DOM after closing", async () => {
@@ -617,22 +587,25 @@ describe("DrawerLauncher", () => {
             await expect(document.body).not.toHaveStyle("overflow: hidden");
         });
 
-        test("Controlled modal is removed from DOM after closing", async () => {
+        test("Controlled modal is removed from DOM after closing without animation", async () => {
             // Arrange
             const TestComponent = () => {
-                const [opened, setOpened] = React.useState(true);
+                const [isOpen, setIsOpen] = React.useState(true);
                 return (
                     <DrawerLauncher
                         alignment="inlineEnd"
                         animated={false}
                         modal={
-                            <FlexibleDialog
-                                title="Animation test"
-                                content={<div data-testid="modal-content" />}
-                            />
+                            isOpen ? (
+                                <FlexibleDialog
+                                    title="Animation test"
+                                    content={
+                                        <div data-testid="modal-content" />
+                                    }
+                                />
+                            ) : null
                         }
-                        opened={opened}
-                        onClose={() => setOpened(false)}
+                        onClose={() => setIsOpen(false)}
                     />
                 );
             };
@@ -649,22 +622,25 @@ describe("DrawerLauncher", () => {
             expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
         });
 
-        test("Scroll is re-enabled after closing controlled modal", async () => {
+        test("Scroll is re-enabled after closing controlled modal without animation", async () => {
             // Arrange
             const TestComponent = () => {
-                const [opened, setOpened] = React.useState(true);
+                const [isOpen, setIsOpen] = React.useState(true);
                 return (
                     <DrawerLauncher
                         alignment="inlineEnd"
                         animated={false}
                         modal={
-                            <FlexibleDialog
-                                title="Animation test"
-                                content={<div data-testid="modal-content" />}
-                            />
+                            isOpen ? (
+                                <FlexibleDialog
+                                    title="Animation test"
+                                    content={
+                                        <div data-testid="modal-content" />
+                                    }
+                                />
+                            ) : null
                         }
-                        opened={opened}
-                        onClose={() => setOpened(false)}
+                        onClose={() => setIsOpen(false)}
                     />
                 );
             };
@@ -687,20 +663,23 @@ describe("DrawerLauncher", () => {
         test("Controlled modal is removed from DOM after animation", async () => {
             // Arrange
             const TestComponent = () => {
-                const [opened, setOpened] = React.useState(true);
+                const [isOpen, setIsOpen] = React.useState(true);
                 return (
                     <DrawerLauncher
                         alignment="inlineEnd"
                         animated={true}
                         timingDuration={100} // Short duration for test
                         modal={
-                            <FlexibleDialog
-                                title="Animation test"
-                                content={<div data-testid="modal-content" />}
-                            />
+                            isOpen ? (
+                                <FlexibleDialog
+                                    title="Animation test"
+                                    content={
+                                        <div data-testid="modal-content" />
+                                    }
+                                />
+                            ) : null
                         }
-                        opened={opened}
-                        onClose={() => setOpened(false)}
+                        onClose={() => setIsOpen(false)}
                     />
                 );
             };
@@ -727,20 +706,23 @@ describe("DrawerLauncher", () => {
         test("Scroll is re-enabled after animated close of controlled modal", async () => {
             // Arrange
             const TestComponent = () => {
-                const [opened, setOpened] = React.useState(true);
+                const [isOpen, setIsOpen] = React.useState(true);
                 return (
                     <DrawerLauncher
                         alignment="inlineEnd"
                         animated={true}
                         timingDuration={100} // Short duration for test
                         modal={
-                            <FlexibleDialog
-                                title="Animation test"
-                                content={<div data-testid="modal-content" />}
-                            />
+                            isOpen ? (
+                                <FlexibleDialog
+                                    title="Animation test"
+                                    content={
+                                        <div data-testid="modal-content" />
+                                    }
+                                />
+                            ) : null
                         }
-                        opened={opened}
-                        onClose={() => setOpened(false)}
+                        onClose={() => setIsOpen(false)}
                     />
                 );
             };

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.tsx
@@ -43,27 +43,26 @@ describe("ModalLauncher", () => {
         expect(portal).toBeInTheDocument();
     });
 
-    test("Modal can be manually opened and closed", async () => {
+    test("Modal can be manually opened and closed via modal prop", async () => {
         // Arrange
-        const UnderTest = ({opened}: {opened: boolean}) => (
+        const UnderTest = ({isOpen}: {isOpen: boolean}) => (
             <ModalLauncher
-                modal={exampleModal}
-                opened={opened}
+                modal={isOpen ? exampleModal : null}
                 onClose={() => {}}
                 testId="modal-launcher-portal"
             />
         );
-        const {rerender} = render(<UnderTest opened={false} />);
+        const {rerender} = render(<UnderTest isOpen={false} />);
 
         // Act
         expect(
             screen.queryByTestId("modal-launcher-portal"),
         ).not.toBeInTheDocument();
-        rerender(<UnderTest opened={true} />);
+        rerender(<UnderTest isOpen={true} />);
         expect(
             await screen.findByTestId("modal-launcher-portal"),
         ).toBeInTheDocument();
-        rerender(<UnderTest opened={false} />);
+        rerender(<UnderTest isOpen={false} />);
         expect(
             screen.queryByTestId("modal-launcher-portal"),
         ).not.toBeInTheDocument();
@@ -176,43 +175,7 @@ describe("ModalLauncher", () => {
         expect(document.body).not.toHaveStyle("overflow: hidden");
     });
 
-    test("using `opened` and `children` should warn", async () => {
-        // Arrange
-        jest.spyOn(console, "warn").mockImplementation(() => {});
-
-        // Act
-        render(
-            <ModalLauncher
-                modal={exampleModal}
-                opened={false}
-                onClose={() => {}}
-            >
-                {({openModal}: any) => <button onClick={openModal} />}
-            </ModalLauncher>,
-        );
-
-        // Assert
-        // eslint-disable-next-line no-console
-        expect(console.warn).toHaveBeenCalledWith(
-            "'children' and 'opened' can't be used together",
-        );
-    });
-
-    test("using `opened` without `onClose` should throw", async () => {
-        // Arrange
-        jest.spyOn(console, "warn").mockImplementation(() => {});
-
-        // Act
-        render(<ModalLauncher modal={exampleModal} opened={false} />);
-
-        // Assert
-        // eslint-disable-next-line no-console
-        expect(console.warn).toHaveBeenCalledWith(
-            "'onClose' should be used with 'opened'",
-        );
-    });
-
-    test("using neither `opened` nor `children` should throw", async () => {
+    test("using controlled mode (no children) without 'onClose' should warn", async () => {
         // Arrange
         jest.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -222,20 +185,19 @@ describe("ModalLauncher", () => {
         // Assert
         // eslint-disable-next-line no-console
         expect(console.warn).toHaveBeenCalledWith(
-            "either 'children' or 'opened' must be set",
+            "'onClose' should be provided when using ModalLauncher in controlled mode (without children)",
         );
     });
 
     test("Clicking outside the modal dialog closes it by default", async () => {
         // Arrange
         const ModalLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(true);
+            const [isOpen, setIsOpen] = React.useState(true);
 
             return (
                 <ModalLauncher
-                    modal={exampleModal}
-                    opened={opened}
-                    onClose={() => setOpened(false)}
+                    modal={isOpen ? exampleModal : null}
+                    onClose={() => setIsOpen(false)}
                     testId="modal-launcher-backdrop"
                 />
             );
@@ -262,13 +224,12 @@ describe("ModalLauncher", () => {
     test("Clicking outside the modal dialog closes it when backdropDismissEnabled is true", async () => {
         // Arrange
         const ModalLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(true);
+            const [isOpen, setIsOpen] = React.useState(true);
 
             return (
                 <ModalLauncher
-                    modal={exampleModal}
-                    opened={opened}
-                    onClose={() => setOpened(false)}
+                    modal={isOpen ? exampleModal : null}
+                    onClose={() => setIsOpen(false)}
                     backdropDismissEnabled={true}
                     testId="modal-launcher-backdrop"
                 />
@@ -295,13 +256,12 @@ describe("ModalLauncher", () => {
     test("If backdropDismissEnabled set to false, clicking outside the modal does not close it", async () => {
         // Arrange
         const ModalLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(true);
+            const [isOpen, setIsOpen] = React.useState(true);
 
             return (
                 <ModalLauncher
-                    modal={exampleModal}
-                    opened={opened}
-                    onClose={() => setOpened(false)}
+                    modal={isOpen ? exampleModal : null}
+                    onClose={() => setIsOpen(false)}
                     backdropDismissEnabled={false}
                     testId="modal-launcher-backdrop"
                 />
@@ -357,13 +317,12 @@ describe("ModalLauncher", () => {
     test("Clicking modal content does not close the modal", async () => {
         // Arrange
         const ModalLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(true);
+            const [isOpen, setIsOpen] = React.useState(true);
 
             return (
                 <ModalLauncher
-                    modal={exampleModal}
-                    opened={opened}
-                    onClose={() => setOpened(false)}
+                    modal={isOpen ? exampleModal : null}
+                    onClose={() => setIsOpen(false)}
                     testId="modal-launcher-backdrop"
                 />
             );
@@ -422,15 +381,7 @@ describe("ModalLauncher", () => {
     test("if modal is closed, return focus to the last element focused outside the modal", async () => {
         // Arrange
         const ModalLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(false);
-
-            const handleOpen = () => {
-                setOpened(true);
-            };
-
-            const handleClose = () => {
-                setOpened(false);
-            };
+            const [isOpen, setIsOpen] = React.useState(false);
 
             return (
                 <MemoryRouter>
@@ -441,27 +392,32 @@ describe("ModalLauncher", () => {
                             </Button>
                             <Button
                                 testId="launcher-button"
-                                onClick={() => handleOpen()}
+                                onClick={() => setIsOpen(true)}
                             >
                                 Open modal
                             </Button>
                             <ModalLauncher
-                                onClose={() => handleClose()}
-                                opened={opened}
-                                modal={({closeModal}: any) => (
-                                    <OnePaneDialog
-                                        title="Regular modal"
-                                        content={<View>Hello World</View>}
-                                        footer={
-                                            <Button
-                                                testId="modal-close-button"
-                                                onClick={closeModal}
-                                            >
-                                                Close Modal
-                                            </Button>
-                                        }
-                                    />
-                                )}
+                                onClose={() => setIsOpen(false)}
+                                modal={
+                                    isOpen
+                                        ? ({closeModal}: any) => (
+                                              <OnePaneDialog
+                                                  title="Regular modal"
+                                                  content={
+                                                      <View>Hello World</View>
+                                                  }
+                                                  footer={
+                                                      <Button
+                                                          testId="modal-close-button"
+                                                          onClick={closeModal}
+                                                      >
+                                                          Close Modal
+                                                      </Button>
+                                                  }
+                                              />
+                                          )
+                                        : null
+                                }
                             />
                         </View>
                     </CompatRouter>
@@ -488,14 +444,10 @@ describe("ModalLauncher", () => {
         });
     });
 
-    test("if modal with opened=true is closed, return focus to the last element focused outside the modal", async () => {
+    test("if modal with controlled open state is closed, return focus to the last element focused outside the modal", async () => {
         // Arrange
         const ModalLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(false);
-
-            const handleClose = () => {
-                setOpened(false);
-            };
+            const [isOpen, setIsOpen] = React.useState(false);
 
             return (
                 <MemoryRouter>
@@ -506,27 +458,32 @@ describe("ModalLauncher", () => {
                             </Button>
                             <Button
                                 testId="launcher-button"
-                                onClick={() => setOpened(true)}
+                                onClick={() => setIsOpen(true)}
                             >
                                 Open modal
                             </Button>
                             <ModalLauncher
-                                onClose={() => handleClose()}
-                                opened={opened}
-                                modal={({closeModal}: any) => (
-                                    <OnePaneDialog
-                                        title="Regular modal"
-                                        content={<View>Hello World</View>}
-                                        footer={
-                                            <Button
-                                                testId="modal-close-button"
-                                                onClick={closeModal}
-                                            >
-                                                Close Modal
-                                            </Button>
-                                        }
-                                    />
-                                )}
+                                onClose={() => setIsOpen(false)}
+                                modal={
+                                    isOpen
+                                        ? ({closeModal}: any) => (
+                                              <OnePaneDialog
+                                                  title="Regular modal"
+                                                  content={
+                                                      <View>Hello World</View>
+                                                  }
+                                                  footer={
+                                                      <Button
+                                                          testId="modal-close-button"
+                                                          onClick={closeModal}
+                                                      >
+                                                          Close Modal
+                                                      </Button>
+                                                  }
+                                              />
+                                          )
+                                        : null
+                                }
                             />
                         </View>
                     </CompatRouter>
@@ -554,15 +511,7 @@ describe("ModalLauncher", () => {
     test("if `closedFocusId` is passed, shift focus to specified element after the modal closes", async () => {
         // Arrange
         const ModalLauncherWrapper = () => {
-            const [opened, setOpened] = React.useState(false);
-
-            const handleOpen = () => {
-                setOpened(true);
-            };
-
-            const handleClose = () => {
-                setOpened(false);
-            };
+            const [isOpen, setIsOpen] = React.useState(false);
 
             return (
                 <View>
@@ -572,28 +521,31 @@ describe("ModalLauncher", () => {
                     </Button>
                     <Button
                         testId="launcher-button"
-                        onClick={() => handleOpen()}
+                        onClick={() => setIsOpen(true)}
                     >
                         Open modal
                     </Button>
                     <ModalLauncher
-                        onClose={() => handleClose()}
-                        opened={opened}
+                        onClose={() => setIsOpen(false)}
                         closedFocusId="button-to-focus-on"
-                        modal={({closeModal}: any) => (
-                            <OnePaneDialog
-                                title="Triggered from action menu"
-                                content={<View>Hello World</View>}
-                                footer={
-                                    <Button
-                                        testId="modal-close-button"
-                                        onClick={closeModal}
-                                    >
-                                        Close Modal
-                                    </Button>
-                                }
-                            />
-                        )}
+                        modal={
+                            isOpen
+                                ? ({closeModal}: any) => (
+                                      <OnePaneDialog
+                                          title="Triggered from action menu"
+                                          content={<View>Hello World</View>}
+                                          footer={
+                                              <Button
+                                                  testId="modal-close-button"
+                                                  onClick={closeModal}
+                                              >
+                                                  Close Modal
+                                              </Button>
+                                          }
+                                      />
+                                  )
+                                : null
+                        }
                     />
                 </View>
             );
@@ -622,7 +574,6 @@ describe("ModalLauncher", () => {
         // Arrange
         render(
             <ModalLauncher
-                opened={true}
                 onClose={jest.fn()}
                 modal={<div role="dialog">dialog</div>}
                 testId="test-id-example"
@@ -639,37 +590,36 @@ describe("ModalLauncher", () => {
     test("should handle focus correctly when opened programmatically through a wrapper component", async () => {
         // Arrange
         const WrappedModalLauncher = () => {
-            const [opened, setOpened] = React.useState(false);
-
-            const handleClose = () => {
-                setOpened(false);
-            };
+            const [isOpen, setIsOpen] = React.useState(false);
 
             return (
                 <View>
                     <Button
                         testId="focused-button"
-                        onClick={() => setOpened(true)}
+                        onClick={() => setIsOpen(true)}
                     >
                         Button that should receive focus
                     </Button>
                     <ModalLauncher
-                        onClose={handleClose}
-                        opened={opened}
-                        modal={({closeModal}) => (
-                            <OnePaneDialog
-                                title="Modal"
-                                content={<View>Content</View>}
-                                footer={
-                                    <Button
-                                        testId="modal-close-button"
-                                        onClick={closeModal}
-                                    >
-                                        Close Modal
-                                    </Button>
-                                }
-                            />
-                        )}
+                        onClose={() => setIsOpen(false)}
+                        modal={
+                            isOpen
+                                ? ({closeModal}) => (
+                                      <OnePaneDialog
+                                          title="Modal"
+                                          content={<View>Content</View>}
+                                          footer={
+                                              <Button
+                                                  testId="modal-close-button"
+                                                  onClick={closeModal}
+                                              >
+                                                  Close Modal
+                                              </Button>
+                                          }
+                                      />
+                                  )
+                                : null
+                        }
                     />
                 </View>
             );
@@ -799,7 +749,6 @@ describe("ModalLauncher", () => {
                         );
                     })}
                     <ModalLauncher
-                        opened={!!selectedItem}
                         onClose={handleCloseModal}
                         closedFocusId={modalTriggerId || undefined}
                         modal={conditionalModal}

--- a/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/modal-launcher.test.tsx
@@ -37,13 +37,29 @@ describe("ModalLauncher", () => {
         // Act
         await userEvent.click(await screen.findByRole("button"));
 
-        const portal = await screen.findByTestId("modal-launcher-portal");
-
         // Assert
-        expect(portal).toBeInTheDocument();
+        expect(
+            await screen.findByTestId("modal-launcher-portal"),
+        ).toBeInTheDocument();
     });
 
-    test("Modal can be manually opened and closed via modal prop", async () => {
+    test("starts closed when modal prop is null", () => {
+        // Arrange
+        render(
+            <ModalLauncher
+                modal={null}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.queryByTestId("modal-launcher-portal"),
+        ).not.toBeInTheDocument();
+    });
+
+    test("shows portal when modal prop becomes non-null", async () => {
         // Arrange
         const UnderTest = ({isOpen}: {isOpen: boolean}) => (
             <ModalLauncher
@@ -55,14 +71,30 @@ describe("ModalLauncher", () => {
         const {rerender} = render(<UnderTest isOpen={false} />);
 
         // Act
-        expect(
-            screen.queryByTestId("modal-launcher-portal"),
-        ).not.toBeInTheDocument();
         rerender(<UnderTest isOpen={true} />);
+
+        // Assert
         expect(
             await screen.findByTestId("modal-launcher-portal"),
         ).toBeInTheDocument();
+    });
+
+    test("hides portal when modal prop returns to null", async () => {
+        // Arrange
+        const UnderTest = ({isOpen}: {isOpen: boolean}) => (
+            <ModalLauncher
+                modal={isOpen ? exampleModal : null}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />
+        );
+        const {rerender} = render(<UnderTest isOpen={true} />);
+        await screen.findByTestId("modal-launcher-portal");
+
+        // Act
         rerender(<UnderTest isOpen={false} />);
+
+        // Assert
         expect(
             screen.queryByTestId("modal-launcher-portal"),
         ).not.toBeInTheDocument();
@@ -80,11 +112,7 @@ describe("ModalLauncher", () => {
                 }
             />
         );
-
         const onCloseMock = jest.fn();
-
-        // Mount the modal launcher. This shouldn't trigger any closing yet,
-        // because we shouldn't be calling the `modal` function yet.
         render(
             <ModalLauncher
                 modal={modalFn}
@@ -94,10 +122,7 @@ describe("ModalLauncher", () => {
                 {({openModal}: any) => <button onClick={openModal} />}
             </ModalLauncher>,
         );
-
         await userEvent.click(await screen.findByRole("button"));
-
-        // wait until the modal is open
         await screen.findByRole("dialog");
 
         // Act
@@ -116,20 +141,16 @@ describe("ModalLauncher", () => {
                 {({openModal}: any) => <button onClick={openModal} />}
             </ModalLauncher>,
         );
-
-        // Launch the modal.
         await userEvent.click(await screen.findByRole("button"));
-
-        // wait until the modal is open
         await screen.findByRole("dialog");
 
         // Act
-        // Simulate an Escape keypress.
         await userEvent.keyboard("{Escape}");
 
         // Assert
-        // Confirm that the modal is no longer mounted.
-        await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+        await waitFor(() =>
+            expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+        );
     });
 
     test("Disable scrolling when the modal is open", async () => {
@@ -141,14 +162,10 @@ describe("ModalLauncher", () => {
         );
 
         // Act
-        // Launch the modal.
         await userEvent.click(await screen.findByRole("button"));
-
-        // wait until the modal is open
         await screen.findByRole("dialog");
 
         // Assert
-        // Now that the modal is open, there should be a ScrollDisabler.
         expect(document.body).toHaveStyle("overflow: hidden");
     });
 
@@ -159,34 +176,117 @@ describe("ModalLauncher", () => {
                 {({openModal}: any) => <button onClick={openModal} />}
             </ModalLauncher>,
         );
-
-        // Launch the modal.
         await userEvent.click(await screen.findByRole("button"));
-
         await screen.findByRole("dialog");
 
-        // Close the modal.
+        // Act
         await userEvent.click(
             await screen.findByRole("button", {name: "Close modal"}),
         );
 
         // Assert
-        // Now that the modal is closed, there should be no ScrollDisabler.
         expect(document.body).not.toHaveStyle("overflow: hidden");
     });
 
-    test("using controlled mode (no children) without 'onClose' should warn", async () => {
+    test("using controlled mode (no children) without 'onClose' should warn", () => {
         // Arrange
-        jest.spyOn(console, "warn").mockImplementation(() => {});
+        const warnSpy = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {});
 
         // Act
         render(<ModalLauncher modal={exampleModal} />);
 
         // Assert
-        // eslint-disable-next-line no-console
-        expect(console.warn).toHaveBeenCalledWith(
+        expect(warnSpy).toHaveBeenCalledWith(
             "'onClose' should be provided when using ModalLauncher in controlled mode (without children)",
         );
+    });
+
+    test("using deprecated `opened` prop logs a deprecation warning", () => {
+        // Arrange
+        const warnSpy = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {});
+
+        // Act
+        render(
+            <ModalLauncher
+                modal={exampleModal}
+                opened={false}
+                onClose={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining("`opened` prop is deprecated"),
+        );
+    });
+
+    test("deprecated `opened` prop: starts closed when false", () => {
+        // Arrange
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+
+        // Act
+        render(
+            <ModalLauncher
+                modal={exampleModal}
+                opened={false}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.queryByTestId("modal-launcher-portal"),
+        ).not.toBeInTheDocument();
+    });
+
+    test("deprecated `opened` prop: shows portal when opened becomes true", async () => {
+        // Arrange
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        const UnderTest = ({isOpen}: {isOpen: boolean}) => (
+            <ModalLauncher
+                modal={exampleModal}
+                opened={isOpen}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />
+        );
+        const {rerender} = render(<UnderTest isOpen={false} />);
+
+        // Act
+        rerender(<UnderTest isOpen={true} />);
+
+        // Assert
+        expect(
+            await screen.findByTestId("modal-launcher-portal"),
+        ).toBeInTheDocument();
+    });
+
+    test("deprecated `opened` prop: hides portal when opened becomes false", async () => {
+        // Arrange
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        const UnderTest = ({isOpen}: {isOpen: boolean}) => (
+            <ModalLauncher
+                modal={exampleModal}
+                opened={isOpen}
+                onClose={() => {}}
+                testId="modal-launcher-portal"
+            />
+        );
+        const {rerender} = render(<UnderTest isOpen={true} />);
+        await screen.findByTestId("modal-launcher-portal");
+
+        // Act
+        rerender(<UnderTest isOpen={false} />);
+
+        // Assert
+        expect(
+            screen.queryByTestId("modal-launcher-portal"),
+        ).not.toBeInTheDocument();
     });
 
     test("Clicking outside the modal dialog closes it by default", async () => {
@@ -202,23 +302,19 @@ describe("ModalLauncher", () => {
                 />
             );
         };
-
         render(<ModalLauncherWrapper />);
-
         await screen.findByRole("dialog");
         const backdrop = await screen.findByTestId("modal-launcher-backdrop");
 
         // Act
-        // Click at top-left corner of the backdrop (outside the modal dialog)
-        // This simulates a real user clicking outside the dialog
         await userEvent.pointer([
             {target: backdrop, coords: {clientX: 10, clientY: 10}},
             {keys: "[MouseLeft>]", target: backdrop},
             {keys: "[/MouseLeft]", target: backdrop},
         ]);
 
-        // Assert - modal should be removed from DOM
-        await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        // Assert
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
     test("Clicking outside the modal dialog closes it when backdropDismissEnabled is true", async () => {
@@ -235,22 +331,18 @@ describe("ModalLauncher", () => {
                 />
             );
         };
-
         render(<ModalLauncherWrapper />);
-
         const backdrop = screen.getByTestId("modal-launcher-backdrop");
 
         // Act
-        // Click at top-left corner of the backdrop (outside the modal dialog)
-        // This simulates a real user clicking outside the dialog
         await userEvent.pointer([
             {target: backdrop, coords: {clientX: 10, clientY: 10}},
             {keys: "[MouseLeft>]", target: backdrop},
             {keys: "[/MouseLeft]", target: backdrop},
         ]);
 
-        // Assert - modal should be removed from DOM
-        await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        // Assert
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
     test("If backdropDismissEnabled set to false, clicking outside the modal does not close it", async () => {
@@ -267,21 +359,17 @@ describe("ModalLauncher", () => {
                 />
             );
         };
-
         render(<ModalLauncherWrapper />);
-
         const backdrop = screen.getByTestId("modal-launcher-backdrop");
 
         // Act
-        // Click at top-left corner of the backdrop (outside the modal dialog)
-        // This simulates a real user clicking outside the dialog
         await userEvent.pointer([
             {target: backdrop, coords: {clientX: 10, clientY: 10}},
             {keys: "[MouseLeft>]", target: backdrop},
             {keys: "[/MouseLeft]", target: backdrop},
         ]);
 
-        // Assert - modal should still be in DOM
+        // Assert
         expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
@@ -295,23 +383,18 @@ describe("ModalLauncher", () => {
                 {({openModal}: any) => <button onClick={openModal} />}
             </ModalLauncher>,
         );
-
-        // Open the modal
         await userEvent.click(screen.getByRole("button"));
-
         const backdrop = screen.getByTestId("modal-launcher-backdrop");
 
         // Act
-        // Click at top-left corner of the backdrop (outside the modal dialog)
-        // This simulates a real user clicking outside the dialog
         await userEvent.pointer([
             {target: backdrop, coords: {clientX: 10, clientY: 10}},
             {keys: "[MouseLeft>]", target: backdrop},
             {keys: "[/MouseLeft]", target: backdrop},
         ]);
 
-        // Assert - modal should be removed from DOM
-        await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        // Assert
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
     test("Clicking modal content does not close the modal", async () => {
@@ -327,15 +410,12 @@ describe("ModalLauncher", () => {
                 />
             );
         };
-
         render(<ModalLauncherWrapper />);
 
-        const dialog = screen.getByRole("dialog");
-
         // Act
-        await userEvent.click(dialog);
+        await userEvent.click(screen.getByRole("dialog"));
 
-        // Assert - modal should still be in DOM
+        // Assert
         expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
@@ -359,21 +439,16 @@ describe("ModalLauncher", () => {
                 )}
             </ModalLauncher>,
         );
-
-        // focus on the open modal button
         await userEvent.tab();
 
         // Act
-        // Launch the modal.
         await userEvent.keyboard("{enter}");
-
-        // wait until the modal is open
         await screen.findByRole("dialog");
 
         // Assert
-        await waitFor(async () =>
+        await waitFor(() =>
             expect(
-                await screen.findByRole("button", {name: "Close modal"}),
+                screen.getByRole("button", {name: "Close modal"}),
             ).toHaveFocus(),
         );
     });
@@ -424,24 +499,16 @@ describe("ModalLauncher", () => {
                 </MemoryRouter>
             );
         };
-
         render(<ModalLauncherWrapper />);
-
         const lastButton = await screen.findByTestId("launcher-button");
-
-        // Launch the modal.
         await userEvent.click(lastButton);
+        await screen.findByRole("dialog");
 
         // Act
-        // Close modal
-        const modalCloseButton =
-            await screen.findByTestId("modal-close-button");
-        await userEvent.click(modalCloseButton);
+        await userEvent.click(await screen.findByTestId("modal-close-button"));
 
         // Assert
-        await waitFor(() => {
-            expect(lastButton).toHaveFocus();
-        });
+        await waitFor(() => expect(lastButton).toHaveFocus());
     });
 
     test("if modal with controlled open state is closed, return focus to the last element focused outside the modal", async () => {
@@ -490,22 +557,16 @@ describe("ModalLauncher", () => {
                 </MemoryRouter>
             );
         };
-
         render(<ModalLauncherWrapper />);
-
         const lastButton = await screen.findByTestId("launcher-button");
         await userEvent.click(lastButton);
+        await screen.findByRole("dialog");
 
         // Act
-        // Close modal
-        const modalCloseButton =
-            await screen.findByTestId("modal-close-button");
-        await userEvent.click(modalCloseButton);
+        await userEvent.click(await screen.findByTestId("modal-close-button"));
 
         // Assert
-        await waitFor(() => {
-            expect(lastButton).toHaveFocus();
-        });
+        await waitFor(() => expect(lastButton).toHaveFocus());
     });
 
     test("if `closedFocusId` is passed, shift focus to specified element after the modal closes", async () => {
@@ -550,24 +611,17 @@ describe("ModalLauncher", () => {
                 </View>
             );
         };
-
         render(<ModalLauncherWrapper />);
-
-        // Launch modal
-        const launcherButton = await screen.findByTestId("launcher-button");
-        await userEvent.click(launcherButton);
+        await userEvent.click(await screen.findByTestId("launcher-button"));
+        await screen.findByRole("dialog");
 
         // Act
-        // Close modal
-        const modalCloseButton =
-            await screen.findByTestId("modal-close-button");
-        await userEvent.click(modalCloseButton);
+        await userEvent.click(await screen.findByTestId("modal-close-button"));
 
         // Assert
-        const focusedButton = await screen.findByTestId("focused-button");
-        await waitFor(() => {
-            expect(focusedButton).toHaveFocus();
-        });
+        await waitFor(() =>
+            expect(screen.getByTestId("focused-button")).toHaveFocus(),
+        );
     });
 
     test("testId should be added to the Backdrop", async () => {
@@ -580,11 +634,10 @@ describe("ModalLauncher", () => {
             />,
         );
 
-        // Act
-        const backdrop = await screen.findByTestId("test-id-example");
-
         // Assert
-        expect(backdrop).toBeInTheDocument();
+        expect(
+            await screen.findByTestId("test-id-example"),
+        ).toBeInTheDocument();
     });
 
     test("should handle focus correctly when opened programmatically through a wrapper component", async () => {
@@ -624,23 +677,16 @@ describe("ModalLauncher", () => {
                 </View>
             );
         };
-
         render(<WrappedModalLauncher />);
-
-        // Focus the button before the modal opens
         const buttonToFocus = await screen.findByTestId("focused-button");
-        await userEvent.click(buttonToFocus); // Move focus to the button
+        await userEvent.click(buttonToFocus);
+        await screen.findByRole("dialog");
 
         // Act
-        // Close modal
-        const modalCloseButton =
-            await screen.findByTestId("modal-close-button");
-        await userEvent.click(modalCloseButton);
+        await userEvent.click(await screen.findByTestId("modal-close-button"));
 
         // Assert
-        await waitFor(() => {
-            expect(buttonToFocus).toHaveFocus();
-        });
+        await waitFor(() => expect(buttonToFocus).toHaveFocus());
     });
 
     describe("Conditional modal content pattern", () => {
@@ -656,7 +702,6 @@ describe("ModalLauncher", () => {
             {id: "3", name: "Charlie Brown", progress: 95},
         ];
 
-        // Shared component for all tests
         const ConditionalModalContainer = () => {
             const [selectedItem, setSelectedItem] = React.useState<{
                 type: "content" | "mastery";
@@ -757,8 +802,7 @@ describe("ModalLauncher", () => {
             );
         };
 
-        // Parameterized tests for opening modals
-        [
+        it.each([
             {
                 name: "opens content modal when clicking content button",
                 triggerId: "content-modal-trigger-1",
@@ -769,24 +813,18 @@ describe("ModalLauncher", () => {
                 triggerId: "mastery-modal-trigger-2",
                 expectedTitle: "Mastery: Bob Johnson",
             },
-        ].forEach(({name, triggerId, expectedTitle}) => {
-            test(name, async () => {
-                // Arrange
-                render(<ConditionalModalContainer />);
+        ])("$name", async ({triggerId, expectedTitle}) => {
+            // Arrange
+            render(<ConditionalModalContainer />);
 
-                // Act
-                const button = await screen.findByTestId(triggerId);
-                await userEvent.click(button);
+            // Act
+            await userEvent.click(await screen.findByTestId(triggerId));
 
-                // Assert
-                expect(
-                    await screen.findByText(expectedTitle),
-                ).toBeInTheDocument();
-            });
+            // Assert
+            expect(await screen.findByText(expectedTitle)).toBeInTheDocument();
         });
 
-        // Parameterized tests for focus management
-        [
+        it.each([
             {
                 name: "returns focus to correct button after closing content modal",
                 triggerId: "content-modal-trigger-1",
@@ -795,30 +833,29 @@ describe("ModalLauncher", () => {
                 name: "returns focus to correct button after closing mastery modal from different row",
                 triggerId: "mastery-modal-trigger-3",
             },
-        ].forEach(({name, triggerId}) => {
-            test(name, async () => {
-                // Arrange
-                render(<ConditionalModalContainer />);
-                const button = await screen.findByTestId(triggerId);
+        ])("$name", async ({triggerId}) => {
+            // Arrange
+            render(<ConditionalModalContainer />);
+            const button = await screen.findByTestId(triggerId);
+            await userEvent.click(button);
+            await screen.findByRole("dialog");
 
-                // Act
-                await userEvent.click(button);
-                await userEvent.click(
-                    await screen.findByRole("button", {name: "Close modal"}),
-                );
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Close modal"}),
+            );
 
-                // Assert
-                await waitFor(() => expect(button).toHaveFocus());
-            });
+            // Assert
+            await waitFor(() => expect(button).toHaveFocus());
         });
 
         test("closes modal and removes it from DOM", async () => {
             // Arrange
             render(<ConditionalModalContainer />);
-            const contentButton = await screen.findByTestId(
-                "content-modal-trigger-1",
+            await userEvent.click(
+                await screen.findByTestId("content-modal-trigger-1"),
             );
-            await userEvent.click(contentButton);
+            await screen.findByRole("dialog");
 
             // Act
             await userEvent.click(
@@ -834,19 +871,17 @@ describe("ModalLauncher", () => {
         test("opens different modal type after closing previous modal", async () => {
             // Arrange
             render(<ConditionalModalContainer />);
-            const contentButton = await screen.findByTestId(
-                "content-modal-trigger-1",
+            await userEvent.click(
+                await screen.findByTestId("content-modal-trigger-1"),
             );
-            await userEvent.click(contentButton);
             await userEvent.click(
                 await screen.findByRole("button", {name: "Close modal"}),
             );
 
             // Act
-            const masteryButton = await screen.findByTestId(
-                "mastery-modal-trigger-2",
+            await userEvent.click(
+                await screen.findByTestId("mastery-modal-trigger-2"),
             );
-            await userEvent.click(masteryButton);
 
             // Assert
             expect(
@@ -861,6 +896,7 @@ describe("ModalLauncher", () => {
                 "mastery-modal-trigger-2",
             );
             await userEvent.click(masteryButton2);
+            await screen.findByRole("dialog");
 
             // Act
             await userEvent.click(

--- a/packages/wonder-blocks-modal/src/components/drawer-launcher.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-launcher.tsx
@@ -140,6 +140,15 @@ type Props = Readonly<{
      * function) to open.
      */
     children?: (arg1: {openModal: () => unknown}) => React.ReactNode;
+    /**
+     * @deprecated Use `modal={isOpen ? ... : null}` instead and keep the
+     * launcher always mounted. Passing `opened` will be removed in a future
+     * major version.
+     *
+     * Controls whether the drawer is visible. When provided, `onClose` must
+     * also be supplied.
+     */
+    opened?: boolean;
 }> &
     WithActionSchedulerProps;
 
@@ -157,6 +166,8 @@ const DrawerLauncher = (props: Props) => {
         testId,
         onClose,
         children,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        opened: deprecatedOpened,
         schedule,
         alignment,
         styles,
@@ -174,8 +185,20 @@ const DrawerLauncher = (props: Props) => {
         null,
     );
 
-    // In controlled mode (no children), open state is derived from the modal prop.
+    // In controlled mode (no children), open state is derived from the modal
+    // prop (or the deprecated `opened` prop when provided as a shim).
     const isControlled = !children;
+
+    React.useEffect(() => {
+        if (deprecatedOpened !== undefined) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                "DrawerLauncher: the `opened` prop is deprecated. " +
+                    "Keep the launcher always mounted and use " +
+                    "`modal={isOpen ? ... : null}` instead.",
+            );
+        }
+    }, [deprecatedOpened]);
 
     // Preserve the last non-null modal so it can be displayed during exit animation.
     const lastNonNullModalRef = React.useRef<
@@ -190,8 +213,13 @@ const DrawerLauncher = (props: Props) => {
     const displayModal =
         modal ?? (isExiting ? lastNonNullModalRef.current : null);
 
+    // Resolve the open signal: deprecated `opened` takes priority as a shim,
+    // otherwise derive from whether modal is non-null.
+    const controlledOpenSignal =
+        deprecatedOpened !== undefined ? deprecatedOpened : modal != null;
+
     const opened = isControlled
-        ? modal != null || isExiting
+        ? controlledOpenSignal || isExiting
         : uncontrolledOpened;
 
     const saveLastElementFocused = React.useCallback(() => {
@@ -215,19 +243,17 @@ const DrawerLauncher = (props: Props) => {
         });
     }, [closedFocusId, schedule]);
 
-    // Track modal prop transitions to manage focus and exit animation in
-    // controlled mode.
-    const prevModalRef = React.useRef(modal);
+    // Track open/close transitions in controlled mode to capture/restore focus.
+    // Supports both the new (modal prop) and deprecated (opened prop) patterns.
+    const prevSignalRef = React.useRef(controlledOpenSignal);
     React.useEffect(() => {
         if (!isControlled) {
-            prevModalRef.current = modal;
+            prevSignalRef.current = controlledOpenSignal;
             return;
         }
-        const prevModal = prevModalRef.current;
-        prevModalRef.current = modal;
-
-        const wasOpen = prevModal != null;
-        const isNowOpen = modal != null;
+        const wasOpen = prevSignalRef.current;
+        const isNowOpen = controlledOpenSignal;
+        prevSignalRef.current = isNowOpen;
 
         if (!wasOpen && isNowOpen) {
             saveLastElementFocused();
@@ -238,7 +264,13 @@ const DrawerLauncher = (props: Props) => {
                 returnFocus();
             }
         }
-    }, [modal, isControlled, animated, saveLastElementFocused, returnFocus]);
+    }, [
+        controlledOpenSignal,
+        isControlled,
+        animated,
+        saveLastElementFocused,
+        returnFocus,
+    ]);
 
     // Handle exit animation completion in controlled mode.
     React.useEffect(() => {
@@ -269,9 +301,8 @@ const DrawerLauncher = (props: Props) => {
                 returnFocus();
             }
         } else {
-            // Controlled: notify parent so they can set modal=null.
-            // The modal transition effect handles exit animation and focus
-            // restoration once the parent updates modal to null.
+            // Controlled: notify parent so they can set modal=null (or opened=false).
+            // The transition effect handles exit animation and focus restoration.
             onClose?.();
         }
     }, [isControlled, onClose, returnFocus, animated, timingDuration]);

--- a/packages/wonder-blocks-modal/src/components/drawer-launcher.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-launcher.tsx
@@ -48,26 +48,29 @@ type DrawerModalFunction = (props: {
     styles?: DrawerDialogStyles;
 }) => DrawerModalElement;
 
-/**
- * Base props shared between controlled and uncontrolled modes
- */
-type BaseProps = Readonly<{
+type Props = Readonly<{
     /**
-     * The modal to render. Should be a DrawerDialog for proper drawer functionality.
+     * The modal to render, or `null` to indicate a closed state.
      *
-     * The modal will be rendered inside of a container whose parent is
-     * document.body. This allows us to use DrawerLauncher within menus and
-     * other components that clip their content. If the modal needs to close
-     * itself by some other means than tapping the backdrop or the default
-     * close button a render callback can be passed. The closeModal function
-     * provided to this callback can be called to close the modal.
+     * Pass a React element or render function to show the drawer. Pass `null`
+     * to keep the launcher mounted but in a closed state — this is the
+     * recommended pattern because it lets the launcher capture and restore
+     * keyboard focus across open/close transitions:
      *
-     * Note: Don't call `closeModal` while rendering! It should be used to
-     * respond to user interaction, like `onClick`.
+     * ```jsx
+     * <DrawerLauncher
+     *     modal={isOpen ? ({closeModal}) => <DrawerDialog .../> : null}
+     *     onClose={() => setIsOpen(false)}
+     *     alignment="inlineStart"
+     * />
+     * ```
      *
      * IMPORTANT: DrawerLauncher is designed specifically for DrawerDialog.
      * Using other modal types may result in incorrect animations, positioning,
      * and styling behavior.
+     *
+     * Note: Don't call `closeModal` while rendering! It should be used to
+     * respond to user interaction, like `onClick`.
      */
     modal: DrawerModalElement | DrawerModalFunction;
     /**
@@ -120,49 +123,25 @@ type BaseProps = Readonly<{
      * Test ID used for e2e testing. It's set on the DrawerBackdrop
      */
     testId?: string;
-}> &
-    WithActionSchedulerProps;
-
-/**
- * Controlled component mode: `opened` and `onClose` are required, `children` is forbidden
- */
-type ControlledProps = BaseProps & {
-    /**
-     * Renders the modal when true, renders nothing when false.
-     *
-     * Using this prop makes the component behave as a controlled component.
-     * The parent is responsible for managing the opening/closing of the modal
-     * when using this prop. `onClose` is required and `children` is forbidden.
-     */
-    opened: boolean;
     /**
      * Called when the modal needs to notify the parent component that it should
-     * be closed. Required when using `opened` prop (controlled mode).
-     */
-    onClose: () => unknown;
-    children?: never;
-};
-
-/**
- * Uncontrolled component mode: `children` is required, `opened` is forbidden
- */
-type UncontrolledProps = BaseProps & {
-    /**
-     * Render prop that provides `openModal` function to trigger the modal.
-     * Required when not using `opened` prop (uncontrolled mode).
-     */
-    children: (arg1: {openModal: () => unknown}) => React.ReactNode;
-    /**
-     * Optional callback when the modal is closed in uncontrolled mode.
+     * be closed. Required in controlled mode (no `children`) so that close
+     * events initiated from within the drawer propagate to the parent.
      */
     onClose?: () => unknown;
-    opened?: never;
-};
-
-/**
- * DrawerLauncher props - enforces proper controlled/uncontrolled usage at the type level
- */
-type Props = ControlledProps | UncontrolledProps;
+    /**
+     * Render prop that receives an `openModal` callback. When provided the
+     * component operates in **uncontrolled** mode: the launcher manages its
+     * own open/close state, and the `modal` prop always describes the dialog
+     * content (never `null`).
+     *
+     * When omitted the component operates in **controlled** mode: pass
+     * `modal={null}` to close and `modal={<DrawerDialog />}` (or a render
+     * function) to open.
+     */
+    children?: (arg1: {openModal: () => unknown}) => React.ReactNode;
+}> &
+    WithActionSchedulerProps;
 
 const defaultProps = {
     backdropDismissEnabled: DEFAULT_DRAWER_BACKDROP_DISMISS_ENABLED,
@@ -176,7 +155,6 @@ const DrawerLauncher = (props: Props) => {
         initialFocusId,
         closedFocusId,
         testId,
-        opened: controlledOpened,
         onClose,
         children,
         schedule,
@@ -186,7 +164,7 @@ const DrawerLauncher = (props: Props) => {
         timingDuration = defaultProps.defaultTimingDuration,
     } = props;
 
-    // State for uncontrolled mode
+    // Uncontrolled open state (used only when `children` is provided)
     const [uncontrolledOpened, setUncontrolledOpened] = React.useState(false);
     // State to track exit animation
     const [isExiting, setIsExiting] = React.useState(false);
@@ -196,26 +174,30 @@ const DrawerLauncher = (props: Props) => {
         null,
     );
 
-    // Determine if we're in controlled or uncontrolled mode
-    const opened =
-        typeof controlledOpened === "boolean"
-            ? controlledOpened
-            : uncontrolledOpened;
+    // In controlled mode (no children), open state is derived from the modal prop.
+    const isControlled = !children;
+
+    // Preserve the last non-null modal so it can be displayed during exit animation.
+    const lastNonNullModalRef = React.useRef<
+        DrawerModalElement | DrawerModalFunction
+    >(null as any);
+    if (modal != null) {
+        lastNonNullModalRef.current = modal;
+    }
+
+    // The modal to actually render: use the real value when open, or the
+    // cached value when playing the exit animation.
+    const displayModal =
+        modal ?? (isExiting ? lastNonNullModalRef.current : null);
+
+    const opened = isControlled
+        ? modal != null || isExiting
+        : uncontrolledOpened;
 
     const saveLastElementFocused = React.useCallback(() => {
         lastElementFocusedOutsideModalRef.current =
             document.activeElement as HTMLElement;
     }, []);
-
-    // Save last focused element when modal opens
-    React.useEffect(() => {
-        if (controlledOpened && !prevControlledOpened.current) {
-            saveLastElementFocused();
-        }
-        prevControlledOpened.current = controlledOpened;
-    }, [controlledOpened, saveLastElementFocused]);
-
-    const prevControlledOpened = React.useRef(controlledOpened);
 
     const returnFocus = React.useCallback(() => {
         // Focus on the specified element after closing the modal.
@@ -233,31 +215,66 @@ const DrawerLauncher = (props: Props) => {
         });
     }, [closedFocusId, schedule]);
 
+    // Track modal prop transitions to manage focus and exit animation in
+    // controlled mode.
+    const prevModalRef = React.useRef(modal);
+    React.useEffect(() => {
+        if (!isControlled) {
+            prevModalRef.current = modal;
+            return;
+        }
+        const prevModal = prevModalRef.current;
+        prevModalRef.current = modal;
+
+        const wasOpen = prevModal != null;
+        const isNowOpen = modal != null;
+
+        if (!wasOpen && isNowOpen) {
+            saveLastElementFocused();
+        } else if (wasOpen && !isNowOpen) {
+            if (animated) {
+                setIsExiting(true);
+            } else {
+                returnFocus();
+            }
+        }
+    }, [modal, isControlled, animated, saveLastElementFocused, returnFocus]);
+
+    // Handle exit animation completion in controlled mode.
+    React.useEffect(() => {
+        if (!isExiting || !isControlled) {
+            return;
+        }
+        const timer = setTimeout(() => {
+            setIsExiting(false);
+            returnFocus();
+        }, timingDuration);
+        return () => clearTimeout(timer);
+    }, [isExiting, isControlled, timingDuration, returnFocus]);
+
     const handleCloseModal = React.useCallback(() => {
-        if (animated) {
-            // If component is animated, allow time for exit animations
-            setIsExiting(true);
-            setTimeout(() => {
-                setIsExiting(false);
-                if (typeof controlledOpened === "boolean") {
-                    onClose?.();
-                } else {
+        if (!isControlled) {
+            if (animated) {
+                // Allow time for exit animations
+                setIsExiting(true);
+                setTimeout(() => {
+                    setIsExiting(false);
                     setUncontrolledOpened(false);
                     onClose?.();
-                }
-                returnFocus();
-            }, timingDuration);
-        } else {
-            // For non-animated case, cleanup immediately
-            if (typeof controlledOpened === "boolean") {
-                onClose?.();
+                    returnFocus();
+                }, timingDuration);
             } else {
                 setUncontrolledOpened(false);
                 onClose?.();
+                returnFocus();
             }
-            returnFocus();
+        } else {
+            // Controlled: notify parent so they can set modal=null.
+            // The modal transition effect handles exit animation and focus
+            // restoration once the parent updates modal to null.
+            onClose?.();
         }
-    }, [controlledOpened, onClose, returnFocus, animated, timingDuration]);
+    }, [isControlled, onClose, returnFocus, animated, timingDuration]);
 
     const openModal = React.useCallback(() => {
         saveLastElementFocused();
@@ -276,9 +293,8 @@ const DrawerLauncher = (props: Props) => {
     );
 
     const renderModal = React.useCallback(() => {
-        // Handle function-based modals
-        if (typeof modal === "function") {
-            const renderedModal = modal({
+        if (typeof displayModal === "function") {
+            const renderedModal = displayModal({
                 closeModal: handleCloseModal,
             });
 
@@ -289,13 +305,12 @@ const DrawerLauncher = (props: Props) => {
             return renderedModal;
         }
 
-        // Handle element-based modals
-        if (!modal) {
+        if (!displayModal) {
             return null;
         }
 
-        return modal;
-    }, [modal, handleCloseModal]);
+        return displayModal;
+    }, [displayModal, handleCloseModal]);
 
     const renderedChildren = children
         ? children({
@@ -370,41 +385,25 @@ function DrawerLauncherKeypressListener({onClose}: {onClose: () => unknown}) {
  * **IMPORTANT**: This component should ONLY be used with DrawerDialog. Using other
  * modal components may result in incorrect animations, positioning, and styling.
  *
+ * Keep the launcher always mounted and use `modal={null}` to close. This
+ * ensures keyboard focus is captured and restored correctly across open/close
+ * transitions:
+ *
+ * ```jsx
+ * <DrawerLauncher
+ *     modal={isOpen ? ({closeModal}) => <DrawerDialog .../> : null}
+ *     onClose={() => setIsOpen(false)}
+ *     animated={animated}
+ *     alignment="inlineStart"
+ * />
+ * ```
+ *
  * - Slide animations can be turned off with the `animated` prop.
  * - Timing of animations can be fine-tuned with the `timingDuration` prop, used on
  * enter and exit animations. It is also used to coordinate timing of focus management
  * on open and close.
  *
- * For conditionally rendering modals, ensure there is only one `DrawerLauncher` in
- * your component tree. A launcher needs to stay mounted on the current page to
- * properly handle the user's keyboard focus on close of modals.
  * Read [more details on Confluence](https://khanacademy.atlassian.net/wiki/spaces/FRONTEND/blog/2025/11/24/4454383789/Wonder+Blocks+Modal+Tips+Tricks).
- *
- * ### Usage
- *
- * ```jsx
- * import {DrawerLauncher, DrawerDialog} from "@khanacademy/wonder-blocks-modal";
- * import {BodyText} from "@khanacademy/wonder-blocks-typography";
- *
- * <DrawerLauncher
- *      onClose={handleClose}
- *      opened={opened}
- *      animated={animated}
- *      alignment="inlineStart"
- *      modal={({closeModal}) => (
- *          <DrawerDialog
- *              title="Assign Mastery Mission"
- *              content={
- *                  <View>
- *                      <BodyText>
- *                          Hello, world
- *                      </BodyText>
- *                  </View>
- *              }
- *          />
- *      )}
- * />
- * ```
  */
 
 DrawerLauncher.displayName = "DrawerLauncher";

--- a/packages/wonder-blocks-modal/src/components/modal-launcher.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-launcher.tsx
@@ -98,6 +98,15 @@ type Props = Readonly<{
      * `modal={null}` to close and `modal={<MyDialog />}` to open.
      */
     children?: (arg1: {openModal: () => unknown}) => React.ReactNode;
+    /**
+     * @deprecated Use `modal={isOpen ? <Dialog /> : null}` instead and keep
+     * the launcher always mounted. Passing `opened` will be removed in a
+     * future major version.
+     *
+     * Controls whether the modal is visible. When provided, the component
+     * operates in controlled mode and `onClose` must also be supplied.
+     */
+    opened?: boolean;
 }> &
     WithActionSchedulerProps;
 
@@ -131,6 +140,8 @@ const ModalLauncher = (props: Props): React.ReactElement | null => {
         initialFocusId,
         modal,
         onClose,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        opened: deprecatedOpened,
         schedule,
         testId,
     } = props;
@@ -142,13 +153,23 @@ const ModalLauncher = (props: Props): React.ReactElement | null => {
     // Uncontrolled open state (used only when `children` is provided)
     const [opened, setOpened] = React.useState(false);
 
-    // In controlled mode (no children), open state is derived from the modal prop.
+    // In controlled mode (no children), open state is derived from the modal
+    // prop (or the deprecated `opened` prop when provided as a shim).
     const isControlled = !children;
-    const isOpened = isControlled ? modal != null : opened;
+    const isOpened = isControlled
+        ? deprecatedOpened !== undefined
+            ? deprecatedOpened
+            : modal != null
+        : opened;
 
     React.useEffect(() => {
-        if (!isControlled && !onClose) {
-            return;
+        if (deprecatedOpened !== undefined) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                "ModalLauncher: the `opened` prop is deprecated. " +
+                    "Keep the launcher always mounted and use " +
+                    "`modal={isOpen ? <Dialog /> : null}` instead.",
+            );
         }
         if (isControlled && !onClose) {
             // eslint-disable-next-line no-console
@@ -156,7 +177,7 @@ const ModalLauncher = (props: Props): React.ReactElement | null => {
                 "'onClose' should be provided when using ModalLauncher in controlled mode (without children)",
             );
         }
-    }, [isControlled, onClose]);
+    }, [deprecatedOpened, isControlled, onClose]);
 
     const saveLastElementFocused = React.useCallback(() => {
         // keep a reference of the element that triggers the modal
@@ -192,25 +213,36 @@ const ModalLauncher = (props: Props): React.ReactElement | null => {
         }
     }, [closedFocusId, schedule]);
 
-    // Track modal prop transitions to manage focus in controlled mode.
-    const prevModalRef = React.useRef(modal);
+    // Track transitions in controlled mode to capture/restore focus.
+    // Supports both the new (modal prop) and deprecated (opened prop) patterns.
+    const prevSignalRef = React.useRef(
+        deprecatedOpened !== undefined ? deprecatedOpened : modal != null,
+    );
     React.useEffect(() => {
         if (!isControlled) {
-            prevModalRef.current = modal;
+            prevSignalRef.current =
+                deprecatedOpened !== undefined
+                    ? deprecatedOpened
+                    : modal != null;
             return;
         }
-        const prevModal = prevModalRef.current;
-        prevModalRef.current = modal;
-
-        const wasOpen = prevModal != null;
-        const isNowOpen = modal != null;
+        const wasOpen = prevSignalRef.current;
+        const isNowOpen =
+            deprecatedOpened !== undefined ? deprecatedOpened : modal != null;
+        prevSignalRef.current = isNowOpen;
 
         if (!wasOpen && isNowOpen) {
             saveLastElementFocused();
         } else if (wasOpen && !isNowOpen) {
             returnFocus();
         }
-    }, [modal, isControlled, saveLastElementFocused, returnFocus]);
+    }, [
+        modal,
+        deprecatedOpened,
+        isControlled,
+        saveLastElementFocused,
+        returnFocus,
+    ]);
 
     const openModal = React.useCallback(() => {
         saveLastElementFocused();
@@ -222,8 +254,8 @@ const ModalLauncher = (props: Props): React.ReactElement | null => {
             setOpened(false);
             returnFocus();
         }
-        // In controlled mode, returnFocus() is called by the modal transition
-        // effect once the parent updates modal to null.
+        // In controlled mode, returnFocus() is called by the transition effect
+        // once the parent updates modal to null (or opened to false).
         onClose?.();
     }, [isControlled, onClose, returnFocus]);
 

--- a/packages/wonder-blocks-modal/src/components/modal-launcher.tsx
+++ b/packages/wonder-blocks-modal/src/components/modal-launcher.tsx
@@ -17,17 +17,34 @@ import ModalContext from "./modal-context";
 
 type Props = Readonly<{
     /**
-     * The modal to render.
+     * The modal to render, or `null` to indicate a closed state.
      *
-     * The modal will be rendered inside of a container whose parent is
-     * document.body. This allows us to use ModalLauncher within menus and
-     * other components that clip their content. If the modal needs to close
-     * itself by some other means than tapping the backdrop or the default
-     * close button a render callback can be passed. The closeModal function
-     * provided to this callback can be called to close the modal.
+     * Pass a React element or render function to show the modal. Pass `null`
+     * to keep the launcher mounted but in a closed state — this is the
+     * recommended pattern for controlled usage because it lets the launcher
+     * capture and restore keyboard focus across open/close transitions:
+     *
+     * ```jsx
+     * <ModalLauncher
+     *     modal={isOpen ? <MyDialog /> : null}
+     *     onClose={() => setIsOpen(false)}
+     * />
+     * ```
+     *
+     * The modal is rendered inside a portal appended to `document.body`, so
+     * it won't be clipped by overflow constraints in the component tree. When
+     * a render function is used, the `closeModal` callback can be called to
+     * trigger a close:
+     *
+     * ```jsx
+     * <ModalLauncher
+     *     modal={({closeModal}) => <MyDialog onClose={closeModal} />}
+     *     onClose={() => setIsOpen(false)}
+     * />
+     * ```
      *
      * Note: Don't call `closeModal` while rendering! It should be used to
-     * respond to user intearction, like `onClick`.
+     * respond to user interaction, like `onClick`.
      */
     modal: ModalElement | ((props: {closeModal: () => void}) => ModalElement);
     /**
@@ -52,17 +69,6 @@ type Props = Readonly<{
     testId?: string;
 
     /**
-     * Renders the modal when true, renders nothing when false.
-     *
-     * Using this prop makes the component behave as a controlled component.
-     * The parent is responsible for managing the opening/closing of the modal
-     * when using this prop.  `onClose` should always be used and `children`
-     * should never be used with this prop.  Not doing so will result in an
-     * error being thrown.
-     */
-    opened?: boolean;
-
-    /**
      * If the parent needs to be notified when the modal is closed, use this
      * prop. You probably want to use this instead of `onClose` on the modals
      * themselves, since this will capture a more complete set of close events.
@@ -70,14 +76,26 @@ type Props = Readonly<{
      * Called when the modal needs to notify the parent component that it should
      * be closed.
      *
-     * This prop must be used when the component is being used as a controlled
-     * component.
+     * Required when using controlled mode (no `children`) so that close events
+     * initiated from within the modal (e.g. X button, Escape key, backdrop
+     * click) propagate to the parent.
      */
     onClose?: () => unknown;
 
     /**
-     * WARNING: This props should only be used when using the component as a
-     * controlled component.
+     * Render prop that receives an `openModal` callback. When provided the
+     * component operates in **uncontrolled** mode: the launcher manages its
+     * own open/close state, and the `modal` prop always describes the dialog
+     * content (never `null`).
+     *
+     * ```jsx
+     * <ModalLauncher modal={<MyDialog />}>
+     *     {({openModal}) => <button onClick={openModal}>Open</button>}
+     * </ModalLauncher>
+     * ```
+     *
+     * When omitted the component operates in **controlled** mode: pass
+     * `modal={null}` to close and `modal={<MyDialog />}` to open.
      */
     children?: (arg1: {openModal: () => unknown}) => React.ReactNode;
 }> &
@@ -86,18 +104,24 @@ type Props = Readonly<{
 /**
  * This component enables you to launch a modal, covering the screen.
  *
- * Children have access to `openModal` function via the function-as-children
- * pattern, so one common use case is for this component to wrap a button:
+ * **Controlled mode** — keep the launcher always mounted and use
+ * `modal={null}` to close:
  *
- * ```js
- * <ModalLauncher modal={<TwoColumnModal ... />}>
- *     {({openModal}) => <button onClick={openModal}>Learn more</button>}
- * </ModalLauncher>
+ * ```jsx
+ * <ModalLauncher
+ *     modal={isOpen ? <MyDialog /> : null}
+ *     onClose={() => setIsOpen(false)}
+ * />
  * ```
  *
- * The actual modal itself is constructed separately, using a layout component
- * like OnePaneDialog and is provided via
- * the `modal` prop.
+ * **Uncontrolled mode** — use the `children` render prop to get an
+ * `openModal` callback:
+ *
+ * ```jsx
+ * <ModalLauncher modal={<MyDialog />}>
+ *     {({openModal}) => <button onClick={openModal}>Open</button>}
+ * </ModalLauncher>
+ * ```
  */
 const ModalLauncher = (props: Props): React.ReactElement | null => {
     const {
@@ -107,7 +131,6 @@ const ModalLauncher = (props: Props): React.ReactElement | null => {
         initialFocusId,
         modal,
         onClose,
-        opened: controlledOpened,
         schedule,
         testId,
     } = props;
@@ -116,41 +139,30 @@ const ModalLauncher = (props: Props): React.ReactElement | null => {
         null,
     );
 
+    // Uncontrolled open state (used only when `children` is provided)
     const [opened, setOpened] = React.useState(false);
-    const isOpened =
-        typeof controlledOpened === "boolean" ? controlledOpened : opened;
+
+    // In controlled mode (no children), open state is derived from the modal prop.
+    const isControlled = !children;
+    const isOpened = isControlled ? modal != null : opened;
 
     React.useEffect(() => {
-        if (typeof controlledOpened === "boolean" && children) {
-            // eslint-disable-next-line no-console
-            console.warn("'children' and 'opened' can't be used together");
+        if (!isControlled && !onClose) {
+            return;
         }
-        if (typeof controlledOpened === "boolean" && !onClose) {
+        if (isControlled && !onClose) {
             // eslint-disable-next-line no-console
-            console.warn("'onClose' should be used with 'opened'");
+            console.warn(
+                "'onClose' should be provided when using ModalLauncher in controlled mode (without children)",
+            );
         }
-        if (typeof controlledOpened !== "boolean" && !children) {
-            // eslint-disable-next-line no-console
-            console.warn("either 'children' or 'opened' must be set");
-        }
-    }, [controlledOpened, children, onClose]);
+    }, [isControlled, onClose]);
 
     const saveLastElementFocused = React.useCallback(() => {
         // keep a reference of the element that triggers the modal
         // @ts-expect-error [FEI-5019] - TS2322 - Type 'Element | null' is not assignable to type 'HTMLElement | null'.
         lastElementFocusedOutsideModalRef.current = document.activeElement;
     }, []);
-
-    React.useEffect(() => {
-        if (!opened && controlledOpened) {
-            saveLastElementFocused();
-        }
-    }, [controlledOpened, opened, saveLastElementFocused]);
-
-    const openModal = React.useCallback(() => {
-        saveLastElementFocused();
-        setOpened(true);
-    }, [saveLastElementFocused]);
 
     const returnFocus = React.useCallback(() => {
         // Focus on the specified element after closing the modal.
@@ -180,11 +192,40 @@ const ModalLauncher = (props: Props): React.ReactElement | null => {
         }
     }, [closedFocusId, schedule]);
 
+    // Track modal prop transitions to manage focus in controlled mode.
+    const prevModalRef = React.useRef(modal);
+    React.useEffect(() => {
+        if (!isControlled) {
+            prevModalRef.current = modal;
+            return;
+        }
+        const prevModal = prevModalRef.current;
+        prevModalRef.current = modal;
+
+        const wasOpen = prevModal != null;
+        const isNowOpen = modal != null;
+
+        if (!wasOpen && isNowOpen) {
+            saveLastElementFocused();
+        } else if (wasOpen && !isNowOpen) {
+            returnFocus();
+        }
+    }, [modal, isControlled, saveLastElementFocused, returnFocus]);
+
+    const openModal = React.useCallback(() => {
+        saveLastElementFocused();
+        setOpened(true);
+    }, [saveLastElementFocused]);
+
     const handleCloseModal = React.useCallback(() => {
-        setOpened(false);
+        if (!isControlled) {
+            setOpened(false);
+            returnFocus();
+        }
+        // In controlled mode, returnFocus() is called by the modal transition
+        // effect once the parent updates modal to null.
         onClose?.();
-        returnFocus();
-    }, [onClose, returnFocus]);
+    }, [isControlled, onClose, returnFocus]);
 
     const renderModal = React.useCallback((): ModalElement => {
         if (typeof modal === "function") {


### PR DESCRIPTION
## Summary:
I've seen numerous PRs in `frontend` that either aim to address focus management issues or perpetuate them without realizing it. WB shouldn't allow a pattern that doesn't work for accessibility, and the `opened` prop is one of those. When WB Modals are conditionally rendered with the `opened` prop, the parent component unmounts and takes ModalLauncher with it. The component tree is detached before the focus management lifecycle can run, and no runtime code can fix it because it isn't mounted anymore.

This PR updates `ModalLauncher` and `DrawerLauncher` to support `modal={null}` as a first-class "closed" state, and deprecates the `opened` prop in favor of this pattern.

What changed:

- The `modal` prop now accepts `null` to indicate a closed state, keeping the launcher always mounted across open/close transitions
- The `opened` prop is deprecated with a runtime `console.warn` and `@deprecated` JSDoc, but remains fully functional — no existing consumers need to change code
- `DrawerLauncher` preserves exit animation content via a cached `ref` when modal transitions to `null`

Why: Conditionally rendering the launcher `({isOpen && <ModalLauncher>})` caused focus to be lost on unmount rather than returned to the triggering element. The new API avoids this pitfall by design.

Migration:

```jsx
// Deprecated (still works, but warns)
<ModalLauncher opened={isOpen} modal={<MyDialog />} onClose={...} />

// Recommended
<ModalLauncher modal={isOpen ? <MyDialog /> : null} onClose={...} />
```

Issue: WB-2346

## Test plan:
1. Ensure tests pass
2. Test stories for ModalLauncher and DrawerLauncher
3. Test integration in `frontend`