### PR TITLE
⚠️ [WB-2331] Phase 5 / Wave C — Migrate Typography to CSS Modules

### DIFF
--- a/.changeset/css-modules-phase-5-typography.md
+++ b/.changeset/css-modules-phase-5-typography.md
@@ -1,0 +1,23 @@
+---
+"@khanacademy/wonder-blocks-typography": minor
+---
+
+Migrate the internal styles of `Heading`, `BodyText`, and `BodyMonospace`
+from Aphrodite to CSS Modules (WB-2331, CSS Modules Phase 5 / Wave C).
+
+- Each component's size/weight variants now live in colocated
+  `heading.module.css` / `body-text.module.css` / `body-monospace.module.css`
+  files, consuming the `--wb-font-*` design tokens and authored inside the
+  shared `@layer shared` cascade layer.
+- The class names route through the existing `Text` / `processStyleList`
+  pipeline (Phase 1), so consumer-provided Aphrodite styles, inline styles,
+  and `style` props continue to compose exactly as before.
+- The package now ships a bundled `dist/index.css`, auto-imported via a
+  side-effect import in the JS entry. SSR consumers that can't process CSS
+  imports may need a CSS loader / mock in their build (standard webpack /
+  Vite / Next.js setups handle this out of the box).
+
+Public API is unchanged. The Aphrodite `styles` export
+(`import {styles} from "@khanacademy/wonder-blocks-typography"`) is
+intentionally retained for cross-package consumers, so the package still
+imports Aphrodite for that export.

--- a/packages/wonder-blocks-typography/src/components/body-monospace.module.css
+++ b/packages/wonder-blocks-typography/src/components/body-monospace.module.css
@@ -1,0 +1,11 @@
+/* Styles for `BodyMonospace`. Tokens come from
+ * `@khanacademy/wonder-blocks-tokens`; the build wraps these rules in
+ * `@layer shared { … }` via the wrap-in-layer plugin in `postcss.config.cjs`. */
+
+.bodyMonospace {
+    display: block;
+    font-family: var(--wb-font-family-mono);
+    font-weight: var(--wb-font-weight-medium);
+    font-size: var(--wb-font-body-size-medium);
+    line-height: var(--wb-font-body-lineHeight-medium);
+}

--- a/packages/wonder-blocks-typography/src/components/body-monospace.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-monospace.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
 
-import styles from "../util/styles";
+import styles from "./body-monospace.module.css";
 
 type Props = PropsFor<typeof Text>;
 
@@ -13,7 +13,7 @@ const BodyMonospace = React.forwardRef(function BodyMonospace(
         <Text
             {...otherProps}
             tag={tag}
-            style={[styles.BodyMonospace, style]}
+            style={[styles.bodyMonospace, style]}
             ref={ref}
         >
             {children}

--- a/packages/wonder-blocks-typography/src/components/body-text.module.css
+++ b/packages/wonder-blocks-typography/src/components/body-text.module.css
@@ -1,0 +1,67 @@
+/* Styles for `BodyText`. Tokens come from `@khanacademy/wonder-blocks-tokens`;
+ * the build wraps these rules in `@layer shared { … }` via the wrap-in-layer
+ * plugin in `postcss.config.cjs`.
+ *
+ * `.bodyText` holds the properties shared by every size/weight combination. The
+ * component always applies it alongside the matched variant class, so the
+ * variant classes only carry the differing size/weight/line-height. */
+
+.bodyText {
+    display: block;
+    font-family: var(--wb-font-family-sans);
+    margin: 0;
+}
+
+.xsmallMedium {
+    font-size: var(--wb-font-body-size-xsmall);
+    font-weight: var(--wb-font-weight-medium);
+    line-height: var(--wb-font-body-lineHeight-xsmall);
+}
+
+.xsmallSemi {
+    font-size: var(--wb-font-body-size-xsmall);
+    font-weight: var(--wb-font-weight-semi);
+    line-height: var(--wb-font-body-lineHeight-xsmall);
+}
+
+.xsmallBold {
+    font-size: var(--wb-font-body-size-xsmall);
+    font-weight: var(--wb-font-weight-bold);
+    line-height: var(--wb-font-body-lineHeight-xsmall);
+}
+
+.smallMedium {
+    font-size: var(--wb-font-body-size-small);
+    font-weight: var(--wb-font-weight-medium);
+    line-height: var(--wb-font-body-lineHeight-small);
+}
+
+.smallSemi {
+    font-size: var(--wb-font-body-size-small);
+    font-weight: var(--wb-font-weight-semi);
+    line-height: var(--wb-font-body-lineHeight-small);
+}
+
+.smallBold {
+    font-size: var(--wb-font-body-size-small);
+    font-weight: var(--wb-font-weight-bold);
+    line-height: var(--wb-font-body-lineHeight-small);
+}
+
+.mediumMedium {
+    font-size: var(--wb-font-body-size-medium);
+    font-weight: var(--wb-font-weight-medium);
+    line-height: var(--wb-font-body-lineHeight-medium);
+}
+
+.mediumSemi {
+    font-size: var(--wb-font-body-size-medium);
+    font-weight: var(--wb-font-weight-semi);
+    line-height: var(--wb-font-body-lineHeight-medium);
+}
+
+.mediumBold {
+    font-size: var(--wb-font-body-size-medium);
+    font-weight: var(--wb-font-weight-bold);
+    line-height: var(--wb-font-body-lineHeight-medium);
+}

--- a/packages/wonder-blocks-typography/src/components/body-text.tsx
+++ b/packages/wonder-blocks-typography/src/components/body-text.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
-import styles from "../util/styles";
+import styles from "./body-text.module.css";
 
 type Props = PropsFor<typeof Text> & {
     size?: "xsmall" | "small" | "medium";
@@ -9,15 +9,15 @@ type Props = PropsFor<typeof Text> & {
 
 // List style combinations for matching with props
 const styleMapping = {
-    "xsmall-medium": styles.BodyTextXSmallMediumWeight,
-    "xsmall-semi": styles.BodyTextXSmallSemiWeight,
-    "xsmall-bold": styles.BodyTextXSmallBoldWeight,
-    "small-medium": styles.BodyTextSmallMediumWeight,
-    "small-semi": styles.BodyTextSmallSemiWeight,
-    "small-bold": styles.BodyTextSmallBoldWeight,
-    "medium-medium": styles.BodyTextMediumMediumWeight,
-    "medium-semi": styles.BodyTextMediumSemiWeight,
-    "medium-bold": styles.BodyTextMediumBoldWeight,
+    "xsmall-medium": styles.xsmallMedium,
+    "xsmall-semi": styles.xsmallSemi,
+    "xsmall-bold": styles.xsmallBold,
+    "small-medium": styles.smallMedium,
+    "small-semi": styles.smallSemi,
+    "small-bold": styles.smallBold,
+    "medium-medium": styles.mediumMedium,
+    "medium-semi": styles.mediumSemi,
+    "medium-bold": styles.mediumBold,
 } as const;
 
 const BodyText = React.forwardRef(function BodyText(
@@ -37,7 +37,7 @@ const BodyText = React.forwardRef(function BodyText(
         <Text
             {...otherProps}
             tag={tag}
-            style={[styles.BodyText, themeBodyText, style]}
+            style={[styles.bodyText, themeBodyText, style]}
             ref={ref}
         >
             {children}

--- a/packages/wonder-blocks-typography/src/components/heading.module.css
+++ b/packages/wonder-blocks-typography/src/components/heading.module.css
@@ -1,0 +1,102 @@
+/* Styles for `Heading`. Tokens come from `@khanacademy/wonder-blocks-tokens`;
+ * the build wraps these rules in `@layer shared { … }` via the wrap-in-layer
+ * plugin in `postcss.config.cjs`.
+ *
+ * `.heading` holds the properties shared by every size/weight combination. The
+ * component always applies it alongside the matched variant class, so the
+ * variant classes only carry the differing size/weight/line-height. */
+
+.heading {
+    display: block;
+    font-family: var(--wb-font-family-sans);
+}
+
+.smallBold {
+    font-size: var(--wb-font-heading-size-small);
+    font-weight: var(--wb-font-weight-bold);
+    line-height: var(--wb-font-heading-lineHeight-small);
+}
+
+.smallSemi {
+    font-size: var(--wb-font-heading-size-small);
+    font-weight: var(--wb-font-weight-semi);
+    line-height: var(--wb-font-heading-lineHeight-small);
+}
+
+.smallMedium {
+    font-size: var(--wb-font-heading-size-small);
+    font-weight: var(--wb-font-weight-medium);
+    line-height: var(--wb-font-heading-lineHeight-small);
+}
+
+.mediumBold {
+    font-size: var(--wb-font-heading-size-medium);
+    font-weight: var(--wb-font-weight-bold);
+    line-height: var(--wb-font-heading-lineHeight-medium);
+}
+
+.mediumSemi {
+    font-size: var(--wb-font-heading-size-medium);
+    font-weight: var(--wb-font-weight-semi);
+    line-height: var(--wb-font-heading-lineHeight-medium);
+}
+
+.mediumMedium {
+    font-size: var(--wb-font-heading-size-medium);
+    font-weight: var(--wb-font-weight-medium);
+    line-height: var(--wb-font-heading-lineHeight-medium);
+}
+
+.largeBold {
+    font-size: var(--wb-font-heading-size-large);
+    font-weight: var(--wb-font-weight-bold);
+    line-height: var(--wb-font-heading-lineHeight-large);
+}
+
+.largeSemi {
+    font-size: var(--wb-font-heading-size-large);
+    font-weight: var(--wb-font-weight-semi);
+    line-height: var(--wb-font-heading-lineHeight-large);
+}
+
+.largeMedium {
+    font-size: var(--wb-font-heading-size-large);
+    font-weight: var(--wb-font-weight-medium);
+    line-height: var(--wb-font-heading-lineHeight-large);
+}
+
+.xlargeBold {
+    font-size: var(--wb-font-heading-size-xlarge);
+    font-weight: var(--wb-font-weight-bold);
+    line-height: var(--wb-font-heading-lineHeight-xlarge);
+}
+
+.xlargeSemi {
+    font-size: var(--wb-font-heading-size-xlarge);
+    font-weight: var(--wb-font-weight-semi);
+    line-height: var(--wb-font-heading-lineHeight-xlarge);
+}
+
+.xlargeMedium {
+    font-size: var(--wb-font-heading-size-xlarge);
+    font-weight: var(--wb-font-weight-medium);
+    line-height: var(--wb-font-heading-lineHeight-xlarge);
+}
+
+.xxlargeBold {
+    font-size: var(--wb-font-heading-size-xxlarge);
+    font-weight: var(--wb-font-weight-bold);
+    line-height: var(--wb-font-heading-lineHeight-xxlarge);
+}
+
+.xxlargeSemi {
+    font-size: var(--wb-font-heading-size-xxlarge);
+    font-weight: var(--wb-font-weight-semi);
+    line-height: var(--wb-font-heading-lineHeight-xxlarge);
+}
+
+.xxlargeMedium {
+    font-size: var(--wb-font-heading-size-xxlarge);
+    font-weight: var(--wb-font-weight-medium);
+    line-height: var(--wb-font-heading-lineHeight-xxlarge);
+}

--- a/packages/wonder-blocks-typography/src/components/heading.tsx
+++ b/packages/wonder-blocks-typography/src/components/heading.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import {PropsFor, Text} from "@khanacademy/wonder-blocks-core";
-import styles from "../util/styles";
+import styles from "./heading.module.css";
 
 const tagMap = {
     xxlarge: "h1",
@@ -20,21 +20,21 @@ type Props = PropsFor<typeof Text> & {
 
 // List style combinations for matching with props
 const styleMapping = {
-    "small-medium": styles.HeadingSmallMediumWeight,
-    "small-semi": styles.HeadingSmallSemiWeight,
-    "small-bold": styles.HeadingSmallBoldWeight,
-    "medium-medium": styles.HeadingMediumMediumWeight,
-    "medium-semi": styles.HeadingMediumSemiWeight,
-    "medium-bold": styles.HeadingMediumBoldWeight,
-    "large-medium": styles.HeadingLargeMediumWeight,
-    "large-semi": styles.HeadingLargeSemiWeight,
-    "large-bold": styles.HeadingLargeBoldWeight,
-    "xlarge-medium": styles.HeadingXLargeMediumWeight,
-    "xlarge-semi": styles.HeadingXLargeSemiWeight,
-    "xlarge-bold": styles.HeadingXLargeBoldWeight,
-    "xxlarge-medium": styles.HeadingXxLargeMediumWeight,
-    "xxlarge-semi": styles.HeadingXxLargeSemiWeight,
-    "xxlarge-bold": styles.HeadingXxLargeBoldWeight,
+    "small-medium": styles.smallMedium,
+    "small-semi": styles.smallSemi,
+    "small-bold": styles.smallBold,
+    "medium-medium": styles.mediumMedium,
+    "medium-semi": styles.mediumSemi,
+    "medium-bold": styles.mediumBold,
+    "large-medium": styles.largeMedium,
+    "large-semi": styles.largeSemi,
+    "large-bold": styles.largeBold,
+    "xlarge-medium": styles.xlargeMedium,
+    "xlarge-semi": styles.xlargeSemi,
+    "xlarge-bold": styles.xlargeBold,
+    "xxlarge-medium": styles.xxlargeMedium,
+    "xxlarge-semi": styles.xxlargeSemi,
+    "xxlarge-bold": styles.xxlargeBold,
 } as const;
 
 const Heading = React.forwardRef(function Heading(props: Props, ref) {
@@ -53,7 +53,7 @@ const Heading = React.forwardRef(function Heading(props: Props, ref) {
         <Text
             {...otherProps}
             tag={resolvedTag}
-            style={[styles.Heading, themeHeading, style]}
+            style={[styles.heading, themeHeading, style]}
             ref={ref}
         >
             {children}


### PR DESCRIPTION
## Summary:
Migrate the internal styles of `Heading`, `BodyText`, and `BodyMonospace`
from Aphrodite to CSS Modules (CSS Modules Phase 5 / Wave C of epic WB-2120).
Each component's size/weight variants now live in colocated `*.module.css`
files consuming `--wb-font-*` tokens, authored inside the shared `@layer
shared` cascade layer and routed through the existing `Text` /
`processStyleList` pipeline.

The public API is unchanged: the Aphrodite `styles` export is intentionally
retained for the 5 not-yet-migrated cross-package consumers
(search-field, tabs, form), so `util/styles.ts` still imports Aphrodite and
the wave's "zero aphrodite imports" checklist item is deferred to a later
wave. The package now ships a bundled `dist/index.css` auto-imported via a
side-effect import in the JS entry (SSR consumers may need a CSS loader/mock).

Verified: stylelint, typecheck, eslint, and the full jest suite all pass with
zero snapshot changes across consumer packages; the build emits the classes
in `@layer shared` with tokens resolved to `var(--wb-font-*)`. Pixel-level
visual parity in both themes still needs Chromatic review.

Issue: WB-2331

## Test plan:

Automated (no action needed):
- `pnpm stylelint` on the new `*.module.css` — clean.
- `pnpm typecheck` — clean (generated `.d.ts` class names match every mapping).
- `pnpm eslint` on the 3 components — clean.
- Full `pnpm jest` — pass, no snapshot changes in any consumer package.
- `pnpm build` — emits `dist/index.css` wrapped in `@layer shared`; ESM/CJS
  entries auto-import the CSS; Aphrodite `styles` export still present.

Manual (human):
- Chromatic visual review in both themes (default + dark) — confirm Heading,
  BodyText, and BodyMonospace render identically at every size/weight.
  Storybook: Typography docs page (e.g. `?path=/docs/typography-heading--docs`).

## Review plan:

Please review these risky changes

1. ⚠️ [`heading.tsx`](https://github.com/Khan/wonder-blocks/pull/3146#discussion_r3552344989)
2. ⚠️ [`body-text.tsx`](https://github.com/Khan/wonder-blocks/pull/3146#discussion_r3552345104)
3. ⚠️ [`body-monospace.tsx`](https://github.com/Khan/wonder-blocks/pull/3146#discussion_r3552345204)

### Common patterns:

**3 Files:** Replace the shared Aphrodite `StyleSheet` import with a colocated per-component CSS Module and remap the style keys to camelCase class names; the base + variant classes are composed via the existing `style` prop array.

```tsx
// before
import styles from "../util/styles";
const styleMapping = {
    "small-bold": styles.HeadingSmallBoldWeight,
    // ...
};
// <Text style={[styles.Heading, themeHeading, style]} />

// after
import styles from "./heading.module.css";
const styleMapping = {
    "small-bold": styles.smallBold,
    // ...
};
// <Text style={[styles.heading, themeHeading, style]} />
```
