### PR TITLE
Restore Catalog sidebar section by nesting stories under Catalog / Components

### DIFF
--- a/.changeset/catalog-category-root-move.md
+++ b/.changeset/catalog-category-root-move.md
@@ -1,0 +1,4 @@
+---
+---
+
+Storybook only: restore the `Catalog` sidebar section by nesting its stories under `Catalog / Components`. Removing `states.stories.tsx` had left `Catalog` with only single-segment titles, which caused it to render as a loose top-level entry instead of a category section. No published package changes.

--- a/__docs__/catalog/catalog.stories.tsx
+++ b/__docs__/catalog/catalog.stories.tsx
@@ -17,7 +17,7 @@ import {
 import {CatalogComponentInfo, ComponentList} from "./catalog-component-info";
 
 export default {
-    title: "Catalog",
+    title: "Catalog / Components",
     tags: ["!autodocs", "!manifest"],
     parameters: {
         chromatic: {


### PR DESCRIPTION
## Summary

Restores the `Catalog` sidebar section in Storybook by updating the story title hierarchy. This is a Storybook-only change with no impact on published packages.

## Changes

- Updated `catalog.stories.tsx` title from `"Catalog"` to `"Catalog / Components"` to properly nest the story under a category section
- Added changeset documenting the Storybook-only fix

## Details

Removing `states.stories.tsx` previously left the `Catalog` section with only single-segment titles, which caused it to render as a loose top-level entry instead of a proper category section in the sidebar. By nesting the story under `Catalog / Components`, the sidebar now correctly displays `Catalog` as a collapsible category section containing the components stories.


Issue: WB-2393 

## Test Plan
1. Confirm `Catalog` stories are not at the root level 

| Before | After | 
| --- | --- |
| <img width="1252" height="1008" alt="image" src="https://github.com/user-attachments/assets/e10aac51-e1e5-493a-b7bd-2943f0891e1c" /> | <img width="1251" height="1011" alt="image" src="https://github.com/user-attachments/assets/e80063a8-83ea-4a61-925b-774b03b60c21" /> |


https://claude.ai/code/session_01K3YDSqeC5hud1J9YAL7SjV