### PR TITLE
Update media-query tokens to fix bugs and cover full range of widths

### DIFF
--- a/.changeset/eighty-suns-taste.md
+++ b/.changeset/eighty-suns-taste.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Update media-query breakpoint and constant tokens to cover full range of widths

--- a/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
+++ b/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
@@ -128,18 +128,21 @@ import {breakpoint} from "@khanacademy/wonder-blocks-tokens";
 | \`breakpoint.width.mdMin\` | \`682\` |
 | \`breakpoint.width.mdMax\` | \`1023\` |
 | \`breakpoint.width.lgMin\` | \`1024\` |
+| \`breakpoint.width.lgMax\` | \`1199\` |
+| \`breakpoint.width.xlMin\` | \`1200\` |
 | \`breakpoint.mediaQuery.xs\` | \`@media screen and (max-width: 567px) /* breakpoint.mediaQuery.xs */\` |
 | \`breakpoint.mediaQuery.sm\` | \`@media screen and (min-width: 568px) and (max-width: 681px) /* breakpoint.mediaQuery.sm */\` |
 | \`breakpoint.mediaQuery.md\` | \`@media screen and (min-width: 682px) and (max-width: 1023px) /* breakpoint.mediaQuery.md */\` |
-| \`breakpoint.mediaQuery.lg\` | \`@media screen and (min-width: 682px) and (max-width: 1024px) /* breakpoint.mediaQuery.lg */\` |
-| \`breakpoint.mediaQuery.xl\` | \`@media screen and (min-width: 1024px) /* breakpoint.mediaQuery.xl */\` |
+| \`breakpoint.mediaQuery.lg\` | \`@media screen and (min-width: 1024px) and (max-width: 1199px) /* breakpoint.mediaQuery.lg */\` |
+| \`breakpoint.mediaQuery.xl\` | \`@media screen and (min-width: 1200px) /* breakpoint.mediaQuery.xl */\` |
 | \`breakpoint.mediaQuery.xsOrSmaller\` | \`@media screen and (max-width: 567px) /* breakpoint.mediaQuery.xsOrSmaller */\` |
 | \`breakpoint.mediaQuery.smOrSmaller\` | \`@media screen and (max-width: 681px) /* breakpoint.mediaQuery.smOrSmaller */\` |
 | \`breakpoint.mediaQuery.mdOrSmaller\` | \`@media screen and (max-width: 1023px) /* breakpoint.mediaQuery.mdOrSmaller */\` |
-| \`breakpoint.mediaQuery.lgOrSmaller\` | \`@media screen and (max-width: 1024px) /* breakpoint.mediaQuery.lgOrSmaller */\` |
+| \`breakpoint.mediaQuery.lgOrSmaller\` | \`@media screen and (max-width: 1199px) /* breakpoint.mediaQuery.lgOrSmaller */\` |
 | \`breakpoint.mediaQuery.smOrLarger\` | \`@media screen and (min-width: 568px) /* breakpoint.mediaQuery.smOrLarger */\` |
 | \`breakpoint.mediaQuery.mdOrLarger\` | \`@media screen and (min-width: 682px) /* breakpoint.mediaQuery.mdOrLarger */\` |
 | \`breakpoint.mediaQuery.lgOrLarger\` | \`@media screen and (min-width: 1024px) /* breakpoint.mediaQuery.lgOrLarger */\` |
+| \`breakpoint.mediaQuery.xlOrLarger\` | \`@media screen and (min-width: 1200px) /* breakpoint.mediaQuery.xlOrLarger */\` |
 "
 `;
 

--- a/packages/wonder-blocks-tokens/src/tokens/media-queries.ts
+++ b/packages/wonder-blocks-tokens/src/tokens/media-queries.ts
@@ -13,6 +13,8 @@ const width = {
     mdMin: 682,
     mdMax: 1023,
     lgMin: 1024,
+    lgMax: 1199,
+    xlMin: 1200,
 } as const;
 
 /* Named mediaQuery conditions */
@@ -21,17 +23,18 @@ const mediaQuery = {
     xs: `@media screen and (max-width: ${width.xsMax}px) /* breakpoint.mediaQuery.xs */`,
     sm: `@media screen and (min-width: ${width.smMin}px) and (max-width: ${width.smMax}px) /* breakpoint.mediaQuery.sm */`,
     md: `@media screen and (min-width: ${width.mdMin}px) and (max-width: ${width.mdMax}px) /* breakpoint.mediaQuery.md */`,
-    lg: `@media screen and (min-width: ${width.mdMin}px) and (max-width: ${width.lgMin}px) /* breakpoint.mediaQuery.lg */`,
-    xl: `@media screen and (min-width: ${width.lgMin}px) /* breakpoint.mediaQuery.xl */`,
+    lg: `@media screen and (min-width: ${width.lgMin}px) and (max-width: ${width.lgMax}px) /* breakpoint.mediaQuery.lg */`,
+    xl: `@media screen and (min-width: ${width.xlMin}px) /* breakpoint.mediaQuery.xl */`,
 
     xsOrSmaller: `@media screen and (max-width: ${width.xsMax}px) /* breakpoint.mediaQuery.xsOrSmaller */`,
     smOrSmaller: `@media screen and (max-width: ${width.smMax}px) /* breakpoint.mediaQuery.smOrSmaller */`,
     mdOrSmaller: `@media screen and (max-width: ${width.mdMax}px) /* breakpoint.mediaQuery.mdOrSmaller */`,
-    lgOrSmaller: `@media screen and (max-width: ${width.lgMin}px) /* breakpoint.mediaQuery.lgOrSmaller */`,
+    lgOrSmaller: `@media screen and (max-width: ${width.lgMax}px) /* breakpoint.mediaQuery.lgOrSmaller */`,
 
     smOrLarger: `@media screen and (min-width: ${width.smMin}px) /* breakpoint.mediaQuery.smOrLarger */`,
     mdOrLarger: `@media screen and (min-width: ${width.mdMin}px) /* breakpoint.mediaQuery.mdOrLarger */`,
     lgOrLarger: `@media screen and (min-width: ${width.lgMin}px) /* breakpoint.mediaQuery.lgOrLarger */`,
+    xlOrLarger: `@media screen and (min-width: ${width.xlMin}px) /* breakpoint.mediaQuery.xlOrLarger */`,
 } as const;
 
 export const breakpoint = {

--- a/types/aphrodite.d.ts
+++ b/types/aphrodite.d.ts
@@ -9,9 +9,9 @@ declare module "aphrodite" {
     const md =
         "@media screen and (min-width: 682px) and (max-width: 1023px) /* breakpoint.mediaQuery.md */";
     const lg =
-        "@media screen and (min-width: 682px) and (max-width: 1024px) /* breakpoint.mediaQuery.lg */";
+        "@media screen and (min-width: 1024px) and (max-width: 1199px) /* breakpoint.mediaQuery.lg */";
     const xl =
-        "@media screen and (min-width: 1024px) /* breakpoint.mediaQuery.xl */";
+        "@media screen and (min-width: 1200px) /* breakpoint.mediaQuery.xl */";
     const xsOrSmaller =
         "@media screen and (max-width: 567px) /* breakpoint.mediaQuery.xsOrSmaller */";
     const smOrSmaller =
@@ -19,13 +19,15 @@ declare module "aphrodite" {
     const mdOrSmaller =
         "@media screen and (max-width: 1023px) /* breakpoint.mediaQuery.mdOrSmaller */";
     const lgOrSmaller =
-        "@media screen and (min-width: 1024px) /* breakpoint.mediaQuery.lgOrLarger */";
+        "@media screen and (max-width: 1199px) /* breakpoint.mediaQuery.lgOrSmaller */";
     const smOrLarger =
         "@media screen and (min-width: 568px) /* breakpoint.mediaQuery.smOrLarger */";
     const mdOrLarger =
         "@media screen and (min-width: 682px) /* breakpoint.mediaQuery.mdOrLarger */";
     const lgOrLarger =
         "@media screen and (min-width: 1024px) /* breakpoint.mediaQuery.lgOrLarger */";
+    const xlOrLarger =
+        "@media screen and (min-width: 1200px) /* breakpoint.mediaQuery.xlOrLarger */";
 
     type _CSSProperties = React.CSSProperties & {
         /**


### PR DESCRIPTION
## Summary:
The `wonder-blocks-tokens` breakpoint definitions had bugs introduced when ported from `frontend`, that this PR aims to fix.

- The `lg` query was defined using `mdMin` and `lgMin` instead of `lgMin` and `lgMax`, making it overlap with `md` rather than span the large breakpoint. 
- The `xl` query reused `lgMin` instead of `xlMin`, making it identical to `lgOrLarger`.
- The `lgOrSmaller` query also used `lgMin` as its upper bound, cutting off at the start of the large breakpoint instead of the end.
    - As a result, screens between `1024–1199px` were treated as larger than "lg or smaller," causing potential layout bugs in 19 call sites in `frontend`.
- `lgMax` and `xlMin` were never defined in the `width` constants, making the wrong values easy to reach for during the port.

Issue: WB-2384

## Test plan:
1. Ensure linting passes
2. Review mediaQuery docs: `?path=/docs/packages-tokens-media-query-breakpoints--docs`
3. Test usage in `frontend` (WIP)