### PR TITLE
Fix playwright browsers install in CI

### DIFF
--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -87,14 +87,16 @@ jobs:
         strategy:
             fail-fast: false
         steps:
-            # Install Playwright system dependencies before checkout/secure-network
+            # Install Playwright system dependencies and browsers before checkout/secure-network
             # so we don't need to allowlist Ubuntu package domains.
             - name: Install Playwright dependencies
               timeout-minutes: 5
               run: |
                   sudo apt-get update
                   sudo apt-get install -y fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei fonts-tlwg-loma-otf fonts-freefont-ttf
-
+            - name: Install Playwright browsers
+              timeout-minutes: 5
+              run: pnpm exec playwright install chromium
             - name: Checking out latest commit
               uses: actions/checkout@v5
             - name: Secure Network
@@ -117,10 +119,6 @@ jobs:
               timeout-minutes: 5
               with:
                   node-version: 24.x
-
-            - name: Install Playwright browsers
-              timeout-minutes: 5
-              run: pnpm exec playwright install chromium
 
             # Build the project
             - name: Generate WB build artifacts


### PR DESCRIPTION
## Summary:

Previously, we were getting the error:

```
Downloading Chromium 143.0.7499.4 (playwright build v1200) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1200/chromium-linux.zip
Error: getaddrinfo EAI_AGAIN storage.googleapis.com
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:internal/dns/promises:101:17) {
  errno: -3001,
  code: 'EAI_AGAIN',
  syscall: 'getaddrinfo',
  hostname: 'storage.googleapis.com'
}
```
Example: https://github.com/Khan/wonder-blocks/actions/runs/28185942242/job/83489438219?pr=3121

This was because the playwright cdn returns a 307 redirect to storage.googleapis.com, which is not part of the sandbox allowlist currently.

Now, we install the playwright browsers before the secure-network step, similar to how we were installing playwright dependencies before that step

(Alternative solution we explored was https://github.com/Khan/wonder-blocks/pull/3127 , where we update the extra domains. We went with changing the order of steps to be consistent with how we install playwright deps)

Issue: WB-2385

## Test plan:

Checks pass