### PR TITLE
MultiSelect: announce correct count for selected items

### DIFF
--- a/.changeset/tasty-books-warn.md
+++ b/.changeset/tasty-books-warn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+Fixes a bug in MultiSelect with incorrect screen reader announcements for more than 2 items

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
@@ -99,6 +100,14 @@ const styles = StyleSheet.create({
     setWidth: {
         minInlineSize: 170,
         width: "100%",
+    },
+    twoSelectsContainer: {
+        flexDirection: "row",
+        gap: sizing.size_080,
+        alignItems: "flex-start",
+    },
+    fullWidth: {
+        inlineSize: "100%",
     },
     customDropdown: {
         maxBlockSize: 200,
@@ -996,4 +1005,88 @@ export const CustomOptionItemsWithNodeLabel: StoryComponentType = {
             <View style={styles.wrapper}>{Story()}</View>
         ),
     ],
+};
+
+/**
+ * Two MultiSelects side by side for manual screen reader testing. Use this
+ * story to verify:
+ * - The focused select announces its current value on open (VoiceOver/Safari
+ *   workaround for stale combobox values).
+ * - Only the interacted select announces — the neighboring select stays silent
+ *   even as the parent re-renders.
+ * - Selecting items announces the updated count while the dropdown is open.
+ * - Closing the dropdown after making selections announces the final state.
+ * - Opening a filterable select does not stomp over the search input
+ *   announcement with an assertive selection announcement.
+ */
+export const TwoMultiSelects: StoryComponentType = {
+    render: function Render() {
+        const [gradeValues, setGradeValues] = React.useState<Array<string>>([
+            "6",
+            "7",
+        ]);
+        const [categoryValues, setCategoryValues] = React.useState<
+            Array<string>
+        >([]);
+
+        return (
+            <View style={styles.twoSelectsContainer}>
+                <LabeledField
+                    label="Grade Level"
+                    field={
+                        <MultiSelect
+                            aria-label="Select grade levels"
+                            isFilterable={true}
+                            labels={{
+                                noneSelected: "All grades",
+                                someSelected: (n: number) =>
+                                    n === 1
+                                        ? "1 grade selected"
+                                        : `${n} grades selected`,
+                            }}
+                            onChange={setGradeValues}
+                            selectedValues={gradeValues}
+                            style={styles.fullWidth}
+                        >
+                            <OptionItem label="Grade 3" value="3" />
+                            <OptionItem label="Grade 4" value="4" />
+                            <OptionItem label="Grade 5" value="5" />
+                            <OptionItem label="Grade 6" value="6" />
+                            <OptionItem label="Grade 7" value="7" />
+                            <OptionItem label="Grade 8" value="8" />
+                        </MultiSelect>
+                    }
+                />
+                <LabeledField
+                    label="Categories"
+                    field={
+                        <MultiSelect
+                            aria-label="Select categories"
+                            labels={{
+                                noneSelected: "All categories",
+                                someSelected: (n: number) =>
+                                    n === 1
+                                        ? "1 category selected"
+                                        : `${n} categories selected`,
+                            }}
+                            onChange={setCategoryValues}
+                            selectedValues={categoryValues}
+                            style={styles.fullWidth}
+                        >
+                            <OptionItem label="Argumentative" value="arg" />
+                            <OptionItem label="Expository" value="exp" />
+                            <OptionItem label="Narrative" value="nar" />
+                            <OptionItem label="Persuasive" value="per" />
+                        </MultiSelect>
+                    }
+                />
+            </View>
+        );
+    },
+    parameters: {
+        chromatic: {
+            // Manual screen reader testing story — no snapshot needed
+            disableSnapshot: true,
+        },
+    },
 };

--- a/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.stories.tsx
@@ -1008,16 +1008,12 @@ export const CustomOptionItemsWithNodeLabel: StoryComponentType = {
 };
 
 /**
- * Two MultiSelects side by side for manual screen reader testing. Use this
- * story to verify:
- * - The focused select announces its current value on open (VoiceOver/Safari
- *   workaround for stale combobox values).
+ * Two MultiSelects side by side for manual screen reader testing.
  * - Only the interacted select announces — the neighboring select stays silent
  *   even as the parent re-renders.
  * - Selecting items announces the updated count while the dropdown is open.
- * - Closing the dropdown after making selections announces the final state.
- * - Opening a filterable select does not stomp over the search input
- *   announcement with an assertive selection announcement.
+ * - Closing the dropdown after making selections announces the final state
+ *   (VoiceOver/Safari workaround for stale combobox values).
  */
 export const TwoMultiSelects: StoryComponentType = {
     render: function Render() {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -1757,7 +1757,7 @@ describe("MultiSelect", () => {
             // Assert
             expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "item 1",
-                level: "assertive",
+                level: "polite",
             });
         });
 
@@ -1801,7 +1801,7 @@ describe("MultiSelect", () => {
             // Should announce "2 items" (selected count), not "3 items" (total count)
             expect(announceMessageSpy).toHaveBeenLastCalledWith({
                 message: "2 items",
-                level: "assertive",
+                level: "polite",
             });
         });
 
@@ -1848,66 +1848,78 @@ describe("MultiSelect", () => {
             // Should announce "2 items" (selected count), not "4 items" (total count)
             expect(announceMessageSpy).toHaveBeenLastCalledWith({
                 message: "2 items",
-                level: "assertive",
+                level: "polite",
             });
         });
 
-        it("should announce the selected count when a non-filterable listbox is opened", async () => {
+        it.each([
+            ["non-filterable", false],
+            ["filterable", true],
+        ])(
+            "should not announce when a %s listbox is opened",
+            async (_label, isFilterable) => {
+                // Arrange
+                const {userEvent} = doRender(
+                    <MultiSelect
+                        onChange={jest.fn()}
+                        isFilterable={isFilterable}
+                        selectedValues={["1", "2"]}
+                        labels={{
+                            ...builtinLabels,
+                            someSelected: (n: number): string =>
+                                n <= 1 ? `${n} school` : `${n} schools`,
+                        }}
+                    >
+                        <OptionItem label="school 1" value="1" />
+                        <OptionItem label="school 2" value="2" />
+                        <OptionItem label="school 3" value="3" />
+                    </MultiSelect>,
+                );
+
+                // Act
+                await userEvent.click(await screen.findByRole("combobox"));
+
+                // Assert
+                expect(announceMessageSpy).not.toHaveBeenCalled();
+            },
+        );
+
+        it("should announce when selecting an item in a filterable listbox", async () => {
             // Arrange
-            const {userEvent} = doRender(
-                <MultiSelect
-                    onChange={jest.fn()}
-                    labels={{
-                        ...builtinLabels,
-                        someSelected: (numOptions: number): string =>
-                            numOptions <= 1
-                                ? `${numOptions} school`
-                                : `${numOptions} schools`,
-                    }}
-                    selectedValues={["1", "2"]}
-                >
-                    <OptionItem label="school 1" value="1" />
-                    <OptionItem label="school 2" value="2" />
-                    <OptionItem label="school 3" value="3" />
-                </MultiSelect>,
-            );
+            const ControlledMultiSelect = () => {
+                const [selectedValues, setSelectedValues] = React.useState<
+                    Array<string>
+                >(["1", "2"]);
+                return (
+                    <MultiSelect
+                        onChange={setSelectedValues}
+                        selectedValues={selectedValues}
+                        isFilterable={true}
+                        labels={{
+                            ...builtinLabels,
+                            someSelected: (n: number): string =>
+                                n <= 1 ? `${n} school` : `${n} schools`,
+                        }}
+                    >
+                        <OptionItem label="school 1" value="1" />
+                        <OptionItem label="school 2" value="2" />
+                        <OptionItem label="school 3" value="3" />
+                        <OptionItem label="school 4" value="4" />
+                    </MultiSelect>
+                );
+            };
+            const {userEvent} = doRender(<ControlledMultiSelect />);
+            await userEvent.click(await screen.findByRole("combobox")); // open
+            announceMessageSpy.mockClear();
 
             // Act
-            await userEvent.click(await screen.findByRole("combobox"));
+            await userEvent.click(await screen.findByText("school 3"));
 
             // Assert
             expect(announceMessageSpy).toHaveBeenCalledWith({
-                message: "2 schools",
-                level: "assertive",
+                message: "3 schools",
+                level: "polite",
             });
-        });
-
-        it("should not announce when a filterable listbox is opened", async () => {
-            // Arrange
-            const {userEvent} = doRender(
-                <MultiSelect
-                    onChange={jest.fn()}
-                    isFilterable={true}
-                    labels={{
-                        ...builtinLabels,
-                        someSelected: (numOptions: number): string =>
-                            numOptions <= 1
-                                ? `${numOptions} school`
-                                : `${numOptions} schools`,
-                    }}
-                    selectedValues={["1", "2"]}
-                >
-                    <OptionItem label="school 1" value="1" />
-                    <OptionItem label="school 2" value="2" />
-                    <OptionItem label="school 3" value="3" />
-                </MultiSelect>,
-            );
-
-            // Act
-            await userEvent.click(await screen.findByRole("combobox"));
-
-            // Assert
-            expect(announceMessageSpy).not.toHaveBeenCalled();
         });
 
         it("should not announce from a neighboring MultiSelect when a parent re-renders due to interaction with another MultiSelect", async () => {
@@ -1951,19 +1963,17 @@ describe("MultiSelect", () => {
             const {userEvent} = doRender(<TwoSelects />);
             const [comboboxA] = await screen.findAllByRole("combobox");
             await userEvent.click(comboboxA); // open select-a, causing parent re-render
-            announceMessageSpy.mockClear();
 
             // Act
             const [cat1] = await screen.findAllByText("cat 1");
             await userEvent.click(cat1); // select in select-a
+            await userEvent.keyboard("{Escape}"); // close to trigger close announcement
 
             // Assert
-            // Only the interacted select should announce; select-b must stay silent
-            expect(announceMessageSpy).toHaveBeenCalledTimes(1);
-            expect(announceMessageSpy).toHaveBeenCalledWith({
-                message: "cat 1",
-                level: "assertive",
-            });
+            // select-b must not have announced its noneSelected label
+            expect(announceMessageSpy).not.toHaveBeenCalledWith(
+                expect.objectContaining({message: "All categories"}),
+            );
         });
 
         it("should announce the final selection when the dropdown closes after a selection change", async () => {
@@ -2066,7 +2076,7 @@ describe("MultiSelect", () => {
             // Assert
             expect(announceMessageSpy).toHaveBeenLastCalledWith({
                 message: "All items",
-                level: "assertive",
+                level: "polite",
             });
         });
 
@@ -2108,7 +2118,7 @@ describe("MultiSelect", () => {
             // Assert
             expect(announceMessageSpy).toHaveBeenLastCalledWith({
                 message: "0 items",
-                level: "assertive",
+                level: "polite",
             });
         });
 
@@ -2145,7 +2155,7 @@ describe("MultiSelect", () => {
             // Assert
             expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "1 planet",
-                level: "assertive",
+                level: "polite",
             });
         });
     });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -1910,6 +1910,125 @@ describe("MultiSelect", () => {
             expect(announceMessageSpy).not.toHaveBeenCalled();
         });
 
+        it("should not announce from a neighboring MultiSelect when a parent re-renders due to interaction with another MultiSelect", async () => {
+            // Regression: inline label objects recreate on every parent render,
+            // which used to cause effect deps to fire and announce stale values
+            // in unrelated MultiSelects on the same page.
+            const TwoSelects = () => {
+                const [selectedA, setSelectedA] = React.useState<Array<string>>(
+                    [],
+                );
+                const [selectedB] = React.useState<Array<string>>(["1"]);
+                return (
+                    <>
+                        <MultiSelect
+                            onChange={setSelectedA}
+                            selectedValues={selectedA}
+                            labels={{
+                                ...builtinLabels,
+                                noneSelected: "All categories",
+                            }}
+                            testId="select-a"
+                        >
+                            <OptionItem label="cat 1" value="1" />
+                            <OptionItem label="cat 2" value="2" />
+                        </MultiSelect>
+                        <MultiSelect
+                            onChange={jest.fn()}
+                            selectedValues={selectedB}
+                            labels={{
+                                ...builtinLabels,
+                                noneSelected: "All categories",
+                            }}
+                            testId="select-b"
+                        >
+                            <OptionItem label="cat 1" value="1" />
+                            <OptionItem label="cat 2" value="2" />
+                        </MultiSelect>
+                    </>
+                );
+            };
+            const {userEvent} = doRender(<TwoSelects />);
+            const [comboboxA] = await screen.findAllByRole("combobox");
+            await userEvent.click(comboboxA); // open select-a, causing parent re-render
+            announceMessageSpy.mockClear();
+
+            // Act
+            const [cat1] = await screen.findAllByText("cat 1");
+            await userEvent.click(cat1); // select in select-a
+
+            // Assert
+            // Only the interacted select should announce; select-b must stay silent
+            expect(announceMessageSpy).toHaveBeenCalledTimes(1);
+            expect(announceMessageSpy).toHaveBeenCalledWith({
+                message: "cat 1",
+                level: "assertive",
+            });
+        });
+
+        it("should announce the final selection when the dropdown closes after a selection change", async () => {
+            // Arrange
+            const ControlledMultiSelect = () => {
+                const [selectedValues, setSelectedValues] = React.useState<
+                    Array<string>
+                >(["1"]);
+                return (
+                    <MultiSelect
+                        onChange={setSelectedValues}
+                        selectedValues={selectedValues}
+                        labels={{
+                            ...builtinLabels,
+                            someSelected: (n: number) =>
+                                n === 1 ? `1 item` : `${n} items`,
+                        }}
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                        <OptionItem label="item 3" value="3" />
+                    </MultiSelect>
+                );
+            };
+            const {userEvent} = doRender(<ControlledMultiSelect />);
+            await userEvent.click(await screen.findByRole("combobox")); // open
+            await userEvent.click(await screen.findByText("item 2")); // select
+            announceMessageSpy.mockClear();
+
+            // Act
+            await userEvent.keyboard("{Escape}"); // close
+
+            // Assert
+            expect(announceMessageSpy).toHaveBeenCalledWith({
+                message: "2 items",
+                level: "polite",
+            });
+        });
+
+        it("should not announce on close if no selection changed", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    selectedValues={["1"]}
+                    labels={{
+                        ...builtinLabels,
+                        someSelected: (n: number) =>
+                            n === 1 ? `1 item` : `${n} items`,
+                    }}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </MultiSelect>,
+            );
+            await userEvent.click(await screen.findByRole("combobox")); // open
+            announceMessageSpy.mockClear();
+
+            // Act
+            await userEvent.keyboard("{Escape}"); // close without selecting
+
+            // Assert
+            expect(announceMessageSpy).not.toHaveBeenCalled();
+        });
+
         it("should announce after selecting all items via the shortcut", async () => {
             // Arrange
             const ControlledMultiSelect = (

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -1759,6 +1759,95 @@ describe("MultiSelect", () => {
             });
         });
 
+        it("should announce the selected item count (not total item count) when selecting while open", async () => {
+            // Arrange
+            const ControlledMultiSelect = (
+                props: Partial<PropsFor<typeof MultiSelect>>,
+            ) => {
+                const [selectedValues, setSelectedValues] = React.useState<
+                    Array<string>
+                >(["1"]);
+                return (
+                    <MultiSelect
+                        {...props}
+                        onChange={setSelectedValues}
+                        selectedValues={selectedValues}
+                        labels={{
+                            ...builtinLabels,
+                            someSelected: (numOptions: number): string =>
+                                numOptions <= 1
+                                    ? `${numOptions} item`
+                                    : `${numOptions} items`,
+                        }}
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                        <OptionItem label="item 3" value="3" />
+                    </MultiSelect>
+                );
+            };
+
+            const {userEvent} = doRender(<ControlledMultiSelect />);
+            // Open the dropdown first
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Act
+            // Select a second item while dropdown is open (now 2 of 3 selected)
+            await userEvent.click(await screen.findByText("item 2"));
+
+            // Assert
+            // Should announce "2 items" (selected count), not "3 items" (total count)
+            expect(announceMessageSpy).toHaveBeenLastCalledWith({
+                message: "2 items",
+            });
+        });
+
+        it("should announce the selected item count (not total item count) when deselecting while open", async () => {
+            // Arrange
+            // Start with 3 of 4 selected so deselecting stays in the count
+            // range (≥2) and the opener uses someSelected rather than an item label
+            const ControlledMultiSelect = (
+                props: Partial<PropsFor<typeof MultiSelect>>,
+            ) => {
+                const [selectedValues, setSelectedValues] = React.useState<
+                    Array<string>
+                >(["1", "2", "3"]);
+                return (
+                    <MultiSelect
+                        {...props}
+                        onChange={setSelectedValues}
+                        selectedValues={selectedValues}
+                        labels={{
+                            ...builtinLabels,
+                            someSelected: (numOptions: number): string =>
+                                numOptions <= 1
+                                    ? `${numOptions} item`
+                                    : `${numOptions} items`,
+                        }}
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                        <OptionItem label="item 3" value="3" />
+                        <OptionItem label="item 4" value="4" />
+                    </MultiSelect>
+                );
+            };
+
+            const {userEvent} = doRender(<ControlledMultiSelect />);
+            // Open the dropdown first
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Act
+            // Deselect one item while dropdown is open (now 2 of 4 selected)
+            await userEvent.click(await screen.findByText("item 1"));
+
+            // Assert
+            // Should announce "2 items" (selected count), not "4 items" (total count)
+            expect(announceMessageSpy).toHaveBeenLastCalledWith({
+                message: "2 items",
+            });
+        });
+
         it("should announce the number of options when the listbox is open", async () => {
             // Arrange
             const labels: LabelsValues = {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -1695,8 +1695,8 @@ describe("MultiSelect", () => {
         });
 
         it("should not announce initial values on mount", async () => {
-            // Arrange & Act
-            doRender(
+            // Arrange
+            const element = (
                 <MultiSelect
                     onChange={jest.fn()}
                     selectedValues={["1", "2"]}
@@ -1711,18 +1711,21 @@ describe("MultiSelect", () => {
                     <OptionItem label="item 1" value="1" />
                     <OptionItem label="item 2" value="2" />
                     <OptionItem label="item 3" value="3" />
-                </MultiSelect>,
+                </MultiSelect>
             );
+
+            // Act
+            doRender(element);
 
             // Assert
             expect(announceMessageSpy).not.toHaveBeenCalled();
         });
 
         it("should announce when values change after mount", async () => {
+            // Arrange
             const ControlledMultiSelect = (
                 props: Partial<PropsFor<typeof MultiSelect>>,
             ) => {
-                // Arrange
                 const [selectedValues, setSelectedValues] = React.useState<
                     Array<string>
                 >([]);
@@ -1745,17 +1748,16 @@ describe("MultiSelect", () => {
                     </MultiSelect>
                 );
             };
-
             const {userEvent} = doRender(<ControlledMultiSelect />);
-            // Act
             await userEvent.click(await screen.findByRole("combobox"));
+
+            // Act
             await userEvent.click(await screen.findByText("item 1"));
 
             // Assert
-            // First call announces total options ("3 items")
-            // Second call announces selected item count
-            expect(announceMessageSpy).toHaveBeenNthCalledWith(2, {
+            expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "item 1",
+                level: "assertive",
             });
         });
 
@@ -1799,6 +1801,7 @@ describe("MultiSelect", () => {
             // Should announce "2 items" (selected count), not "3 items" (total count)
             expect(announceMessageSpy).toHaveBeenLastCalledWith({
                 message: "2 items",
+                level: "assertive",
             });
         });
 
@@ -1845,21 +1848,24 @@ describe("MultiSelect", () => {
             // Should announce "2 items" (selected count), not "4 items" (total count)
             expect(announceMessageSpy).toHaveBeenLastCalledWith({
                 message: "2 items",
+                level: "assertive",
             });
         });
 
-        it("should announce the number of options when the listbox is open", async () => {
+        it("should announce the selected count (not total count) when the listbox is opened", async () => {
             // Arrange
-            const labels: LabelsValues = {
-                ...builtinLabels,
-                someSelected: (numOptions: number): string =>
-                    numOptions <= 1
-                        ? `${numOptions} school`
-                        : `${numOptions} schools`,
-            };
-
             const {userEvent} = doRender(
-                <MultiSelect onChange={jest.fn()} labels={labels} opened={true}>
+                <MultiSelect
+                    onChange={jest.fn()}
+                    labels={{
+                        ...builtinLabels,
+                        someSelected: (numOptions: number): string =>
+                            numOptions <= 1
+                                ? `${numOptions} school`
+                                : `${numOptions} schools`,
+                    }}
+                    selectedValues={["1", "2"]}
+                >
                     <OptionItem label="school 1" value="1" />
                     <OptionItem label="school 2" value="2" />
                     <OptionItem label="school 3" value="3" />
@@ -1871,8 +1877,92 @@ describe("MultiSelect", () => {
             await userEvent.click(opener);
 
             // Assert
-            await expect(announceMessageSpy).toHaveBeenCalledWith({
-                message: "3 schools",
+            expect(announceMessageSpy).toHaveBeenCalledWith({
+                message: "2 schools",
+                level: "assertive",
+            });
+        });
+
+        it("should announce after selecting all items via the shortcut", async () => {
+            // Arrange
+            const ControlledMultiSelect = (
+                props: Partial<PropsFor<typeof MultiSelect>>,
+            ) => {
+                const [selectedValues, setSelectedValues] = React.useState<
+                    Array<string>
+                >([]);
+                return (
+                    <MultiSelect
+                        {...props}
+                        onChange={setSelectedValues}
+                        selectedValues={selectedValues}
+                        shortcuts={true}
+                        labels={{
+                            ...builtinLabels,
+                            selectAllLabel: (n: number) => `Select all (${n})`,
+                            someSelected: (n: number) =>
+                                n === 1 ? "1 item" : `${n} items`,
+                            allSelected: "All items",
+                        }}
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                        <OptionItem label="item 3" value="3" />
+                    </MultiSelect>
+                );
+            };
+            const {userEvent} = doRender(<ControlledMultiSelect />);
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Act
+            await userEvent.click(await screen.findByText("Select all (3)"));
+
+            // Assert
+            expect(announceMessageSpy).toHaveBeenLastCalledWith({
+                message: "All items",
+                level: "assertive",
+            });
+        });
+
+        it("should announce after clearing all items via the shortcut", async () => {
+            // Arrange
+            const ControlledMultiSelect = (
+                props: Partial<PropsFor<typeof MultiSelect>>,
+            ) => {
+                const [selectedValues, setSelectedValues] = React.useState<
+                    Array<string>
+                >(["1", "2"]);
+                return (
+                    <MultiSelect
+                        {...props}
+                        onChange={setSelectedValues}
+                        selectedValues={selectedValues}
+                        shortcuts={true}
+                        labels={{
+                            ...builtinLabels,
+                            selectAllLabel: (n: number) => `Select all (${n})`,
+                            selectNoneLabel: "Clear selection",
+                            noneSelected: "0 items",
+                            someSelected: (n: number) =>
+                                n === 1 ? "1 item" : `${n} items`,
+                        }}
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                        <OptionItem label="item 3" value="3" />
+                    </MultiSelect>
+                );
+            };
+            const {userEvent} = doRender(<ControlledMultiSelect />);
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Act
+            await userEvent.click(await screen.findByText("Clear selection"));
+
+            // Assert
+            expect(announceMessageSpy).toHaveBeenLastCalledWith({
+                message: "0 items",
+                level: "assertive",
             });
         });
 
@@ -1907,8 +1997,9 @@ describe("MultiSelect", () => {
             await userEvent.paste("ear");
 
             // Assert
-            await expect(announceMessageSpy).toHaveBeenCalledWith({
+            expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "1 planet",
+                level: "assertive",
             });
         });
     });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -1852,7 +1852,7 @@ describe("MultiSelect", () => {
             });
         });
 
-        it("should announce the selected count (not total count) when the listbox is opened", async () => {
+        it("should announce the selected count when a non-filterable listbox is opened", async () => {
             // Arrange
             const {userEvent} = doRender(
                 <MultiSelect
@@ -1871,16 +1871,43 @@ describe("MultiSelect", () => {
                     <OptionItem label="school 3" value="3" />
                 </MultiSelect>,
             );
-            const opener = await screen.findByRole("combobox");
 
             // Act
-            await userEvent.click(opener);
+            await userEvent.click(await screen.findByRole("combobox"));
 
             // Assert
             expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "2 schools",
                 level: "assertive",
             });
+        });
+
+        it("should not announce when a filterable listbox is opened", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <MultiSelect
+                    onChange={jest.fn()}
+                    isFilterable={true}
+                    labels={{
+                        ...builtinLabels,
+                        someSelected: (numOptions: number): string =>
+                            numOptions <= 1
+                                ? `${numOptions} school`
+                                : `${numOptions} schools`,
+                    }}
+                    selectedValues={["1", "2"]}
+                >
+                    <OptionItem label="school 1" value="1" />
+                    <OptionItem label="school 2" value="2" />
+                    <OptionItem label="school 3" value="3" />
+                </MultiSelect>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(announceMessageSpy).not.toHaveBeenCalled();
         });
 
         it("should announce after selecting all items via the shortcut", async () => {

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1219,8 +1219,8 @@ describe("SingleSelect", () => {
         });
 
         it("should not announce initial value on mount", async () => {
-            // Arrange & Act
-            doRender(
+            // Arrange
+            const element = (
                 <SingleSelect
                     onChange={onChange}
                     placeholder="Choose"
@@ -1228,8 +1228,11 @@ describe("SingleSelect", () => {
                 >
                     <OptionItem label="item 1" value="1" />
                     <OptionItem label="item 2" value="2" />
-                </SingleSelect>,
+                </SingleSelect>
             );
+
+            // Act
+            doRender(element);
 
             // Assert
             expect(announceMessageSpy).not.toHaveBeenCalled();
@@ -1259,11 +1262,54 @@ describe("SingleSelect", () => {
             await userEvent.click(await screen.findByText("item 1")); // Selects item
 
             // Assert
-            // First call announces total options ("2 items")
-            // Second call announces selected item
-            expect(announceMessageSpy).toHaveBeenNthCalledWith(2, {
+            expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "item 1",
+                level: "assertive",
             });
+        });
+
+        it("should announce the selected item when a non-filterable dropdown is opened", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    selectedValue="2"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </SingleSelect>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(announceMessageSpy).toHaveBeenCalledWith({
+                message: "item 2",
+                level: "assertive",
+            });
+        });
+
+        it("should not announce when a filterable dropdown is opened", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <SingleSelect
+                    onChange={onChange}
+                    placeholder="Choose"
+                    selectedValue="2"
+                    isFilterable={true}
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </SingleSelect>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(announceMessageSpy).not.toHaveBeenCalled();
         });
 
         it("should change the number of options after using the search filter", async () => {
@@ -1288,6 +1334,7 @@ describe("SingleSelect", () => {
             // Assert
             await expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "1 item",
+                level: "assertive",
             });
         });
     });

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -1264,53 +1264,36 @@ describe("SingleSelect", () => {
             // Assert
             expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "item 1",
-                level: "assertive",
+                level: "polite",
             });
         });
 
-        it("should announce the selected item when a non-filterable dropdown is opened", async () => {
-            // Arrange
-            const {userEvent} = doRender(
-                <SingleSelect
-                    onChange={onChange}
-                    placeholder="Choose"
-                    selectedValue="2"
-                >
-                    <OptionItem label="item 1" value="1" />
-                    <OptionItem label="item 2" value="2" />
-                </SingleSelect>,
-            );
+        it.each([
+            ["non-filterable", false],
+            ["filterable", true],
+        ])(
+            "should not announce when a %s dropdown is opened",
+            async (_label, isFilterable) => {
+                // Arrange
+                const {userEvent} = doRender(
+                    <SingleSelect
+                        onChange={onChange}
+                        placeholder="Choose"
+                        selectedValue="2"
+                        isFilterable={isFilterable}
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                    </SingleSelect>,
+                );
 
-            // Act
-            await userEvent.click(await screen.findByRole("combobox"));
+                // Act
+                await userEvent.click(await screen.findByRole("combobox"));
 
-            // Assert
-            expect(announceMessageSpy).toHaveBeenCalledWith({
-                message: "item 2",
-                level: "assertive",
-            });
-        });
-
-        it("should not announce when a filterable dropdown is opened", async () => {
-            // Arrange
-            const {userEvent} = doRender(
-                <SingleSelect
-                    onChange={onChange}
-                    placeholder="Choose"
-                    selectedValue="2"
-                    isFilterable={true}
-                >
-                    <OptionItem label="item 1" value="1" />
-                    <OptionItem label="item 2" value="2" />
-                </SingleSelect>,
-            );
-
-            // Act
-            await userEvent.click(await screen.findByRole("combobox"));
-
-            // Assert
-            expect(announceMessageSpy).not.toHaveBeenCalled();
-        });
+                // Assert
+                expect(announceMessageSpy).not.toHaveBeenCalled();
+            },
+        );
 
         it("should change the number of options after using the search filter", async () => {
             // Arrange
@@ -1334,7 +1317,7 @@ describe("SingleSelect", () => {
             // Assert
             await expect(announceMessageSpy).toHaveBeenCalledWith({
                 message: "1 item",
-                level: "assertive",
+                level: "polite",
             });
         });
     });

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -553,6 +553,7 @@ const MultiSelect = (props: Props) => {
     const handleAnnouncement = (message: string) => {
         announceMessage({
             message,
+            level: "assertive",
         });
     };
 
@@ -577,26 +578,38 @@ const MultiSelect = (props: Props) => {
         [selectedValues],
     );
 
+    // Refs so the announcement effect re-fires only on meaningful changes,
+    // not on every render caused by inline label object identity churn.
+    const childrenRef = React.useRef(children);
+    childrenRef.current = children;
+    const getMenuTextOrNodeRef = React.useRef(getMenuTextOrNode);
+    getMenuTextOrNodeRef.current = getMenuTextOrNode;
+    const maybeGetOpenerStringValueRef = React.useRef(
+        maybeGetOpenerStringValue,
+    );
+    maybeGetOpenerStringValueRef.current = maybeGetOpenerStringValue;
+
+    // Announces the opener value on open and after each selection change.
     React.useEffect(() => {
         if (isInitialRender.current) {
             isInitialRender.current = false;
             return;
         }
-
+        if (!open) {
+            return;
+        }
         const optionItems = React.Children.toArray(
-            children,
+            childrenRef.current,
         ) as OptionItemComponentArray;
-        const openerContent = getMenuTextOrNode(optionItems);
-        const openerStringValue = maybeGetOpenerStringValue(
+        const openerContent = getMenuTextOrNodeRef.current(optionItems);
+        const openerStringValue = maybeGetOpenerStringValueRef.current(
             optionItems,
             openerContent,
         );
-
         if (openerStringValue) {
-            // opener value changed, so let's announce it
             handleAnnouncement(openerStringValue);
         }
-    }, [children, getMenuTextOrNode, maybeGetOpenerStringValue]);
+    }, [open, selectedValues]);
 
     // If aria-required was supplied, use that. Otherwise, convert `required` to a boolean
     // and apply that value to aria-required.
@@ -666,9 +679,8 @@ const MultiSelect = (props: Props) => {
 
     const {clearSearch, filter, noResults, someSelected} = labels;
 
-    // Use a ref so the filter-count effect below only re-fires when the
-    // filtered item count or open state changes, not on every render caused
-    // by label prop object identity churn.
+    // Use refs so the effects below only re-fire when their relevant values
+    // change, not on every render caused by label prop object identity churn.
     const someSelectedRef = React.useRef(someSelected);
     someSelectedRef.current = someSelected;
 
@@ -684,14 +696,14 @@ const MultiSelect = (props: Props) => {
     const isDisabled = numEnabledOptions === 0 || disabled;
     const disableInteraction = isDisabled || readOnly;
 
-    // Announce the number of visible items when the dropdown opens or when
-    // the search filter changes. Selection-count announcements are handled
-    // separately by the opener-change effect above.
+    // Announces the filtered count when the search filter changes while open.
+    // Filtering only changes displayed options, not selectedValues, so this
+    // effect is separate from the selection/open effect above.
     React.useEffect(() => {
         if (open) {
             handleAnnouncement(someSelectedRef.current(filteredItems.length));
         }
-    }, [filteredItems.length, open, someSelectedRef]);
+    }, [filteredItems.length, someSelectedRef]); // eslint-disable-line react-hooks/exhaustive-deps
     return (
         <Id id={dropdownId}>
             {(uniqueDropdownId) => (

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -550,11 +550,8 @@ const MultiSelect = (props: Props) => {
         handleOpenChanged(!open);
     };
 
-    const handleAnnouncement = (
-        message: string,
-        level: "assertive" | "polite" = "assertive",
-    ) => {
-        announceMessage({message, level});
+    const handleAnnouncement = (message: string) => {
+        announceMessage({message, level: "polite"});
     };
 
     const maybeGetOpenerStringValue = React.useCallback(
@@ -578,10 +575,11 @@ const MultiSelect = (props: Props) => {
         [selectedValues],
     );
 
-    // Refs so the announcement effect re-fires only on meaningful changes,
-    // not on every render caused by inline label object identity churn.
     const prevOpenRef = React.useRef(open);
     const selectionChangedRef = React.useRef(false);
+    // Refs so announceOpenerValue always reads current values: the effect only
+    // re-runs on [selectedValues, open], so plain closure vars would be stale
+    // if children/labels change identity mid-session (parent re-renders).
     const childrenRef = React.useRef(children);
     childrenRef.current = children;
     const getMenuTextOrNodeRef = React.useRef(getMenuTextOrNode);
@@ -591,9 +589,7 @@ const MultiSelect = (props: Props) => {
     );
     maybeGetOpenerStringValueRef.current = maybeGetOpenerStringValue;
 
-    const announceOpenerValue = (
-        level: "assertive" | "polite" = "assertive",
-    ) => {
+    const announceOpenerValue = () => {
         const optionItems = React.Children.toArray(
             childrenRef.current,
         ) as OptionItemComponentArray;
@@ -603,14 +599,13 @@ const MultiSelect = (props: Props) => {
             openerContent,
         );
         if (openerStringValue) {
-            handleAnnouncement(openerStringValue, level);
+            handleAnnouncement(openerStringValue);
         }
     };
 
-    // Announces the opener value when selectedValues changes (while open),
-    // when the dropdown opens (VoiceOver/Safari workaround for stale combobox
-    // values, skipped for filterable dropdowns), or when the dropdown closes
-    // after a selection change.
+    // Announces the current selection when selectedValues changes while open,
+    // and when the dropdown closes after a selection change (polite workaround
+    // for VoiceOver/Safari caching a stale combobox value on close).
     React.useEffect(() => {
         if (isInitialRender.current) {
             isInitialRender.current = false;
@@ -621,26 +616,23 @@ const MultiSelect = (props: Props) => {
         const justClosed = !open && prevOpenRef.current;
         prevOpenRef.current = open;
         if (justOpened) {
+            // Intercept open transition so it doesn't fall into the selection
+            // branch below; reset so prior-session selections don't carry over.
             selectionChangedRef.current = false;
-            // don't announce when moving focus to input so we don't
-            // prevent other system announcements
-            if (!isFilterable) {
-                announceOpenerValue();
-            }
         } else if (justClosed) {
+            // Announce the final value on close — works around VoiceOver/Safari
+            // caching a stale combobox value when the dropdown closes.
             if (selectionChangedRef.current) {
-                // announce updated value politely to work around VO/Safari
-                // holding onto stale value, but not stomping over collapse
-                // announcement
-                announceOpenerValue("polite");
+                announceOpenerValue();
+                selectionChangedRef.current = false;
             }
         } else if (open) {
-            // announce changed values assertively to work around VO/Safari
-            // making confusing stale announcements on both the opener value
-            // and individual additions/removals in the listbox
+            // Selection changed while open — announce and track for close.
             selectionChangedRef.current = true;
             announceOpenerValue();
         }
+        // announceOpenerValue excluded from deps intentionally — it reads via refs
+        // to avoid re-firing on label identity churn (see comment above).
     }, [selectedValues, open]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // If aria-required was supplied, use that. Otherwise, convert `required` to a boolean

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -550,11 +550,11 @@ const MultiSelect = (props: Props) => {
         handleOpenChanged(!open);
     };
 
-    const handleAnnouncement = (message: string) => {
-        announceMessage({
-            message,
-            level: "assertive",
-        });
+    const handleAnnouncement = (
+        message: string,
+        level: "assertive" | "polite" = "assertive",
+    ) => {
+        announceMessage({message, level});
     };
 
     const maybeGetOpenerStringValue = React.useCallback(
@@ -581,6 +581,7 @@ const MultiSelect = (props: Props) => {
     // Refs so the announcement effect re-fires only on meaningful changes,
     // not on every render caused by inline label object identity churn.
     const prevOpenRef = React.useRef(open);
+    const selectionChangedRef = React.useRef(false);
     const childrenRef = React.useRef(children);
     childrenRef.current = children;
     const getMenuTextOrNodeRef = React.useRef(getMenuTextOrNode);
@@ -590,7 +591,9 @@ const MultiSelect = (props: Props) => {
     );
     maybeGetOpenerStringValueRef.current = maybeGetOpenerStringValue;
 
-    const announceOpenerValue = () => {
+    const announceOpenerValue = (
+        level: "assertive" | "polite" = "assertive",
+    ) => {
         const optionItems = React.Children.toArray(
             childrenRef.current,
         ) as OptionItemComponentArray;
@@ -600,14 +603,14 @@ const MultiSelect = (props: Props) => {
             openerContent,
         );
         if (openerStringValue) {
-            handleAnnouncement(openerStringValue);
+            handleAnnouncement(openerStringValue, level);
         }
     };
 
-    // Announces the opener value when selectedValues changes (while open) or
+    // Announces the opener value when selectedValues changes (while open),
     // when the dropdown opens (VoiceOver/Safari workaround for stale combobox
-    // values). Skips the open trigger for filterable dropdowns since focus moves
-    // to the search input there.
+    // values, skipped for filterable dropdowns), or when the dropdown closes
+    // after a selection change.
     React.useEffect(() => {
         if (isInitialRender.current) {
             isInitialRender.current = false;
@@ -615,8 +618,27 @@ const MultiSelect = (props: Props) => {
             return;
         }
         const justOpened = open && !prevOpenRef.current;
+        const justClosed = !open && prevOpenRef.current;
         prevOpenRef.current = open;
-        if (open && (!justOpened || !isFilterable)) {
+        if (justOpened) {
+            selectionChangedRef.current = false;
+            // don't announce when moving focus to input so we don't
+            // prevent other system announcements
+            if (!isFilterable) {
+                announceOpenerValue();
+            }
+        } else if (justClosed) {
+            if (selectionChangedRef.current) {
+                // announce updated value politely to work around VO/Safari
+                // holding onto stale value, but not stomping over collapse
+                // announcement
+                announceOpenerValue("polite");
+            }
+        } else if (open) {
+            // announce changed values assertively to work around VO/Safari
+            // making confusing stale announcements on both the opener value
+            // and individual additions/removals in the listbox
+            selectionChangedRef.current = true;
             announceOpenerValue();
         }
     }, [selectedValues, open]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -666,6 +666,12 @@ const MultiSelect = (props: Props) => {
 
     const {clearSearch, filter, noResults, someSelected} = labels;
 
+    // Use a ref so the filter-count effect below only re-fires when the
+    // filtered item count or open state changes, not on every render caused
+    // by label prop object identity churn.
+    const someSelectedRef = React.useRef(someSelected);
+    someSelectedRef.current = someSelected;
+
     const allChildren = (
         React.Children.toArray(children) as Array<
             React.ReactElement<React.ComponentProps<typeof OptionItem>>
@@ -678,11 +684,14 @@ const MultiSelect = (props: Props) => {
     const isDisabled = numEnabledOptions === 0 || disabled;
     const disableInteraction = isDisabled || readOnly;
 
+    // Announce the number of visible items when the dropdown opens or when
+    // the search filter changes. Selection-count announcements are handled
+    // separately by the opener-change effect above.
     React.useEffect(() => {
         if (open) {
-            handleAnnouncement(someSelected(filteredItems.length));
+            handleAnnouncement(someSelectedRef.current(filteredItems.length));
         }
-    }, [filteredItems.length, someSelected, open]);
+    }, [filteredItems.length, open, someSelectedRef]);
     return (
         <Id id={dropdownId}>
             {(uniqueDropdownId) => (

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -580,6 +580,7 @@ const MultiSelect = (props: Props) => {
 
     // Refs so the announcement effect re-fires only on meaningful changes,
     // not on every render caused by inline label object identity churn.
+    const prevOpenRef = React.useRef(open);
     const childrenRef = React.useRef(children);
     childrenRef.current = children;
     const getMenuTextOrNodeRef = React.useRef(getMenuTextOrNode);
@@ -589,15 +590,7 @@ const MultiSelect = (props: Props) => {
     );
     maybeGetOpenerStringValueRef.current = maybeGetOpenerStringValue;
 
-    // Announces the opener value on open and after each selection change.
-    React.useEffect(() => {
-        if (isInitialRender.current) {
-            isInitialRender.current = false;
-            return;
-        }
-        if (!open) {
-            return;
-        }
+    const announceOpenerValue = () => {
         const optionItems = React.Children.toArray(
             childrenRef.current,
         ) as OptionItemComponentArray;
@@ -609,7 +602,24 @@ const MultiSelect = (props: Props) => {
         if (openerStringValue) {
             handleAnnouncement(openerStringValue);
         }
-    }, [open, selectedValues]);
+    };
+
+    // Announces the opener value when selectedValues changes (while open) or
+    // when the dropdown opens (VoiceOver/Safari workaround for stale combobox
+    // values). Skips the open trigger for filterable dropdowns since focus moves
+    // to the search input there.
+    React.useEffect(() => {
+        if (isInitialRender.current) {
+            isInitialRender.current = false;
+            prevOpenRef.current = open;
+            return;
+        }
+        const justOpened = open && !prevOpenRef.current;
+        prevOpenRef.current = open;
+        if (open && (!justOpened || !isFilterable)) {
+            announceOpenerValue();
+        }
+    }, [selectedValues, open]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // If aria-required was supplied, use that. Otherwise, convert `required` to a boolean
     // and apply that value to aria-required.
@@ -696,11 +706,9 @@ const MultiSelect = (props: Props) => {
     const isDisabled = numEnabledOptions === 0 || disabled;
     const disableInteraction = isDisabled || readOnly;
 
-    // Announces the filtered count when the search filter changes while open.
-    // Filtering only changes displayed options, not selectedValues, so this
-    // effect is separate from the selection/open effect above.
+    // Announces the filtered count when the user types in the search field.
     React.useEffect(() => {
-        if (open) {
+        if (searchText) {
             handleAnnouncement(someSelectedRef.current(filteredItems.length));
         }
     }, [filteredItems.length, someSelectedRef]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -443,18 +443,17 @@ const SingleSelect = (props: Props) => {
     const handleAnnouncement = (message: string) => {
         announceMessage({
             message,
+            level: "assertive",
         });
     };
 
-    // Announce when selectedValue or children changes in the opener, but skip initial render
-    React.useEffect(() => {
-        if (isInitialRender.current) {
-            isInitialRender.current = false;
-            return;
-        }
+    const isInitialOpenRender = React.useRef(true);
+    const childrenRef = React.useRef(children);
+    childrenRef.current = children;
 
+    const announceSelectedItem = () => {
         const optionItems = React.Children.toArray(
-            children,
+            childrenRef.current,
         ) as OptionItemComponentArray;
         const selectedItem = optionItems.find(
             (option) => option.props.value === selectedValue,
@@ -465,7 +464,29 @@ const SingleSelect = (props: Props) => {
                 handleAnnouncement(label);
             }
         }
-    }, [selectedValue, children]);
+    };
+
+    // Announces the selected item's label after each selection change.
+    React.useEffect(() => {
+        if (isInitialRender.current) {
+            isInitialRender.current = false;
+            return;
+        }
+        announceSelectedItem();
+    }, [selectedValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // VoiceOver/Safari workaround: re-announces the current selection on open
+    // since VoiceOver may cache a stale combobox value. Skipped for filterable
+    // dropdowns where focus moves to the search input instead.
+    React.useEffect(() => {
+        if (isInitialOpenRender.current) {
+            isInitialOpenRender.current = false;
+            return;
+        }
+        if (open && !isFilterable) {
+            announceSelectedItem();
+        }
+    }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // If aria-required was supplied, use that. Otherwise, convert `required` to a boolean
     // and apply that value to aria-required.
@@ -557,18 +578,18 @@ const SingleSelect = (props: Props) => {
     const isDisabled = numEnabledOptions === 0 || disabled;
     const disableInteraction = isDisabled || readOnly;
 
-    // Extract out someResults. When we put labels in the dependency array,
-    // useEffect happens on every render (I think because labels is a new object)
-    // each time so it thinks it has changed
     const {someResults} = labels;
+    const someResultsRef = React.useRef(someResults);
+    someResultsRef.current = someResults;
+    const openRef = React.useRef(open);
+    openRef.current = open;
 
-    // Announce in a screen reader when the number of filtered items changes
-    // when the dropdown is open
+    // Announces the filtered count when the search filter changes while open.
     React.useEffect(() => {
-        if (open) {
-            handleAnnouncement(someResults(items.length));
+        if (openRef.current) {
+            handleAnnouncement(someResultsRef.current(items.length));
         }
-    }, [items.length, someResults, open]);
+    }, [items.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return (
         <Id id={dropdownId}>

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -441,13 +441,9 @@ const SingleSelect = (props: Props) => {
     };
 
     const handleAnnouncement = (message: string) => {
-        announceMessage({
-            message,
-            level: "assertive",
-        });
+        announceMessage({message, level: "polite"});
     };
 
-    const isInitialOpenRender = React.useRef(true);
     const childrenRef = React.useRef(children);
     childrenRef.current = children;
 
@@ -474,19 +470,6 @@ const SingleSelect = (props: Props) => {
         }
         announceSelectedItem();
     }, [selectedValue]); // eslint-disable-line react-hooks/exhaustive-deps
-
-    // VoiceOver/Safari workaround: re-announces the current selection on open
-    // since VoiceOver may cache a stale combobox value. Skipped for filterable
-    // dropdowns where focus moves to the search input instead.
-    React.useEffect(() => {
-        if (isInitialOpenRender.current) {
-            isInitialOpenRender.current = false;
-            return;
-        }
-        if (open && !isFilterable) {
-            announceSelectedItem();
-        }
-    }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // If aria-required was supplied, use that. Otherwise, convert `required` to a boolean
     // and apply that value to aria-required.


### PR DESCRIPTION
## Summary:

Fix screen reader announcements in MultiSelect and SingleSelect

Several live region announcement bugs are fixed, plus a VoiceOver/Safari workaround for stale combobox values:

- **Wrong item count announced on selection** — the MultiSelect component was announcing total visible options instead of selected count, caused by `labels` prop object identity churn re-firing the effect on every parent render
- **Neighboring MultiSelect announcing on unrelated interactions** — same root cause; inline label objects recreating on parent re-renders triggered announcement effects in unrelated selects on the same page
- **VoiceOver caching a stale combobox value on re-open** — both components make a `polite` announcement of the current selection when a non-filterable dropdown opens
- **Close announcement** — MultiSelecs makes a `polite` announcement of the final selection state when the dropdown closes after a selection change
- Equivalent fixes applied to SingleSelect where applicable. 
- New unit tests and a two-select playtesting story are included, to test the neighboring announcement issue.

Issue: WB-2383

## Test plan:
1. Ensure tests pass
2. Review stories with VoiceOver running: 
   - `/?path=/story/packages-dropdown-testing-snapshots-multiselect--scenarios&globals=theme:thunderblocks`
   - `/?path=/story/packages-dropdown-multiselect--two-multi-selects`
3. Compare to PROD