### PR TITLE
Refactor Radio to render through DetailCell with appearance prop

### DIFF
--- a/.changeset/radio-detail-cell.md
+++ b/.changeset/radio-detail-cell.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-form": minor
+---
+
+`Radio` is now composed from `DetailCell` internally (radio input as the cell's `leftAccessory`, label as `title`, description as `subtitle2`). It also gains an `appearance` prop: `"default"` (the default) keeps the current compact radio row, and `"cell"` opts into the full `DetailCell` styling (padding + horizontal rule).
+
+The `appearance` prop is also forwarded through `Choice` and `RadioGroup`, so setting `appearance="cell"` on a `RadioGroup` renders every radio in the group as a cell. It only applies to radios (ignored for checkboxes).

--- a/.changeset/radio-detail-cell.md
+++ b/.changeset/radio-detail-cell.md
@@ -2,6 +2,9 @@
 "@khanacademy/wonder-blocks-form": minor
 ---
 
-`Radio` is now composed from `DetailCell` internally (radio input as the cell's `leftAccessory`, label as `title`, description as `subtitle2`). It also gains an `appearance` prop: `"default"` (the default) keeps the current compact radio row, and `"cell"` opts into the full `DetailCell` styling (padding + horizontal rule).
+`Radio` is now composed from `DetailCell` internally (radio input as the cell's `leftAccessory`, label as `title`, description as `subtitle2`). New props:
 
-The `appearance` prop is also forwarded through `Choice` and `RadioGroup`, so setting `appearance="cell"` on a `RadioGroup` renders every radio in the group as a cell. It only applies to radios (ignored for checkboxes).
+- `appearance` (`"default" | "cell"`): `"default"` keeps the current compact radio row; `"cell"` renders the radio as an individually bordered, rounded card that shows a colored border when checked (the "radio as cell" look).
+- `rightAccessory`: content rendered at the end of the row (e.g. a "Recommended" label), mapped to the underlying `DetailCell`'s `rightAccessory`.
+
+Both `appearance` and `rightAccessory` are forwarded through `Choice`, and `appearance` is also forwarded through `RadioGroup` (setting it on the group renders every radio as a cell). These props only apply to radios (ignored for checkboxes).

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -5,6 +5,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import Link from "@khanacademy/wonder-blocks-link";
 
 import {Choice, RadioGroup} from "@khanacademy/wonder-blocks-form";
 import packageConfig from "../../packages/wonder-blocks-form/package.json";
@@ -97,36 +98,70 @@ Basic.parameters = {
     },
 };
 
+const COURSES = [
+    {
+        value: "2nd-grade",
+        title: "2nd grade math",
+        units: 12,
+        hours: 13,
+        recommended: true,
+    },
+    {value: "3rd-grade", title: "3rd grade math", units: 12, hours: 13},
+    {value: "4th-grade", title: "4th grade math", units: 9, hours: 14},
+];
+
+/**
+ * A course-picker built from `appearance="cell"` radios. Each option renders
+ * as a bordered card (the selected card uses a colored border), with a subtitle
+ * and an "Overview" link, plus an optional `rightAccessory` used here for the
+ * "Recommended" label.
+ */
 export const CellAppearance: StoryComponentType = () => {
-    const [selectedValue, setSelectedValue] = React.useState("squirtle-cell");
+    const [selectedValue, setSelectedValue] = React.useState("2nd-grade");
 
     return (
-        <RadioGroup
-            groupName="pokemon-cell"
-            label="Pokemon"
-            description="Your first Pokemon."
-            appearance="cell"
-            onChange={setSelectedValue}
-            selectedValue={selectedValue}
-        >
-            <Choice
-                label="Bulbasaur"
-                value="bulbasaur-cell"
-                description="A grass-type Pokemon."
-            />
-            <Choice
-                label="Charmander"
-                value="charmander-cell"
-                description="Oops, we ran out of Charmanders"
-                disabled
-            />
-            <Choice
-                label="Squirtle"
-                value="squirtle-cell"
-                description="A water-type Pokemon."
-            />
-            <Choice label="Pikachu" value="pikachu-cell" />
-        </RadioGroup>
+        <View style={styles.coursePicker}>
+            <RadioGroup
+                groupName="course"
+                appearance="cell"
+                onChange={setSelectedValue}
+                selectedValue={selectedValue}
+            >
+                {COURSES.map((course) => (
+                    <Choice
+                        key={course.value}
+                        value={course.value}
+                        label={course.title}
+                        description={
+                            <>
+                                {`${course.units} units • est. ${course.hours} hours`}
+                                <Link
+                                    href="https://www.khanacademy.org"
+                                    target="_blank"
+                                    style={styles.overviewLink}
+                                >
+                                    Overview
+                                </Link>
+                            </>
+                        }
+                        rightAccessory={
+                            course.recommended ? (
+                                <BodyText
+                                    size="small"
+                                    tag="span"
+                                    style={styles.recommended}
+                                >
+                                    Recommended
+                                </BodyText>
+                            ) : undefined
+                        }
+                    />
+                ))}
+            </RadioGroup>
+            <Link href="https://www.khanacademy.org">
+                Select a different course
+            </Link>
+        </View>
     );
 };
 
@@ -134,9 +169,10 @@ CellAppearance.parameters = {
     docs: {
         description: {
             story: `Setting \`appearance="cell"\` on the \`RadioGroup\`
-        forwards it to every radio, rendering each option with the full
-        \`DetailCell\` style (padding and a horizontal rule) so the group reads
-        as a list of cells.`,
+        forwards it to every radio, rendering each option as a bordered card.
+        The selected card uses a colored border. This example also uses each
+        \`Choice\`'s \`rightAccessory\` (for the "Recommended" label) and a
+        rich \`description\` (metadata plus an "Overview" link).`,
         },
     },
 };
@@ -315,5 +351,15 @@ const styles = StyleSheet.create({
     },
     prompt: {
         marginBlockEnd: 16,
+    },
+    coursePicker: {
+        gap: sizing.size_120,
+        maxInlineSize: 520,
+    },
+    overviewLink: {
+        marginInlineStart: sizing.size_160,
+    },
+    recommended: {
+        color: semanticColor.core.foreground.neutral.default,
     },
 });

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -4,7 +4,10 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import {
+    BodyText,
+    styles as typographyStyles,
+} from "@khanacademy/wonder-blocks-typography";
 import Link from "@khanacademy/wonder-blocks-link";
 
 import {Choice, RadioGroup} from "@khanacademy/wonder-blocks-form";
@@ -126,6 +129,22 @@ export const CellAppearance: StoryComponentType = () => {
                 appearance="cell"
                 onChange={setSelectedValue}
                 selectedValue={selectedValue}
+                label={
+                    <BodyText
+                        weight="semi"
+                        tag="span"
+                        style={{textAlign: "center"}}
+                    >
+                        Assign to{" "}
+                        <BodyText
+                            style={typographyStyles.HeadingXxLargeBoldWeight}
+                            tag="span"
+                        >
+                            Period 1 - Algegra 1A
+                        </BodyText>
+                    </BodyText>
+                }
+                description="Choose a course to assign unit missions and instantly start students on personalized practice proven to help reach growth targets. "
             >
                 {COURSES.map((course) => (
                     <Choice

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -180,6 +180,39 @@ export const CellAppearance: StoryComponentType = () => {
             <Link href="https://www.khanacademy.org">
                 Select a different course
             </Link>
+
+            {/*
+             * "Other assignment options" belongs to the SAME radio group as the
+             * courses above: it reuses the `course` groupName and shares the
+             * `selectedValue`/`onChange` state, so selecting any option here
+             * deselects the course cards (and vice versa). It's a separate
+             * RadioGroup only because it needs its own heading and a horizontal
+             * (two-up) layout.
+             */}
+            <View style={styles.otherOptions}>
+                <BodyText weight="bold" tag="span">
+                    Other assignment options
+                </BodyText>
+                <RadioGroup
+                    groupName="course"
+                    appearance="cell"
+                    style={styles.otherOptionsRow}
+                    onChange={setSelectedValue}
+                    selectedValue={selectedValue}
+                >
+                    <Choice
+                        value="upload-pacing-guide"
+                        label="Upload a pacing guide"
+                        description="Math only"
+                        style={styles.otherOption}
+                    />
+                    <Choice
+                        value="manually-assign"
+                        label="Manually assign content"
+                        style={styles.otherOption}
+                    />
+                </RadioGroup>
+            </View>
         </View>
     );
 };
@@ -380,5 +413,18 @@ const styles = StyleSheet.create({
     },
     recommended: {
         color: semanticColor.core.foreground.neutral.default,
+    },
+    otherOptions: {
+        gap: sizing.size_120,
+    },
+    otherOptionsRow: {
+        flexDirection: "row",
+        gap: sizing.size_120,
+    },
+    otherOption: {
+        // Each card takes an equal share of the row, and we clear the vertical
+        // gap the group injects between stacked choices (not wanted in a row).
+        flex: 1,
+        marginBlockStart: 0,
     },
 });

--- a/__docs__/wonder-blocks-form/radio-group.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio-group.stories.tsx
@@ -97,6 +97,50 @@ Basic.parameters = {
     },
 };
 
+export const CellAppearance: StoryComponentType = () => {
+    const [selectedValue, setSelectedValue] = React.useState("squirtle-cell");
+
+    return (
+        <RadioGroup
+            groupName="pokemon-cell"
+            label="Pokemon"
+            description="Your first Pokemon."
+            appearance="cell"
+            onChange={setSelectedValue}
+            selectedValue={selectedValue}
+        >
+            <Choice
+                label="Bulbasaur"
+                value="bulbasaur-cell"
+                description="A grass-type Pokemon."
+            />
+            <Choice
+                label="Charmander"
+                value="charmander-cell"
+                description="Oops, we ran out of Charmanders"
+                disabled
+            />
+            <Choice
+                label="Squirtle"
+                value="squirtle-cell"
+                description="A water-type Pokemon."
+            />
+            <Choice label="Pikachu" value="pikachu-cell" />
+        </RadioGroup>
+    );
+};
+
+CellAppearance.parameters = {
+    docs: {
+        description: {
+            story: `Setting \`appearance="cell"\` on the \`RadioGroup\`
+        forwards it to every radio, rendering each option with the full
+        \`DetailCell\` style (padding and a horizontal rule) so the group reads
+        as a list of cells.`,
+        },
+    },
+};
+
 export const Error: StoryComponentType = () => {
     const emptyError = "You must select an option to continue.";
     const [selectedValue, setSelectedValue] = React.useState("");

--- a/__docs__/wonder-blocks-form/radio.stories.tsx
+++ b/__docs__/wonder-blocks-form/radio.stories.tsx
@@ -128,6 +128,46 @@ WithLabel.parameters = {
     },
 };
 
+export const Appearance: StoryComponentType = () => {
+    const [selected, setSelected] = React.useState("default");
+
+    return (
+        <View style={styles.appearanceColumn}>
+            <Radio
+                label="Default appearance"
+                description="Renders as a compact row with no padding or divider."
+                checked={selected === "default"}
+                onChange={() => setSelected("default")}
+            />
+            <Radio
+                appearance="cell"
+                label="Cell appearance"
+                description="Adds the DetailCell padding and an inset divider so a list of radios reads as a set of cells."
+                checked={selected === "cell"}
+                onChange={() => setSelected("cell")}
+            />
+            <Radio
+                appearance="cell"
+                label="Another cell"
+                description="Cell-appearance radios stack into a list."
+                checked={selected === "another"}
+                onChange={() => setSelected("another")}
+            />
+        </View>
+    );
+};
+
+Appearance.parameters = {
+    docs: {
+        description: {
+            story: `The \`appearance\` prop controls how the radio's
+            underlying \`DetailCell\` is styled. \`"default"\` (the default)
+            keeps the compact radio row. \`"cell"\` opts into the full
+            \`DetailCell\` look, adding padding and a horizontal rule.`,
+        },
+    },
+};
+
 export const AdditionalClickTarget: StoryComponentType = () => {
     const [checked, setChecked] = React.useState(false);
     const headingText = "Functions";
@@ -167,6 +207,10 @@ const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
         gap: sizing.size_240,
+    },
+    appearanceColumn: {
+        gap: sizing.size_080,
+        maxInlineSize: 400,
     },
     wrapper: {
         flexDirection: "row",

--- a/packages/wonder-blocks-form/package.json
+++ b/packages/wonder-blocks-form/package.json
@@ -33,6 +33,7 @@
     "prepublishOnly": "../../utils/publish/package-pre-publish-check.sh"
   },
   "dependencies": {
+    "@khanacademy/wonder-blocks-cell": "workspace:*",
     "@khanacademy/wonder-blocks-clickable": "workspace:*",
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-icon": "workspace:*",

--- a/packages/wonder-blocks-form/src/components/choice.tsx
+++ b/packages/wonder-blocks-form/src/components/choice.tsx
@@ -18,6 +18,14 @@ type Props = AriaProps & {
     /** User-defined. Optional additional styling. */
     style?: StyleType;
     /**
+     * User-defined. Controls the visual appearance of the choice. Only applies
+     * to radio choices (within a `RadioGroup`); ignored for checkboxes.
+     *
+     * - `"default"` renders the compact radio row.
+     * - `"cell"` renders the radio using the full `DetailCell` style.
+     */
+    appearance?: "default" | "cell";
+    /**
      * Auto-populated by parent. Whether this choice is checked.
      * @ignore
      */
@@ -129,23 +137,28 @@ const Choice = React.forwardRef(function Choice(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         value,
         variant,
+        // `appearance` only applies to Radio, so it's pulled out here and
+        // forwarded to Radio explicitly below (Checkbox does not support it).
+        appearance,
         ...remainingProps
     } = props;
 
-    const getChoiceComponent = (
-        variant?: string | null,
-    ): typeof Radio | typeof Checkbox => {
-        if (variant === "checkbox") {
-            return Checkbox;
-        } else {
-            return Radio;
-        }
-    };
+    if (variant === "checkbox") {
+        return (
+            <Checkbox
+                {...remainingProps}
+                checked={checked}
+                disabled={disabled}
+                onChange={onChange}
+                ref={ref}
+            />
+        );
+    }
 
-    const ChoiceComponent = getChoiceComponent(variant);
     return (
-        <ChoiceComponent
+        <Radio
             {...remainingProps}
+            appearance={appearance}
             checked={checked}
             disabled={disabled}
             onChange={onChange}

--- a/packages/wonder-blocks-form/src/components/choice.tsx
+++ b/packages/wonder-blocks-form/src/components/choice.tsx
@@ -26,6 +26,12 @@ type Props = AriaProps & {
      */
     appearance?: "default" | "cell";
     /**
+     * User-defined. Optional content rendered at the end of the row (e.g. a
+     * "Recommended" label). Only applies to radio choices; ignored for
+     * checkboxes. Most useful with `appearance="cell"`.
+     */
+    rightAccessory?: React.ReactNode;
+    /**
      * Auto-populated by parent. Whether this choice is checked.
      * @ignore
      */
@@ -137,9 +143,11 @@ const Choice = React.forwardRef(function Choice(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         value,
         variant,
-        // `appearance` only applies to Radio, so it's pulled out here and
-        // forwarded to Radio explicitly below (Checkbox does not support it).
+        // `appearance` and `rightAccessory` only apply to Radio, so they're
+        // pulled out here and forwarded to Radio explicitly below (Checkbox does
+        // not support them).
         appearance,
+        rightAccessory,
         ...remainingProps
     } = props;
 
@@ -159,6 +167,7 @@ const Choice = React.forwardRef(function Choice(
         <Radio
             {...remainingProps}
             appearance={appearance}
+            rightAccessory={rightAccessory}
             checked={checked}
             disabled={disabled}
             onChange={onChange}

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -51,6 +51,14 @@ type RadioGroupProps = {
      */
     selectedValue: string;
     /**
+     * Controls the visual appearance of every radio in the group.
+     *
+     * - `"default"` (the default) renders each radio as a compact row.
+     * - `"cell"` renders each radio using the full `DetailCell` style (padding
+     *   and a horizontal rule), so the group reads as a list of cells.
+     */
+    appearance?: "default" | "cell";
+    /**
      * Test ID used for e2e testing.
      */
     testId?: string;
@@ -107,6 +115,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(
         onChange,
         selectedValue,
         style,
+        appearance,
         testId,
     } = props;
 
@@ -152,6 +161,9 @@ const RadioGroup = React.forwardRef(function RadioGroup(
                         style,
                     ],
                     variant: "radio",
+                    // Only forward appearance when set, so a per-Choice
+                    // appearance can still take precedence if left unset here.
+                    ...(appearance ? {appearance} : {}),
                 });
             })}
         </StyledFieldset>

--- a/packages/wonder-blocks-form/src/components/radio-group.tsx
+++ b/packages/wonder-blocks-form/src/components/radio-group.tsx
@@ -54,8 +54,9 @@ type RadioGroupProps = {
      * Controls the visual appearance of every radio in the group.
      *
      * - `"default"` (the default) renders each radio as a compact row.
-     * - `"cell"` renders each radio using the full `DetailCell` style (padding
-     *   and a horizontal rule), so the group reads as a list of cells.
+     * - `"cell"` renders each radio as an individually bordered, rounded card
+     *   (the selected card uses a colored border), so the group reads as a set
+     *   of selectable cards.
      */
     appearance?: "default" | "cell";
     /**

--- a/packages/wonder-blocks-form/src/components/radio.tsx
+++ b/packages/wonder-blocks-form/src/components/radio.tsx
@@ -258,13 +258,14 @@ const styles = StyleSheet.create({
     // constant across states to avoid layout shift when selecting.
     cellCard: {
         borderStyle: "solid",
-        borderWidth: border.width.medium,
+        borderWidth: border.width.thin,
         borderColor: semanticColor.core.border.neutral.subtle,
         borderRadius: border.radius.radius_120,
     },
     // When checked, the card shows the instructive (selected) border color.
     cellCardSelected: {
         borderColor: semanticColor.core.border.instructive.default,
+        borderWidth: border.width.medium,
     },
     // Align the title/subtitle and the radio to the top of the card so the
     // radio lines up with the title rather than the vertical center.

--- a/packages/wonder-blocks-form/src/components/radio.tsx
+++ b/packages/wonder-blocks-form/src/components/radio.tsx
@@ -1,7 +1,14 @@
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
 
+import {Id, View} from "@khanacademy/wonder-blocks-core";
+import {font, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import {DetailCell} from "@khanacademy/wonder-blocks-cell";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import ChoiceInternal from "./choice-internal";
+
+import RadioCore from "./radio-core";
+import theme from "../theme";
 
 // Keep synced with ChoiceComponentProps in ../util/types.js
 type ChoiceComponentProps = AriaProps & {
@@ -41,7 +48,7 @@ type ChoiceComponentProps = AriaProps & {
      */
     style?: StyleType;
     /**
-     * Adds CSS classes to the Checkbox.
+     * Adds CSS classes to the Radio.
      */
     className?: string;
     /**
@@ -54,6 +61,19 @@ type ChoiceComponentProps = AriaProps & {
      * @ignore
      */
     groupName?: string;
+    /**
+     * Controls the visual appearance of the radio.
+     *
+     * - `"default"` (the default) renders the radio as a compact row (radio
+     *   input + label + description) with no surrounding padding or divider.
+     * - `"cell"` renders the radio using the full `DetailCell` style, adding the
+     *   cell's padding and a horizontal rule so a list of radios reads as a set
+     *   of cells.
+     *
+     * In both cases the layout is composed from `DetailCell`; `appearance` only
+     * toggles the cell's own padding/divider styling.
+     */
+    appearance?: "default" | "cell";
 };
 
 /**
@@ -62,21 +82,162 @@ type ChoiceComponentProps = AriaProps & {
  *
  * This component should not really be used by itself because radio buttons are
  * often grouped together. See RadioGroup.
+ *
+ * Internally, `Radio` is composed from `DetailCell`: the radio input is rendered
+ * as the cell's `leftAccessory`, the label as its `title`, and the description
+ * as its `subtitle2`. The cell has no `onClick`/`href` so it renders a plain
+ * container (not a `Clickable`), keeping the native `<input>` as the single
+ * interactive element.
  */ const Radio = React.forwardRef(function Radio(
     props: ChoiceComponentProps,
     ref: React.ForwardedRef<HTMLInputElement>,
 ) {
-    const {disabled = false, error = false, ...otherProps} = props;
+    const {
+        checked,
+        description,
+        disabled = false,
+        error = false,
+        id,
+        label,
+        onChange,
+        style,
+        className,
+        testId,
+        groupName,
+        appearance = "default",
+        ...ariaProps
+    } = props;
+
+    const handleClick: () => void = () => {
+        // Radio buttons cannot be unchecked.
+        if (checked) {
+            return;
+        }
+        onChange(!checked);
+    };
 
     return (
-        <ChoiceInternal
-            {...otherProps}
-            variant="radio"
-            disabled={disabled}
-            error={error}
-            ref={ref}
-        />
+        // A radio element should always have a unique ID set so that the label
+        // can always refer to this element. This guarantees that clicking on
+        // the label will always click on the radio as well. If an ID is passed
+        // in as a prop, use that one. Otherwise, create a unique ID.
+        <Id id={id}>
+            {(uniqueId) => {
+                // Create a unique ID for the description section to be used by
+                // this element's `aria-describedby`.
+                const descriptionId = description
+                    ? `${uniqueId}-description`
+                    : undefined;
+
+                const labelNode = label ? (
+                    <BodyText
+                        tag="div"
+                        weight="semi"
+                        style={[styles.label, disabled && styles.disabledLabel]}
+                    >
+                        <label htmlFor={uniqueId}>{label}</label>
+                    </BodyText>
+                ) : (
+                    // DetailCell requires a title; render an empty node when
+                    // there is no label.
+                    ""
+                );
+
+                const descriptionNode = description ? (
+                    <BodyText
+                        size="small"
+                        id={descriptionId}
+                        style={styles.description}
+                    >
+                        {description}
+                    </BodyText>
+                ) : undefined;
+
+                return (
+                    <View style={style} className={className}>
+                        <DetailCell
+                            testId={testId}
+                            horizontalRule={
+                                appearance === "cell" ? "inset" : "none"
+                            }
+                            styles={
+                                appearance === "cell"
+                                    ? undefined
+                                    : {
+                                          root: styles.compactRoot,
+                                          content: styles.compactContent,
+                                          leftAccessory:
+                                              styles.compactAccessory,
+                                      }
+                            }
+                            leftAccessory={
+                                <RadioCore
+                                    {...ariaProps}
+                                    id={uniqueId}
+                                    checked={checked}
+                                    disabled={disabled}
+                                    error={error}
+                                    groupName={groupName}
+                                    aria-describedby={descriptionId}
+                                    onClick={handleClick}
+                                    ref={ref}
+                                />
+                            }
+                            title={labelNode}
+                            subtitle2={descriptionNode}
+                        />
+                    </View>
+                );
+            }}
+        </Id>
     );
+});
+
+const styles = StyleSheet.create({
+    // Strip the DetailCell padding/min-height/background so the default
+    // appearance renders as the compact radio row it was before.
+    compactRoot: {
+        paddingBlock: 0,
+        paddingInline: 0,
+        minBlockSize: 0,
+        gap: sizing.size_080,
+        background: semanticColor.core.transparent,
+        // DetailCell clips overflow to contain its selected/press indicator.
+        // The compact radio has no such indicator, and clipping would cut off
+        // the radio input's focus ring, so restore visible overflow.
+        overflow: "visible",
+        // DetailCell's wrapper uses `flex: 1`, which makes the cell grow to
+        // fill the container. That would swallow any vertical alignment (e.g.
+        // `justifyContent`/fixed height) applied by a consumer to the choice's
+        // container. Keep the cell at its natural height so those styles work
+        // as they did before this component composed DetailCell.
+        flex: "0 1 auto",
+    },
+    // Top-align the label/description with the radio input, and match the
+    // original 4px (size_040) spacing between the label and description
+    // (DetailCell's default content gap is only 2px).
+    compactContent: {
+        alignSelf: "flex-start",
+        gap: sizing.size_040,
+    },
+    // Account for half of the default label lineHeight difference, which is
+    // 18px (label text) - 16px (radio size). This equals 1 pixel above and 1
+    // pixel below to be vertically centered with the label.
+    compactAccessory: {
+        alignSelf: "flex-start",
+        marginBlockStart: sizing.size_010,
+    },
+    label: {
+        color: semanticColor.core.foreground.neutral.strong,
+        lineHeight: font.body.lineHeight.small,
+    },
+    disabledLabel: {
+        // Match disabled text input label color
+        color: semanticColor.core.foreground.disabled.subtle,
+    },
+    description: {
+        color: theme.description.color.foreground,
+    },
 });
 
 export default Radio;

--- a/packages/wonder-blocks-form/src/components/radio.tsx
+++ b/packages/wonder-blocks-form/src/components/radio.tsx
@@ -2,7 +2,12 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 
 import {Id, View} from "@khanacademy/wonder-blocks-core";
-import {font, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    font,
+    semanticColor,
+    sizing,
+} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {DetailCell} from "@khanacademy/wonder-blocks-cell";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
@@ -38,6 +43,12 @@ type ChoiceComponentProps = AriaProps & {
      */
     description?: React.ReactNode;
     /**
+     * Optional content rendered at the end of the row (e.g. a "Recommended"
+     * label or an icon). Maps to the underlying `DetailCell`'s `rightAccessory`.
+     * Most useful with `appearance="cell"`.
+     */
+    rightAccessory?: React.ReactNode;
+    /**
      * Unique identifier attached to the HTML input element. If used, need to
      * guarantee that the ID is unique within everything rendered on a page.
      * Used to match `<label>` with `<input>` elements for screenreaders.
@@ -65,13 +76,13 @@ type ChoiceComponentProps = AriaProps & {
      * Controls the visual appearance of the radio.
      *
      * - `"default"` (the default) renders the radio as a compact row (radio
-     *   input + label + description) with no surrounding padding or divider.
-     * - `"cell"` renders the radio using the full `DetailCell` style, adding the
-     *   cell's padding and a horizontal rule so a list of radios reads as a set
-     *   of cells.
+     *   input + label + description) with no surrounding padding or border.
+     * - `"cell"` renders the radio as an individually bordered, rounded card
+     *   (with the `DetailCell` padding). When checked, the card's border uses
+     *   the selected/instructive color, so a group of radios reads as a set of
+     *   selectable cards.
      *
-     * In both cases the layout is composed from `DetailCell`; `appearance` only
-     * toggles the cell's own padding/divider styling.
+     * In both cases the layout is composed from `DetailCell`.
      */
     appearance?: "default" | "cell";
 };
@@ -105,6 +116,7 @@ type ChoiceComponentProps = AriaProps & {
         testId,
         groupName,
         appearance = "default",
+        rightAccessory,
         ...ariaProps
     } = props;
 
@@ -157,12 +169,25 @@ type ChoiceComponentProps = AriaProps & {
                     <View style={style} className={className}>
                         <DetailCell
                             testId={testId}
-                            horizontalRule={
-                                appearance === "cell" ? "inset" : "none"
-                            }
+                            // Both appearances draw their own separators (the
+                            // "cell" appearance renders each radio as a bordered
+                            // card), so DetailCell's built-in rule is never used.
+                            horizontalRule="none"
                             styles={
                                 appearance === "cell"
-                                    ? undefined
+                                    ? {
+                                          // Render the radio as a bordered card
+                                          // that shows a colored border when
+                                          // checked (the "radio as cell" look).
+                                          root: [
+                                              styles.cellCard,
+                                              checked &&
+                                                  styles.cellCardSelected,
+                                          ],
+                                          content: styles.cellContent,
+                                          leftAccessory: styles.cellAccessory,
+                                          rightAccessory: styles.cellAccessory,
+                                      }
                                     : {
                                           root: styles.compactRoot,
                                           content: styles.compactContent,
@@ -185,6 +210,7 @@ type ChoiceComponentProps = AriaProps & {
                             }
                             title={labelNode}
                             subtitle2={descriptionNode}
+                            rightAccessory={rightAccessory}
                         />
                     </View>
                 );
@@ -225,6 +251,30 @@ const styles = StyleSheet.create({
     // pixel below to be vertically centered with the label.
     compactAccessory: {
         alignSelf: "flex-start",
+        marginBlockStart: sizing.size_010,
+    },
+    // "cell" appearance: render each radio as an individually bordered,
+    // rounded card (keeping DetailCell's padding). The border width stays
+    // constant across states to avoid layout shift when selecting.
+    cellCard: {
+        borderStyle: "solid",
+        borderWidth: border.width.medium,
+        borderColor: semanticColor.core.border.neutral.subtle,
+        borderRadius: border.radius.radius_120,
+    },
+    // When checked, the card shows the instructive (selected) border color.
+    cellCardSelected: {
+        borderColor: semanticColor.core.border.instructive.default,
+    },
+    // Align the title/subtitle and the radio to the top of the card so the
+    // radio lines up with the title rather than the vertical center.
+    cellContent: {
+        alignSelf: "flex-start",
+    },
+    cellAccessory: {
+        alignSelf: "flex-start",
+        // Nudge the radio down to vertically center it against the title's
+        // line height.
         marginBlockStart: sizing.size_010,
     },
     label: {

--- a/packages/wonder-blocks-form/src/components/radio.tsx
+++ b/packages/wonder-blocks-form/src/components/radio.tsx
@@ -254,18 +254,24 @@ const styles = StyleSheet.create({
         marginBlockStart: sizing.size_010,
     },
     // "cell" appearance: render each radio as an individually bordered,
-    // rounded card (keeping DetailCell's padding). The border width stays
-    // constant across states to avoid layout shift when selecting.
+    // rounded card (keeping DetailCell's padding).
     cellCard: {
         borderStyle: "solid",
         borderWidth: border.width.thin,
         borderColor: semanticColor.core.border.neutral.subtle,
         borderRadius: border.radius.radius_120,
     },
-    // When checked, the card shows the instructive (selected) border color.
+    // When checked, the card shows the instructive (selected) color. We use an
+    // outline (drawn on top of, and overlapping, the existing border via a
+    // negative offset) rather than changing the border itself, so selecting an
+    // option does not shift the card's layout.
     cellCardSelected: {
-        borderColor: semanticColor.core.border.instructive.default,
-        borderWidth: border.width.medium,
+        outlineStyle: "solid",
+        outlineWidth: border.width.medium,
+        outlineColor: semanticColor.core.border.instructive.default,
+        // Pull the outline in by the border width so it overlaps (and hides)
+        // the neutral border instead of doubling up with it.
+        outlineOffset: `calc(${border.width.thin} * -1)`,
     },
     // Align the title/subtitle and the radio to the top of the card so the
     // radio lines up with the title rather than the vertical center.

--- a/packages/wonder-blocks-form/tsconfig-build.json
+++ b/packages/wonder-blocks-form/tsconfig-build.json
@@ -7,6 +7,7 @@
     },
     "references": [
         {"path": "../wonder-blocks-button/tsconfig-build.json"},
+        {"path": "../wonder-blocks-cell/tsconfig-build.json"},
         {"path": "../wonder-blocks-clickable/tsconfig-build.json"},
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,6 +1026,9 @@ importers:
 
   packages/wonder-blocks-form:
     dependencies:
+      '@khanacademy/wonder-blocks-cell':
+        specifier: workspace:*
+        version: link:../wonder-blocks-cell
       '@khanacademy/wonder-blocks-clickable':
         specifier: workspace:*
         version: link:../wonder-blocks-clickable


### PR DESCRIPTION
## Summary

Refactors `Radio` so it composes `DetailCell` (from `@khanacademy/wonder-blocks-cell`) as its layout skeleton, and adds an `appearance` prop to opt into the full Cell look. This is a POC exploring "radio as cell".

- The radio input renders as the cell's `leftAccessory`, the label as `title`, and the description as `subtitle2`.
- The cell has **no** `onClick`/`href`, so it renders a plain container (not a `Clickable`), keeping the native `<input>` as the single interactive element (avoids nested-interactive a11y issues; label click still selects via `<label htmlFor>`).
- New **`appearance`** prop (`"default" | "cell"`), forwarded through `Choice` and `RadioGroup`:
  - `"default"` (the default) preserves the current compact radio row.
  - `"cell"` opts into DetailCell's padding + horizontal rule, so a `RadioGroup appearance="cell"` reads as a list of cells.
- **Scope:** Radio only — `Checkbox`/`ChoiceInternal` are untouched.

## Preserving the current look

The default appearance strips DetailCell's padding/min-height/background and restores the original layout details:
- label `line-height` and 4px (`size_040`) label↔description spacing,
- `overflow: visible` so the radio's focus ring isn't clipped,
- `flex: 0 1 auto` overriding DetailCell's `flex: 1`, so consumer container styles (e.g. fixed height + `justifyContent`) position content exactly as before.

## Test plan

- `pnpm typecheck` — clean
- `pnpm lint` (changed files) — clean
- `pnpm jest` `wonder-blocks-form` suite — passes (incl. `checkbox`/`checkbox-group`, confirming the `Choice` restructure didn't regress checkboxes)
- Storybook: new `Radio > Appearance` and `RadioGroup > CellAppearance` stories; default-appearance stories verified against the previous look.

## Notes / follow-ups

- Chromatic diffs expected even for `appearance="default"` (DOM structure changed); review against "close to current".
- `appearance` set on a `RadioGroup` wins over a per-`Choice` value (injected last in `cloneElement`).
- Label-less radios pass `title=""` (empty node).