### PR TITLE
Add dark color-scheme support to preview styles

### DIFF
--- a/.changeset/dark-theme-color-scheme.md
+++ b/.changeset/dark-theme-color-scheme.md
@@ -1,0 +1,4 @@
+---
+---
+
+Set `color-scheme: dark` on the `:root` element in Storybook when the body's `data-wb-theme` attribute ends in `-dark`.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -176,6 +176,14 @@ const withThemeSwitcher: Decorator = (Story, {globals: {theme}}) => {
         if (theme) {
             // Switch the body class based on the theme.
             document.body.setAttribute(THEME_DATA_ATTRIBUTE, theme);
+            // Set `color-scheme: dark` on the `:root` element when the theme is
+            // a dark theme (e.g. `syl-dark`). This ensures that browser-rendered
+            // UI (form controls, scrollbars, etc.) matches the dark theme.
+            if (theme.endsWith("-dark")) {
+                document.documentElement.style.colorScheme = "dark";
+            } else {
+                document.documentElement.style.removeProperty("color-scheme");
+            }
             setLocalTheme(theme);
         }
     }, [theme]);

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -176,14 +176,6 @@ const withThemeSwitcher: Decorator = (Story, {globals: {theme}}) => {
         if (theme) {
             // Switch the body class based on the theme.
             document.body.setAttribute(THEME_DATA_ATTRIBUTE, theme);
-            // Set `color-scheme: dark` on the `:root` element when the theme is
-            // a dark theme (e.g. `syl-dark`). This ensures that browser-rendered
-            // UI (form controls, scrollbars, etc.) matches the dark theme.
-            if (theme.endsWith("-dark")) {
-                document.documentElement.style.colorScheme = "dark";
-            } else {
-                document.documentElement.style.removeProperty("color-scheme");
-            }
             setLocalTheme(theme);
         }
     }, [theme]);

--- a/static/sb-styles/preview.css
+++ b/static/sb-styles/preview.css
@@ -12,7 +12,8 @@ html {
 
 /* Set `color-scheme: dark` on the `:root` element when the body uses a dark
  * theme (e.g. `syl-dark`). This ensures that browser-rendered UI (form
- * controls, scrollbars, etc.) matches the dark theme. */
+ * controls, scrollbars, etc.) matches the dark theme.
+ * This will be moved to WB global styles in WB-2394. */
 :root:has(body[data-wb-theme$="-dark"]) {
     color-scheme: dark;
 }

--- a/static/sb-styles/preview.css
+++ b/static/sb-styles/preview.css
@@ -10,6 +10,13 @@ html {
     color: var(--wb-semanticColor-core-foreground-neutral-strong);
 }
 
+/* Set `color-scheme: dark` on the `:root` element when the body uses a dark
+ * theme (e.g. `syl-dark`). This ensures that browser-rendered UI (form
+ * controls, scrollbars, etc.) matches the dark theme. */
+:root:has(body[data-wb-theme$="-dark"]) {
+    color-scheme: dark;
+}
+
 /* These overrides depend on a Base 10 font size */
 .sb-show-main.sb-main-padded {
     padding: 0.8rem;


### PR DESCRIPTION
## Summary

Storybook: Added CSS rule to set `color-scheme: dark` on the root element when a dark theme is applied to the body. This ensures that browser-rendered UI elements (scrollbars, etc.) match the dark theme styling.

Note: Created WB-2394 to centralize global styles like this within a WB package! Consumers will need to configure this in the short term. Here's the frontend PR that does this: https://github.com/Khan/frontend/pull/13358

## Changes

- Added `:root:has(body[data-wb-theme$="-dark"])` selector that sets `color-scheme: dark`
- This rule targets any body element with a data attribute ending in "-dark" (e.g., `syl-dark`)

Issue: WB-2395

## Test Plan 

Verify native browser elements like scrollbars show as dark in the `syl-dark` theme: 

| Before | After | 
| --- | --- |
| <img width="1728" height="1048" alt="image" src="https://github.com/user-attachments/assets/b1bff463-9ecc-43e4-bfec-9074e9580a8c" /> | <img width="1728" height="1055" alt="image" src="https://github.com/user-attachments/assets/281f9183-6472-4f40-b35b-884058def777" /> |