### PR TITLE
FEI-7954: Enforce mutual exclusivity of location and initialEntries in router adapter

### DIFF
--- a/.changeset/grumpy-suns-attack.md
+++ b/.changeset/grumpy-suns-attack.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing-core": patch
+---
+
+Router test harness adapter: make the context-mode `location` and `initialEntries` config options mutually exclusive at the type level. Previously this exclusivity relied on union excess-property checking, which TypeScript 6.0 relaxed; it is now enforced structurally with `never` guards (mirroring the existing data-routes guards) so combining the two shapes is a hard type error under both TypeScript 5.7 and 6.0.

--- a/consistency-tests/__tests__/clickables.test.tsx
+++ b/consistency-tests/__tests__/clickables.test.tsx
@@ -123,6 +123,7 @@ describe.each`
         // Note: window.location.assign and window.open need mock functions in
         // the testing environment, but JSDOM protects assign from being changed
         // so we need to replace the whole location object.
+        // @ts-expect-error [FEI-5019] - TS2322 - Type '{ assign: Mock<any, any, any>; ... }' is not assignable to type 'string & Location'.
         window.location = {...window.location, assign: jest.fn()};
         window.open = jest.fn();
     });

--- a/consistency-tests/__tests__/clickables.test.tsx
+++ b/consistency-tests/__tests__/clickables.test.tsx
@@ -122,9 +122,10 @@ describe.each`
     beforeEach(() => {
         // Note: window.location.assign and window.open need mock functions in
         // the testing environment, but JSDOM protects assign from being changed
-        // so we need to replace the whole location object.
-        // @ts-expect-error [FEI-5019] - TS2322 - Type '{ assign: Mock<any, any, any>; ... }' is not assignable to type 'string & Location'.
-        window.location = {...window.location, assign: jest.fn()};
+        // so we need to replace the whole location object. The DOM types don't
+        // allow reassigning `window.location`, so cast the replacement (a
+        // targeted cast rather than an `@ts-expect-error` line suppression).
+        window.location = {...window.location, assign: jest.fn()} as any;
         window.open = jest.fn();
     });
 

--- a/consistency-tests/__tests__/tsconfig-shared-types.test.ts
+++ b/consistency-tests/__tests__/tsconfig-shared-types.test.ts
@@ -1,0 +1,73 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import * as ts from "typescript";
+
+/**
+ * `packages/tsconfig-shared.json` is extended (via `extends`) by every
+ * package's declaration build (`tsconfig-build.json`), and it pins an explicit
+ * `compilerOptions.types` array.
+ *
+ * This pin is required because TypeScript 6.0 changed the default `types` value
+ * to `[]`, so the composite `build:types` step no longer auto-includes the
+ * `@types/*` global type packages (`@types/node`, `@types/jest`, ...).
+ *
+ * `pnpm typecheck` (the root `tsconfig.json`) does NOT extend
+ * `tsconfig-shared.json` and still auto-resolves every `@types/*` package, so a
+ * missing entry in the pinned list passes `typecheck` but breaks `build:types`
+ * (and therefore publishing) with a "Cannot find name ..." error. This test
+ * keeps the pinned list in sync with the repo's declared `@types/*`
+ * dependencies so that divergence cannot silently regress.
+ */
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+/**
+ * Read `compilerOptions.types` from a tsconfig file, tolerating JSONC (comments
+ * and trailing commas) the way the TypeScript compiler does.
+ */
+const readPinnedTypes = (tsconfigPath: string): Array<string> => {
+    const text = fs.readFileSync(tsconfigPath, "utf8");
+    const {config, error} = ts.parseConfigFileTextToJson(tsconfigPath, text);
+    if (error) {
+        throw new Error(
+            `Failed to parse ${tsconfigPath}: ` +
+                ts.flattenDiagnosticMessageText(error.messageText, "\n"),
+        );
+    }
+    return config?.compilerOptions?.types ?? [];
+};
+
+/**
+ * The `@types/*` packages declared in the root `package.json`, with the
+ * `@types/` prefix stripped (e.g. `@types/node` -> `node`).
+ */
+const getTypesPackageNames = (): Array<string> => {
+    const pkg = JSON.parse(
+        fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+    );
+    const allDeps = {
+        ...(pkg.dependencies ?? {}),
+        ...(pkg.devDependencies ?? {}),
+    };
+    return Object.keys(allDeps)
+        .filter((name) => name.startsWith("@types/"))
+        .map((name) => name.slice("@types/".length));
+};
+
+describe("packages/tsconfig-shared.json `types`", () => {
+    it("lists exactly the repo's `@types/*` dependencies", () => {
+        // Arrange
+        const expected = getTypesPackageNames().sort();
+
+        // Act
+        const actual = readPinnedTypes(
+            path.join(repoRoot, "packages", "tsconfig-shared.json"),
+        ).sort();
+
+        // Assert
+        // If this fails, add the missing `@types/*` package(s) to the `types`
+        // array in packages/tsconfig-shared.json (or remove stale entries).
+        // Otherwise `build:types` will fail even though `pnpm typecheck` passes.
+        expect(actual).toEqual(expected);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "swc_mut_cjs_exports": "^10.7.0",
     "tstyche": "^7.0.0",
     "turbo": "^2.5.3",
-    "typescript": "5.7.3",
+    "typescript": "6.0.3",
     "typescript-coverage-report": "^1.1.0",
     "vite": "^6.0.11",
     "vitest": "^4.0.15"

--- a/packages/tsconfig-shared.json
+++ b/packages/tsconfig-shared.json
@@ -12,6 +12,12 @@
         // list them explicitly here to keep them in scope when emitting
         // declarations. (The root `tsconfig.json` used by `typecheck` does not
         // extend this file, so its behaviour is unaffected.)
+        //
+        // KEEP IN SYNC: this list must include every `@types/*` package whose
+        // globals are used by package source. Because `typecheck` still
+        // auto-resolves all `@types/*`, a missing entry here passes `typecheck`
+        // but fails `build:types` with "Cannot find name ...". When adding a
+        // new global-providing `@types/*` dependency, add it here too.
         "types": [
             "aria-query",
             "history",

--- a/packages/tsconfig-shared.json
+++ b/packages/tsconfig-shared.json
@@ -6,6 +6,27 @@
         "composite": true,
         "incremental": true, // Required for composite projects
 
+        // TypeScript 6.0 changed the default `types` value from "include every
+        // `@types/*` package" to `[]`. Composite builds no longer auto-include
+        // the global type packages (e.g. `@types/node`, `@types/jest`), so we
+        // list them explicitly here to keep them in scope when emitting
+        // declarations. (The root `tsconfig.json` used by `typecheck` does not
+        // extend this file, so its behaviour is unaffected.)
+        "types": [
+            "aria-query",
+            "history",
+            "jest",
+            "jest-axe",
+            "jscodeshift",
+            "node",
+            "node-fetch",
+            "react",
+            "react-dom",
+            "react-router",
+            "react-router-dom",
+            "react-window",
+        ],
+
         // We use rollup + swc to compile our bundles so we only need tsc to
         // output .d.ts files
         "declaration": true,

--- a/packages/tsconfig-shared.json
+++ b/packages/tsconfig-shared.json
@@ -13,11 +13,11 @@
         // declarations. (The root `tsconfig.json` used by `typecheck` does not
         // extend this file, so its behaviour is unaffected.)
         //
-        // KEEP IN SYNC: this list must include every `@types/*` package whose
-        // globals are used by package source. Because `typecheck` still
-        // auto-resolves all `@types/*`, a missing entry here passes `typecheck`
-        // but fails `build:types` with "Cannot find name ...". When adding a
-        // new global-providing `@types/*` dependency, add it here too.
+        // This list must stay in sync with the repo's `@types/*` dependencies:
+        // because `typecheck` still auto-resolves all `@types/*`, a missing
+        // entry here passes `typecheck` but fails `build:types`. The test in
+        // consistency-tests/__tests__/tsconfig-shared-types.test.ts enforces
+        // this.
         "types": [
             "aria-query",
             "history",

--- a/packages/wonder-blocks-button/src/components/__tests__/button.test.tsx
+++ b/packages/wonder-blocks-button/src/components/__tests__/button.test.tsx
@@ -19,8 +19,10 @@ describe("Button", () => {
     });
 
     afterAll(() => {
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'Location' is not assignable to type 'string & Location'.
-        window.location = location;
+        // The DOM types treat `window.location` as non-reassignable, so cast
+        // the saved value to restore it (a targeted cast rather than an
+        // `@ts-expect-error` that would suppress the whole line).
+        window.location = location as any;
     });
 
     describe("attributes", () => {

--- a/packages/wonder-blocks-button/src/components/__tests__/button.test.tsx
+++ b/packages/wonder-blocks-button/src/components/__tests__/button.test.tsx
@@ -19,6 +19,7 @@ describe("Button", () => {
     });
 
     afterAll(() => {
+        // @ts-expect-error [FEI-5019] - TS2322 - Type 'Location' is not assignable to type 'string & Location'.
         window.location = location;
     });
 

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-unstyled.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-unstyled.test.tsx
@@ -20,8 +20,10 @@ describe("IconButtonUnstyled", () => {
     });
 
     afterAll(() => {
-        // @ts-expect-error [FEI-5019] - TS2322 - Type 'Location' is not assignable to type 'string & Location'.
-        window.location = location;
+        // The DOM types treat `window.location` as non-reassignable, so cast
+        // the saved value to restore it (a targeted cast rather than an
+        // `@ts-expect-error` that would suppress the whole line).
+        window.location = location as any;
     });
 
     test("render a span containing the reference to the icon", async () => {

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-unstyled.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-unstyled.test.tsx
@@ -20,6 +20,7 @@ describe("IconButtonUnstyled", () => {
     });
 
     afterAll(() => {
+        // @ts-expect-error [FEI-5019] - TS2322 - Type 'Location' is not assignable to type 'string & Location'.
         window.location = location;
     });
 

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.typestest.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.typestest.tsx
@@ -60,4 +60,18 @@ describe("router adapter config", () => {
         // @ts-expect-error: is not assignable to type 'undefined'
         adapter(null, {path: "/math/*", routes: [{path: "/"}]});
     });
+
+    it("should reject combining location with initialEntries", () => {
+        // @ts-expect-error: is not assignable to type 'undefined'
+        adapter(null, {location: "/math", initialEntries: ["/math"]});
+    });
+
+    it("should reject combining forceStatic location with initialEntries", () => {
+        adapter(null, {
+            location: "/math",
+            forceStatic: true,
+            // @ts-expect-error: is not assignable to type 'undefined'
+            initialEntries: ["/math"],
+        });
+    });
 });

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.typestest.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.typestest.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import {describe, it} from "tstyche";
+import {describe, expect, it} from "tstyche";
 
 import {adapter} from "../router";
+import type {Config} from "../router";
 
 describe("router adapter config", () => {
     it("should accept a context-mode location string", () => {
@@ -73,5 +74,74 @@ describe("router adapter config", () => {
             // @ts-expect-error: is not assignable to type 'undefined'
             initialEntries: ["/math"],
         });
+    });
+});
+
+/**
+ * These assertions check the exported `Config` type directly (rather than
+ * through the `adapter` call site). They exercise structural assignability,
+ * which - unlike passing a fresh object literal as a function argument - does
+ * NOT rely on excess-property checking. That is exactly the guarantee TS 6.0
+ * weakened, so these are the regression tests for the `NotLocation` /
+ * `NotInitialEntries` / `NotDataRoutes` `never` guards that make `Config` a
+ * disjoint union.
+ */
+describe("Config (disjoint union)", () => {
+    it("accepts a bare location string", () => {
+        expect("/math").type.toBeAssignableTo<Config>();
+    });
+
+    it("accepts a location object", () => {
+        expect({location: "/math"}).type.toBeAssignableTo<Config>();
+    });
+
+    it("accepts a forceStatic location object", () => {
+        expect({
+            location: "/math",
+            forceStatic: true,
+        } as const).type.toBeAssignableTo<Config>();
+    });
+
+    it("accepts an initialEntries object", () => {
+        expect({initialEntries: ["/math"]}).type.toBeAssignableTo<Config>();
+    });
+
+    it("accepts a data-routes object", () => {
+        expect({routes: [{path: "/"}]}).type.toBeAssignableTo<Config>();
+    });
+
+    it("accepts data-routes combined with initialEntries", () => {
+        expect({
+            routes: [{path: "/"}],
+            initialEntries: ["/"],
+        }).type.toBeAssignableTo<Config>();
+    });
+
+    it("rejects combining location with initialEntries", () => {
+        expect({
+            location: "/math",
+            initialEntries: ["/math"],
+        }).type.not.toBeAssignableTo<Config>();
+    });
+
+    it("rejects combining location with data-routes routes", () => {
+        expect({
+            location: "/math",
+            routes: [{path: "/"}],
+        }).type.not.toBeAssignableTo<Config>();
+    });
+
+    it("rejects combining context-mode path with data-routes routes", () => {
+        expect({
+            path: "/math/*",
+            routes: [{path: "/"}],
+        }).type.not.toBeAssignableTo<Config>();
+    });
+
+    it("rejects combining location with data-routes hydrationData", () => {
+        expect({
+            location: "/math",
+            hydrationData: {loaderData: {}},
+        }).type.not.toBeAssignableTo<Config>();
     });
 });

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.typestest.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/__tests__/router.typestest.tsx
@@ -62,19 +62,8 @@ describe("router adapter config", () => {
         adapter(null, {path: "/math/*", routes: [{path: "/"}]});
     });
 
-    it("should reject combining location with initialEntries", () => {
-        // @ts-expect-error: is not assignable to type 'undefined'
-        adapter(null, {location: "/math", initialEntries: ["/math"]});
-    });
-
-    it("should reject combining forceStatic location with initialEntries", () => {
-        adapter(null, {
-            location: "/math",
-            forceStatic: true,
-            // @ts-expect-error: is not assignable to type 'undefined'
-            initialEntries: ["/math"],
-        });
-    });
+    // NOTE: the `location`-vs-`initialEntries` exclusivity is covered without
+    // suppressions in the "Config (disjoint union)" suite below.
 });
 
 /**
@@ -122,6 +111,14 @@ describe("Config (disjoint union)", () => {
             location: "/math",
             initialEntries: ["/math"],
         }).type.not.toBeAssignableTo<Config>();
+    });
+
+    it("rejects combining forceStatic location with initialEntries", () => {
+        expect({
+            location: "/math",
+            forceStatic: true,
+            initialEntries: ["/math"],
+        } as const).type.not.toBeAssignableTo<Config>();
     });
 
     it("rejects combining location with data-routes routes", () => {

--- a/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
+++ b/packages/wonder-blocks-testing-core/src/harness/adapters/router.tsx
@@ -46,6 +46,30 @@ type NotDataRoutes = {
 };
 
 /**
+ * Key that only exists in the MemoryRouter (`initialEntries`) context mode.
+ *
+ * Forbidden (typed as `never`) in the `location` context modes so the two
+ * context-mode shapes can never be combined: passing `initialEntries`
+ * alongside a `location` is a type error.
+ *
+ * TS 6.0 relaxed union excess-property checking, so this exclusivity must be
+ * enforced structurally rather than relying on excess-property errors.
+ */
+type NotInitialEntries = {
+    initialEntries?: never;
+};
+
+/**
+ * Key that only exists in the `location` context modes.
+ *
+ * Forbidden (typed as `never`) in the `initialEntries` context mode for the
+ * same reason as `NotInitialEntries`.
+ */
+type NotLocation = {
+    location?: never;
+};
+
+/**
  * Configuration for the data-routes mode of the `router` adapter.
  *
  * Selected by the presence of `routes`. Renders a RR v6 data router
@@ -123,80 +147,83 @@ type DataRoutesConfig = {
  */
 export type Config =
     | Readonly<
-          | (NotDataRoutes & {
-                /**
-                 * See MemoryRouter prop for initialEntries.
-                 */
-                initialEntries: MemoryRouterProps["initialEntries"];
-                /**
-                 * See MemoryRouter prop for initialIndex.
-                 */
-                initialIndex?: MemoryRouterProps["initialIndex"];
-                /**
-                 * A path match to use.
-                 *
-                 * When this is specified, the harnessed component will be
-                 * rendered inside a `Route` handler with this path.
-                 *
-                 * If the path matches the location, then the route will
-                 * render the component.
-                 *
-                 * If the path does not match the location, then the route
-                 * will not render the component.
-                 */
-                path?: string;
-            })
-          | (NotDataRoutes & {
-                /**
-                 * The location to use.
-                 */
-                location: LocationDescriptor;
-                /**
-                 * Force the use of a StaticRouter, instead of MemoryRouter.
-                 */
-                forceStatic: true;
-                /**
-                 * If true, then we will not use a CompatRouter.
-                 *
-                 * NOTE(john): There are cases where we don't want a CompatRouter
-                 * here as it uses useLayoutEffect, which causes issues in our
-                 * test environment. Namely, that it generates a warning about
-                 * the use of useLayoutEffect, which causes an error.
-                 */
-                disableCompatRouter?: boolean;
-                /**
-                 * A path match to use.
-                 *
-                 * When this is specified, the harnessed component will be
-                 * rendered inside a `Route` handler with this path.
-                 *
-                 * If the path matches the location, then the route will
-                 * render the component.
-                 *
-                 * If the path does not match the location, then the route
-                 * will not render the component.
-                 */
-                path?: string;
-            })
-          | (NotDataRoutes & {
-                /**
-                 * The initial location to use.
-                 */
-                location: LocationDescriptor;
-                /**
-                 * A path match to use.
-                 *
-                 * When this is specified, the harnessed component will be
-                 * rendered inside a `Route` handler with this path.
-                 *
-                 * If the path matches the location, then the route will
-                 * render the component.
-                 *
-                 * If the path does not match the location, then the route
-                 * will not render the component.
-                 */
-                path?: string;
-            })
+          | (NotDataRoutes &
+                NotLocation & {
+                    /**
+                     * See MemoryRouter prop for initialEntries.
+                     */
+                    initialEntries: MemoryRouterProps["initialEntries"];
+                    /**
+                     * See MemoryRouter prop for initialIndex.
+                     */
+                    initialIndex?: MemoryRouterProps["initialIndex"];
+                    /**
+                     * A path match to use.
+                     *
+                     * When this is specified, the harnessed component will be
+                     * rendered inside a `Route` handler with this path.
+                     *
+                     * If the path matches the location, then the route will
+                     * render the component.
+                     *
+                     * If the path does not match the location, then the route
+                     * will not render the component.
+                     */
+                    path?: string;
+                })
+          | (NotDataRoutes &
+                NotInitialEntries & {
+                    /**
+                     * The location to use.
+                     */
+                    location: LocationDescriptor;
+                    /**
+                     * Force the use of a StaticRouter, instead of MemoryRouter.
+                     */
+                    forceStatic: true;
+                    /**
+                     * If true, then we will not use a CompatRouter.
+                     *
+                     * NOTE(john): There are cases where we don't want a CompatRouter
+                     * here as it uses useLayoutEffect, which causes issues in our
+                     * test environment. Namely, that it generates a warning about
+                     * the use of useLayoutEffect, which causes an error.
+                     */
+                    disableCompatRouter?: boolean;
+                    /**
+                     * A path match to use.
+                     *
+                     * When this is specified, the harnessed component will be
+                     * rendered inside a `Route` handler with this path.
+                     *
+                     * If the path matches the location, then the route will
+                     * render the component.
+                     *
+                     * If the path does not match the location, then the route
+                     * will not render the component.
+                     */
+                    path?: string;
+                })
+          | (NotDataRoutes &
+                NotInitialEntries & {
+                    /**
+                     * The initial location to use.
+                     */
+                    location: LocationDescriptor;
+                    /**
+                     * A path match to use.
+                     *
+                     * When this is specified, the harnessed component will be
+                     * rendered inside a `Route` handler with this path.
+                     *
+                     * If the path matches the location, then the route will
+                     * render the component.
+                     *
+                     * If the path does not match the location, then the route
+                     * will not render the component.
+                     */
+                    path?: string;
+                })
           | DataRoutesConfig
       >
     // The initial location to use.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,10 +122,10 @@ importers:
         version: 29.7.0
       '@khanacademy/eslint-config':
         specifier: ^5.2.0
-        version: 5.2.0(@khanacademy/eslint-plugin@3.1.1(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint-import-resolver-typescript@3.7.0)(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-prettier@5.2.3(@types/eslint@9.6.1)(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint@8.57.1)(prettier@3.4.2))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1)
+        version: 5.2.0(@khanacademy/eslint-plugin@3.1.1(eslint@8.57.1)(typescript@6.0.3))(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint-import-resolver-typescript@3.7.0)(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-prettier@5.2.3(@types/eslint@9.6.1)(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint@8.57.1)(prettier@3.4.2))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1)
       '@khanacademy/eslint-plugin':
         specifier: ^3.1.1
-        version: 3.1.1(eslint@8.57.1)(typescript@5.7.3)
+        version: 3.1.1(eslint@8.57.1)(typescript@6.0.3)
       '@khanacademy/eslint-plugin-wonder-blocks':
         specifier: workspace:*
         version: link:packages/eslint-plugin-wonder-blocks
@@ -242,19 +242,19 @@ importers:
         version: 10.3.5(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-mcp':
         specifier: ^0.6.0
-        version: 0.6.0(@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)
+        version: 0.6.0(@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)
       '@storybook/addon-vitest':
         specifier: 10.3.5
-        version: 10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15)
+        version: 10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15)
       '@storybook/builder-vite':
         specifier: ^10.3.5
         version: 10.3.6(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@storybook/react-vite':
         specifier: ^10.3.5
-        version: 10.3.6(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+        version: 10.3.6(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@swc-node/register':
         specifier: ^1.10.10
-        version: 1.10.10(@swc/core@1.11.22(@swc/helpers@0.5.17))(@swc/types@0.1.21)(typescript@5.7.3)
+        version: 1.10.10(@swc/core@1.11.22(@swc/helpers@0.5.17))(@swc/types@0.1.21)(typescript@6.0.3)
       '@swc/core':
         specifier: ^1.11.22
         version: 1.11.22(@swc/helpers@0.5.17)
@@ -311,19 +311,19 @@ importers:
         version: 1.8.8
       '@typescript-eslint/eslint-plugin':
         specifier: 8.17.0
-        version: 8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: 8.17.0
-        version: 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.17.0(eslint@8.57.1)(typescript@6.0.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.9.0
         version: 3.9.0(@swc/helpers@0.5.17)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@vitest/browser':
         specifier: ^4.0.15
-        version: 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
+        version: 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
       '@vitest/browser-playwright':
         specifier: ^4.0.15
-        version: 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(playwright@1.57.0)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
+        version: 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(playwright@1.57.0)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
       alex:
         specifier: ^11.0.1
         version: 11.0.1
@@ -347,10 +347,10 @@ importers:
         version: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.27.5
-        version: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+        version: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jest:
         specifier: 28.11.0
-        version: 28.11.0(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.0))(typescript@5.7.3)
+        version: 28.11.0(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.0))(typescript@6.0.3)
       eslint-plugin-jsdoc:
         specifier: ^50.6.3
         version: 50.6.3(eslint@8.57.1)
@@ -359,7 +359,7 @@ importers:
         version: 6.10.2(eslint@8.57.1)
       eslint-plugin-monorepo:
         specifier: ^0.3.2
-        version: 0.3.2(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+        version: 0.3.2(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: ^5.2.3
         version: 5.2.3(@types/eslint@9.6.1)(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint@8.57.1)(prettier@3.4.2)
@@ -374,10 +374,10 @@ importers:
         version: 5.1.0(eslint@8.57.1)
       eslint-plugin-storybook:
         specifier: ^10.3.5
-        version: 10.3.6(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)
+        version: 10.3.6(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)
       eslint-plugin-testing-library:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@8.57.1)(typescript@5.7.3)
+        version: 7.1.1(eslint@8.57.1)(typescript@6.0.3)
       eslint-watch:
         specifier: ^8.0.0
         version: 8.0.0(eslint@8.57.1)
@@ -407,7 +407,7 @@ importers:
         version: 17.3.0(@babel/preset-env@7.26.7(@babel/core@7.28.5))
       npm-package-json-lint:
         specifier: ^8.0.0
-        version: 8.0.0(typescript@5.7.3)
+        version: 8.0.0(typescript@6.0.3)
       playwright:
         specifier: ^1.57.0
         version: 1.57.0
@@ -440,22 +440,22 @@ importers:
         version: 10.7.0(@swc/core@1.11.22(@swc/helpers@0.5.17))(@swc/jest@0.2.38(@swc/core@1.11.22(@swc/helpers@0.5.17)))
       tstyche:
         specifier: ^7.0.0
-        version: 7.0.0(typescript@5.7.3)
+        version: 7.0.0(typescript@6.0.3)
       turbo:
         specifier: ^2.5.3
         version: 2.5.3
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 6.0.3
+        version: 6.0.3
       typescript-coverage-report:
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.7.3)
+        version: 1.1.0(typescript@6.0.3)
       vite:
         specifier: ^6.0.11
         version: 6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0)
       vitest:
         specifier: ^4.0.15
-        version: 4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(terser@5.39.0)(yaml@2.7.0)
+        version: 4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(terser@5.39.0)(yaml@2.7.0)
 
   build-settings: {}
 
@@ -463,7 +463,7 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^8.59.0
-        version: 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.59.0(eslint@8.57.1)(typescript@6.0.3)
     devDependencies:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
@@ -473,10 +473,10 @@ importers:
         version: 17.0.33
       '@typescript-eslint/rule-tester':
         specifier: ^8.59.0
-        version: 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.59.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/typescript-estree':
         specifier: ^8.59.0
-        version: 8.59.0(typescript@5.7.3)
+        version: 8.59.0(typescript@6.0.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -7601,6 +7601,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -9406,13 +9411,13 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       glob: 13.0.6
-      react-docgen-typescript: 2.2.2(typescript@5.7.3)
+      react-docgen-typescript: 2.2.2(typescript@6.0.3)
       vite: 6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -9439,23 +9444,23 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@khanacademy/eslint-config@5.2.0(@khanacademy/eslint-plugin@3.1.1(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint-import-resolver-typescript@3.7.0)(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-prettier@5.2.3(@types/eslint@9.6.1)(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint@8.57.1)(prettier@3.4.2))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1)':
+  '@khanacademy/eslint-config@5.2.0(@khanacademy/eslint-plugin@3.1.1(eslint@8.57.1)(typescript@6.0.3))(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint-import-resolver-typescript@3.7.0)(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-prettier@5.2.3(@types/eslint@9.6.1)(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint@8.57.1)(prettier@3.4.2))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1)':
     dependencies:
-      '@khanacademy/eslint-plugin': 3.1.1(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/eslint-plugin': 8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@khanacademy/eslint-plugin': 3.1.1(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       eslint-config-prettier: 10.0.1(eslint@8.57.1)
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-prettier: 5.2.3(@types/eslint@9.6.1)(eslint-config-prettier@10.0.1(eslint@8.57.1))(eslint@8.57.1)(prettier@3.4.2)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
 
-  '@khanacademy/eslint-plugin@3.1.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@khanacademy/eslint-plugin@3.1.1(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@babel/types': 7.28.5
-      '@typescript-eslint/utils': 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.17.0(eslint@8.57.1)(typescript@6.0.3)
       checksync: 5.0.5
     transitivePeerDependencies:
       - eslint
@@ -9756,31 +9761,31 @@ snapshots:
     optionalDependencies:
       react: 18.2.0
 
-  '@storybook/addon-mcp@0.6.0(@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)':
+  '@storybook/addon-mcp@0.6.0(@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15))(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)':
     dependencies:
-      '@storybook/mcp': 0.7.0(typescript@5.7.3)
-      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.7.3))(valibot@1.2.0(typescript@5.7.3))
-      '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@5.7.3))
+      '@storybook/mcp': 0.7.0(typescript@6.0.3)
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))
+      '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@6.0.3))
       picoquery: 2.5.0
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      tmcp: 1.19.3(typescript@5.7.3)
-      valibot: 1.2.0(typescript@5.7.3)
+      tmcp: 1.19.3(typescript@6.0.3)
+      valibot: 1.2.0(typescript@6.0.3)
     optionalDependencies:
-      '@storybook/addon-vitest': 10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15)
+      '@storybook/addon-vitest': 10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15)':
+  '@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.0.15)(@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15))(@vitest/runner@4.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vitest@4.0.15)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
-      '@vitest/browser': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
-      '@vitest/browser-playwright': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(playwright@1.57.0)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
+      '@vitest/browser': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
+      '@vitest/browser-playwright': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(playwright@1.57.0)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
       '@vitest/runner': 4.0.15
-      vitest: 4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(terser@5.39.0)(yaml@2.7.0)
+      vitest: 4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(terser@5.39.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -9812,12 +9817,12 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@storybook/mcp@0.7.0(typescript@5.7.3)':
+  '@storybook/mcp@0.7.0(typescript@6.0.3)':
     dependencies:
-      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.7.3))(valibot@1.2.0(typescript@5.7.3))
-      '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@5.7.3))
-      tmcp: 1.19.3(typescript@5.7.3)
-      valibot: 1.2.0(typescript@5.7.3)
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))
+      '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@6.0.3))
+      tmcp: 1.19.3(typescript@6.0.3)
+      valibot: 1.2.0(typescript@6.0.3)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
@@ -9828,12 +9833,12 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@storybook/react-vite@10.3.6(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
+  '@storybook/react-vite@10.3.6(esbuild@0.24.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
       '@storybook/builder-vite': 10.3.6(esbuild@0.24.2)(rollup@2.79.2)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
-      '@storybook/react': 10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)
+      '@storybook/react': 10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.2.0
@@ -9850,17 +9855,17 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3)':
+  '@storybook/react@10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.3.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react: 18.2.0
       react-docgen: 8.0.2
-      react-docgen-typescript: 2.2.2(typescript@5.7.3)
+      react-docgen-typescript: 2.2.2(typescript@6.0.3)
       react-dom: 18.2.0(react@18.2.0)
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9869,7 +9874,7 @@ snapshots:
       '@swc/core': 1.11.22(@swc/helpers@0.5.17)
       '@swc/types': 0.1.21
 
-  '@swc-node/register@1.10.10(@swc/core@1.11.22(@swc/helpers@0.5.17))(@swc/types@0.1.21)(typescript@5.7.3)':
+  '@swc-node/register@1.10.10(@swc/core@1.11.22(@swc/helpers@0.5.17))(@swc/types@0.1.21)(typescript@6.0.3)':
     dependencies:
       '@swc-node/core': 1.13.3(@swc/core@1.11.22(@swc/helpers@0.5.17))(@swc/types@0.1.21)
       '@swc-node/sourcemap-support': 0.5.1
@@ -9879,7 +9884,7 @@ snapshots:
       oxc-resolver: 5.3.0
       pirates: 4.0.6
       tslib: 2.8.1
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@swc/types'
       - supports-color
@@ -10001,22 +10006,22 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.3(typescript@5.7.3))(valibot@1.2.0(typescript@5.7.3))':
+  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.3(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))':
     dependencies:
       '@standard-schema/spec': 1.0.0
-      '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@5.7.3))
-      tmcp: 1.19.3(typescript@5.7.3)
-      valibot: 1.2.0(typescript@5.7.3)
+      '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@6.0.3))
+      tmcp: 1.19.3(typescript@6.0.3)
+      valibot: 1.2.0(typescript@6.0.3)
 
-  '@tmcp/session-manager@0.2.1(tmcp@1.19.3(typescript@5.7.3))':
+  '@tmcp/session-manager@0.2.1(tmcp@1.19.3(typescript@6.0.3))':
     dependencies:
-      tmcp: 1.19.3(typescript@5.7.3)
+      tmcp: 1.19.3(typescript@6.0.3)
 
-  '@tmcp/transport-http@0.8.5(tmcp@1.19.3(typescript@5.7.3))':
+  '@tmcp/transport-http@0.8.5(tmcp@1.19.3(typescript@6.0.3))':
     dependencies:
-      '@tmcp/session-manager': 0.2.1(tmcp@1.19.3(typescript@5.7.3))
+      '@tmcp/session-manager': 0.2.1(tmcp@1.19.3(typescript@6.0.3))
       esm-env: 1.2.2
-      tmcp: 1.19.3(typescript@5.7.3)
+      tmcp: 1.19.3(typescript@6.0.3)
 
   '@tootallnate/once@2.0.0': {}
 
@@ -10220,21 +10225,21 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.17.0
-      '@typescript-eslint/type-utils': 8.17.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.17.0(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.17.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.17.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.7.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10251,32 +10256,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.17.0
+      '@typescript-eslint/types': 8.17.0
+      '@typescript-eslint/typescript-estree': 8.17.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.17.0
+      debug: 4.4.3
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.0
       '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       eslint: 8.57.1
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.0(typescript@5.7.3)':
+  '@typescript-eslint/project-service@8.59.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/rule-tester@8.59.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.59.0(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@6.0.3)
       ajv: 6.12.6
       eslint: 8.57.1
       json-stable-stringify-without-jsonify: 1.0.1
@@ -10301,19 +10319,19 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/visitor-keys': 8.59.0
 
-  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.7.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.17.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.17.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.17.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.17.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.17.0(eslint@8.57.1)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.7.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10338,7 +10356,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.22.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.17.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.17.0
+      '@typescript-eslint/visitor-keys': 8.17.0
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.0
+      ts-api-utils: 1.4.3(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.22.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.22.0
       '@typescript-eslint/visitor-keys': 8.22.0
@@ -10347,57 +10380,57 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.0
-      ts-api-utils: 2.0.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.0(typescript@5.7.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/project-service': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.17.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.17.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.17.0
       '@typescript-eslint/types': 8.17.0
-      '@typescript-eslint/typescript-estree': 8.17.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.17.0(typescript@6.0.3)
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.22.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.22.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.22.0
       '@typescript-eslint/types': 8.22.0
-      '@typescript-eslint/typescript-estree': 8.22.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.22.0(typescript@6.0.3)
       eslint: 8.57.1
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.0(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.59.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.59.0
       '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.3)
       eslint: 8.57.1
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10418,9 +10451,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.7.3))':
+  '@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3))':
     dependencies:
-      valibot: 1.2.0(typescript@5.7.3)
+      valibot: 1.2.0(typescript@6.0.3)
 
   '@vitejs/plugin-react-swc@3.9.0(@swc/helpers@0.5.17)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
@@ -10429,29 +10462,29 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/browser-playwright@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(playwright@1.57.0)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)':
+  '@vitest/browser-playwright@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(playwright@1.57.0)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)':
     dependencies:
-      '@vitest/browser': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
-      '@vitest/mocker': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+      '@vitest/browser': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
+      '@vitest/mocker': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       playwright: 1.57.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(terser@5.39.0)(yaml@2.7.0)
+      vitest: 4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(terser@5.39.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)':
+  '@vitest/browser@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)':
     dependencies:
-      '@vitest/mocker': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+      '@vitest/mocker': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@vitest/utils': 4.0.15
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(terser@5.39.0)(yaml@2.7.0)
+      vitest: 4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(terser@5.39.0)(yaml@2.7.0)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -10476,13 +10509,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
+  '@vitest/mocker@4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 4.0.15
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.7.0(@types/node@22.13.0)(typescript@5.7.3)
+      msw: 2.7.0(@types/node@22.13.0)(typescript@6.0.3)
       vite: 6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.2.4':
@@ -11089,14 +11122,14 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig@8.3.6(typescript@5.7.3):
+  cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
   create-jest@29.7.0(@types/node@22.13.0):
     dependencies:
@@ -11486,22 +11519,22 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -11512,7 +11545,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11524,18 +11557,18 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.0))(typescript@5.7.3):
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.13.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.22.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.22.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.17.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)
       jest: 29.7.0(@types/node@22.13.0)
     transitivePeerDependencies:
       - supports-color
@@ -11577,9 +11610,9 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-monorepo@0.3.2(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-plugin-monorepo@0.3.2(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       get-monorepo-packages: 1.3.0
       globby: 7.1.1
       load-json-file: 4.0.0
@@ -11635,19 +11668,19 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@10.3.6(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.7.3):
+  eslint-plugin-storybook@10.3.6(eslint@8.57.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.59.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.4.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-testing-library@7.1.1(eslint@8.57.1)(typescript@5.7.3):
+  eslint-plugin-testing-library@7.1.1(eslint@8.57.1)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/scope-manager': 8.22.0
-      '@typescript-eslint/utils': 8.22.0(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.22.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -13973,7 +14006,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3):
+  msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -13994,7 +14027,7 @@ snapshots:
       type-fest: 4.41.0
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
     optional: true
@@ -14074,12 +14107,12 @@ snapshots:
 
   npm-normalize-package-bin@3.0.1: {}
 
-  npm-package-json-lint@8.0.0(typescript@5.7.3):
+  npm-package-json-lint@8.0.0(typescript@6.0.3):
     dependencies:
       ajv: 6.12.6
       ajv-errors: 1.0.1(ajv@6.12.6)
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.7.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       debug: 4.4.3
       globby: 11.1.0
       ignore: 5.3.2
@@ -14494,9 +14527,9 @@ snapshots:
       date-fns-jalali: 4.1.0-0
       react: 18.2.0
 
-  react-docgen-typescript@2.2.2(typescript@5.7.3):
+  react-docgen-typescript@2.2.2(typescript@6.0.3):
     dependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
   react-docgen@8.0.2:
     dependencies:
@@ -15359,13 +15392,13 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tmcp@1.19.3(typescript@5.7.3):
+  tmcp@1.19.3(typescript@6.0.3):
     dependencies:
       '@standard-schema/spec': 1.0.0
       json-rpc-2.0: 1.7.1
       sqids: 0.3.0
       uri-template-matcher: 1.1.2
-      valibot: 1.2.0(typescript@5.7.3)
+      valibot: 1.2.0(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -15411,13 +15444,17 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-api-utils@2.0.0(typescript@5.7.3):
+  ts-api-utils@1.4.3(typescript@6.0.3):
     dependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
-  ts-api-utils@2.5.0(typescript@5.7.3):
+  ts-api-utils@2.0.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
+
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   ts-dedent@2.2.0: {}
 
@@ -15438,14 +15475,14 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tstyche@7.0.0(typescript@5.7.3):
+  tstyche@7.0.0(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
-  tsutils@3.21.0(typescript@5.7.3):
+  tsutils@3.21.0(typescript@6.0.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.7.3
+      typescript: 6.0.3
 
   turbo-darwin-64@2.5.3:
     optional: true
@@ -15478,14 +15515,14 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-coverage-core@2.29.7(typescript@5.7.3):
+  type-coverage-core@2.29.7(typescript@6.0.3):
     dependencies:
       fast-glob: 3.3.3
       minimatch: 10.0.1
       normalize-path: 3.0.0
       tslib: 2.8.1
-      tsutils: 3.21.0(typescript@5.7.3)
-      typescript: 5.7.3
+      tsutils: 3.21.0(typescript@6.0.3)
+      typescript: 6.0.3
 
   type-detect@4.0.8: {}
 
@@ -15546,17 +15583,19 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-coverage-report@1.1.0(typescript@5.7.3):
+  typescript-coverage-report@1.1.0(typescript@6.0.3):
     dependencies:
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 5.1.0
       ncp: 2.0.0
       rimraf: 3.0.2
-      type-coverage-core: 2.29.7(typescript@5.7.3)
-      typescript: 5.7.3
+      type-coverage-core: 2.29.7(typescript@6.0.3)
+      typescript: 6.0.3
 
   typescript@5.7.3: {}
+
+  typescript@6.0.3: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -15798,9 +15837,9 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@1.2.0(typescript@5.7.3):
+  valibot@1.2.0(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 6.0.3
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -15875,10 +15914,10 @@ snapshots:
       terser: 5.39.0
       yaml: 2.7.0
 
-  vitest@4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(terser@5.39.0)(yaml@2.7.0):
+  vitest@4.0.15(@types/node@22.13.0)(@vitest/browser-playwright@4.0.15)(jsdom@20.0.3)(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(terser@5.39.0)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 4.0.15
-      '@vitest/mocker': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
+      '@vitest/mocker': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))
       '@vitest/pretty-format': 4.0.15
       '@vitest/runner': 4.0.15
       '@vitest/snapshot': 4.0.15
@@ -15899,7 +15938,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.0
-      '@vitest/browser-playwright': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@5.7.3))(playwright@1.57.0)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
+      '@vitest/browser-playwright': 4.0.15(msw@2.7.0(@types/node@22.13.0)(typescript@6.0.3))(playwright@1.57.0)(vite@6.0.11(@types/node@22.13.0)(terser@5.39.0)(yaml@2.7.0))(vitest@4.0.15)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## Summary

Updated the router test harness adapter to enforce mutual exclusivity between `location` and `initialEntries` configuration options at the type level, ensuring TypeScript 6.0 compatibility.

Issue: FEI-7954

## Key Changes

- **Router adapter types**: Added `NotInitialEntries` and `NotLocation` discriminator types to structurally enforce that `location` and `initialEntries` cannot be combined in the same config object
  - Applied `NotLocation` to the `initialEntries`-based union member
  - Applied `NotInitialEntries` to both `location`-based union members
  - This mirrors the existing `NotDataRoutes` pattern for data-routes exclusivity

- **Type tests**: Added two new test cases to verify the mutual exclusivity is enforced:
  - Rejects combining `location` with `initialEntries`
  - Rejects combining `forceStatic` location with `initialEntries`

- **TypeScript upgrade**: Updated `package.json` to use TypeScript 6.0.3 (from 5.7.3)

- **tsconfig-shared.json**: Added explicit `types` array configuration to handle TypeScript 6.0's changed default behavior for `@types/*` packages in composite builds
  - Lists all global-providing `@types/*` dependencies to ensure they remain in scope during declaration emission
  - Includes: aria-query, history, jest, jest-axe, jscodeshift, node, node-fetch, react, react-dom, react-router, react-router-dom, react-window

- **Test file updates**: Added `@ts-expect-error` comments in test files to suppress new TypeScript 6.0 type errors related to `window.location` assignment

## Implementation Details

TypeScript 6.0 relaxed union excess-property checking, which previously prevented combining incompatible union members. The structural `never` guards ensure type safety across both TypeScript 5.7 and 6.0 by making it impossible to satisfy both the positive requirement (e.g., `initialEntries: ...`) and the negative constraint (e.g., `location?: never`) simultaneously.

https://claude.ai/code/session_01CgbaANpEqVYPiEG9kiRjGU