### PR TITLE
Fix playwright browsers install

### DIFF
--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -104,7 +104,8 @@ jobs:
                   # registry.npmjs.org: npm package registry for pnpm install
                   # playwright.download.prss.microsoft.com: Playwright browser binary downloads
                   # cdn.playwright.dev: Playwright browser binary CDN
-                  extra-domains: registry.npmjs.org playwright.download.prss.microsoft.com cdn.playwright.dev
+                  # storage.googleapis.com: cdn.playwright.dev returns a 307 redirect to storage.googleapis.com for downloads, so we need to allowlist that too.
+                  extra-domains: registry.npmjs.org playwright.download.prss.microsoft.com cdn.playwright.dev storage.googleapis.com
 
             - name: Use Node.js 24.x
               uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary:

Add `storage.googleapis.com` to sandboxing so that playwright can be installed for the `Run Storybook tests` check.

The original error message:
```
Downloading Chromium 143.0.7499.4 (playwright build v1200) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1200/chromium-linux.zip
Error: getaddrinfo EAI_AGAIN storage.googleapis.com
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:internal/dns/promises:101:17) {
  errno: -3001,
  code: 'EAI_AGAIN',
  syscall: 'getaddrinfo',
  hostname: 'storage.googleapis.com'
}
```

Confirmed that https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1200/chromium-linux.zip responds with a 307 redirect to `storage.googleapis.com` 

<img width="953" height="559" alt="Screenshot 2026-06-25 at 1 01 39 PM" src="https://github.com/user-attachments/assets/6514993d-e123-4f40-acb6-e5e310898dc0" />

<img width="949" height="756" alt="Screenshot 2026-06-25 at 1 01 53 PM" src="https://github.com/user-attachments/assets/59f06608-a3d2-4d09-9cfd-f9e7e0e2fbc0" />


Issue: WB-2385


## Test plan:

Confirm checks pass