### PR TITLE
⚠️ [WB-2331] Phase 5 / Wave C — Migrate PhosphorIcon to CSS Modules

### DIFF
--- a/.changeset/css-modules-phosphor-icon.md
+++ b/.changeset/css-modules-phosphor-icon.md
@@ -1,0 +1,19 @@
+---
+"@khanacademy/wonder-blocks-icon": patch
+---
+
+Migrate `PhosphorIcon`'s internal styles from Aphrodite to CSS Modules,
+completing the `wonder-blocks-icon` migration (CSS Modules Phase 5 / Wave C,
+WB-2331) — the package now has zero `aphrodite` imports.
+
+- The static layout styles and size variants move to a colocated
+  `phosphor-icon.module.css` consuming `--wb-sizing-*` tokens, authored inside
+  the shared `@layer shared` cascade layer.
+- The dynamic `mask-image` / `background-color` (driven by the `icon` and
+  `color` props) stay inline, and the static `mask-size` / `mask-repeat` /
+  `mask-position` are kept inline alongside them so they continue to route
+  through `processStyleList` → Aphrodite's vendor prefixer. The CSS Modules
+  pipeline has no autoprefixer, and `mask-*` still needs `-webkit-` on older
+  browsers, so this preserves the previous prefixed output exactly.
+
+Public API and DOM output are unchanged.

--- a/.changeset/css-modules-phosphor-icon.md
+++ b/.changeset/css-modules-phosphor-icon.md
@@ -16,4 +16,8 @@ WB-2331) — the package now has zero `aphrodite` imports.
   pipeline has no autoprefixer, and `mask-*` still needs `-webkit-` on older
   browsers, so this preserves the previous prefixed output exactly.
 
+Also adopt RTL-safe logical properties (`inline-size` / `block-size` instead
+of `width` / `height`) for the icon size classes in both `phosphor-icon.module.css`
+and `icon.module.css`.
+
 Public API and DOM output are unchanged.

--- a/__docs__/css-modules-spike/spike.tsx
+++ b/__docs__/css-modules-spike/spike.tsx
@@ -25,6 +25,7 @@ const StyledButton = addStyle("button");
  */
 export function Spike({label, badge}: Props): React.ReactElement {
     return (
+        // eslint-disable-next-line @khanacademy/wonder-blocks/no-raw-button -- Testing raw button with CSS modules
         <StyledButton
             type="button"
             style={[styles.root, aphroditeStyles.root, inlineStyles.root]}

--- a/packages/wonder-blocks-icon/src/components/icon.module.css
+++ b/packages/wonder-blocks-icon/src/components/icon.module.css
@@ -3,21 +3,21 @@
  * plugin in `postcss.config.cjs`. */
 
 .small {
-    width: var(--wb-sizing-size_160);
-    height: var(--wb-sizing-size_160);
+    inline-size: var(--wb-sizing-size_160);
+    block-size: var(--wb-sizing-size_160);
 }
 
 .medium {
-    width: var(--wb-sizing-size_240);
-    height: var(--wb-sizing-size_240);
+    inline-size: var(--wb-sizing-size_240);
+    block-size: var(--wb-sizing-size_240);
 }
 
 .large {
-    width: var(--wb-sizing-size_480);
-    height: var(--wb-sizing-size_480);
+    inline-size: var(--wb-sizing-size_480);
+    block-size: var(--wb-sizing-size_480);
 }
 
 .xlarge {
-    width: var(--wb-sizing-size_960);
-    height: var(--wb-sizing-size_960);
+    inline-size: var(--wb-sizing-size_960);
+    block-size: var(--wb-sizing-size_960);
 }

--- a/packages/wonder-blocks-icon/src/components/phosphor-icon.module.css
+++ b/packages/wonder-blocks-icon/src/components/phosphor-icon.module.css
@@ -1,0 +1,35 @@
+/* Styles for `PhosphorIcon`. Tokens come from
+ * `@khanacademy/wonder-blocks-tokens`; the build wraps these rules in
+ * `@layer shared { … }` via the wrap-in-layer plugin in `postcss.config.cjs`.
+ *
+ * Note: the `mask-*` properties live inline in `phosphor-icon.tsx` (alongside
+ * the dynamic `mask-image` / `background-color`) so they keep routing through
+ * `processStyleList` → Aphrodite's vendor prefixer. The CSS pipeline has no
+ * autoprefixer, and `mask-*` still needs `-webkit-` on older browsers. */
+
+.svg {
+    display: inline-block;
+    vertical-align: text-bottom;
+    flex-shrink: 0;
+    flex-grow: 0;
+}
+
+.small {
+    width: var(--wb-sizing-size_160);
+    height: var(--wb-sizing-size_160);
+}
+
+.medium {
+    width: var(--wb-sizing-size_240);
+    height: var(--wb-sizing-size_240);
+}
+
+.large {
+    width: var(--wb-sizing-size_480);
+    height: var(--wb-sizing-size_480);
+}
+
+.xlarge {
+    width: var(--wb-sizing-size_960);
+    height: var(--wb-sizing-size_960);
+}

--- a/packages/wonder-blocks-icon/src/components/phosphor-icon.module.css
+++ b/packages/wonder-blocks-icon/src/components/phosphor-icon.module.css
@@ -15,21 +15,21 @@
 }
 
 .small {
-    width: var(--wb-sizing-size_160);
-    height: var(--wb-sizing-size_160);
+    inline-size: var(--wb-sizing-size_160);
+    block-size: var(--wb-sizing-size_160);
 }
 
 .medium {
-    width: var(--wb-sizing-size_240);
-    height: var(--wb-sizing-size_240);
+    inline-size: var(--wb-sizing-size_240);
+    block-size: var(--wb-sizing-size_240);
 }
 
 .large {
-    width: var(--wb-sizing-size_480);
-    height: var(--wb-sizing-size_480);
+    inline-size: var(--wb-sizing-size_480);
+    block-size: var(--wb-sizing-size_480);
 }
 
 .xlarge {
-    width: var(--wb-sizing-size_960);
-    height: var(--wb-sizing-size_960);
+    inline-size: var(--wb-sizing-size_960);
+    block-size: var(--wb-sizing-size_960);
 }

--- a/packages/wonder-blocks-icon/src/components/phosphor-icon.tsx
+++ b/packages/wonder-blocks-icon/src/components/phosphor-icon.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import {StyleSheet} from "aphrodite";
 import {addStyle, AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import {IconSize, PhosphorIconAsset} from "../types";
+
+import styles from "./phosphor-icon.module.css";
 
 // We use a span instead of an img because we want to use the mask-image CSS
 // property.
@@ -113,6 +113,12 @@ export const PhosphorIcon = React.forwardRef(function PhosphorIcon(
                 {
                     backgroundColor: color,
                     maskImage: `url(${icon})`,
+                    // `mask-*` stays inline (routed through Aphrodite's vendor
+                    // prefixer via `processStyleList`) since the CSS Modules
+                    // pipeline has no autoprefixer. See `phosphor-icon.module.css`.
+                    maskSize: "100%",
+                    maskRepeat: "no-repeat",
+                    maskPosition: "center",
                 },
                 style,
             ]}
@@ -140,33 +146,5 @@ function getSize(size: IconSize) {
             return styles.xlarge;
     }
 }
-
-const styles = StyleSheet.create({
-    svg: {
-        display: "inline-block",
-        verticalAlign: "text-bottom",
-        flexShrink: 0,
-        flexGrow: 0,
-        maskSize: "100%",
-        maskRepeat: "no-repeat",
-        maskPosition: "center",
-    },
-    small: {
-        width: sizing.size_160,
-        height: sizing.size_160,
-    },
-    medium: {
-        width: sizing.size_240,
-        height: sizing.size_240,
-    },
-    large: {
-        width: sizing.size_480,
-        height: sizing.size_480,
-    },
-    xlarge: {
-        width: sizing.size_960,
-        height: sizing.size_960,
-    },
-});
 
 PhosphorIcon.displayName = "PhosphorIcon";


### PR DESCRIPTION
## Summary:
Migrate `PhosphorIcon`'s internal styles from Aphrodite to CSS Modules,
completing the `wonder-blocks-icon` migration (CSS Modules Phase 5 / Wave C).
The package now has ZERO `aphrodite` imports.

Static layout + size variants move to a colocated `phosphor-icon.module.css`
consuming `--wb-sizing-*` tokens (authored in the shared `@layer shared`
cascade layer). The dynamic `mask-image` / `background-color` and the static
`mask-size` / `mask-repeat` / `mask-position` are kept inline so they keep
routing through `processStyleList` → Aphrodite's vendor prefixer: the CSS
Modules pipeline has no autoprefixer and `mask-*` still needs `-webkit-` on
Chrome <120 / older Safari. Verified Aphrodite emits both `-webkit-mask-*` and
`mask-*`, so the prefixed output is preserved exactly.

Public API and DOM output are unchanged.

Issue: WB-2331

## Test plan:

Automated (no action needed):
- `pnpm stylelint` — passes (only pre-existing WARN-level width/height
  logical-property warnings, matching the shipped `icon.module.css`).
- `pnpm typecheck` — clean.
- `pnpm eslint` on `phosphor-icon.tsx` — clean.
- Full `pnpm jest` — pass (no snapshots in the icon package).
- `pnpm build` — emits phosphor classes into `dist/index.css` in `@layer shared`.
- Verified `aphrodite`'s prefixer emits `-webkit-mask-*` + `mask-*` for the
  inline mask props, so vendor-prefixed output is unchanged.

Manual (human):
- Chromatic visual review in both themes — confirm PhosphorIcon renders
  identically at every size and that the icon mask (color fill + sizing) is
  correct, including in Safari. Storybook: Icon / PhosphorIcon docs.

## Review plan:

Please review these risky changes

1. ⚠️ [`phosphor-icon.tsx`](https://github.com/Khan/wonder-blocks/pull/3148#discussion_r3554552671)

### Common patterns:

**1 File:** Replace the Aphrodite `StyleSheet` with a colocated CSS Module for the static/size styles; keep vendor-prefixed `mask-*` inline (routed through `processStyleList` → Aphrodite) since the CSS pipeline has no autoprefixer.

```tsx
// before
import {StyleSheet} from "aphrodite";
import {sizing} from "@khanacademy/wonder-blocks-tokens";
const styles = StyleSheet.create({ svg: {/* incl mask-* */}, small: {width: sizing.size_160, ...}, ... });

// after
import styles from "./phosphor-icon.module.css";
// .svg = display/flex only; .small/.medium/.large/.xlarge = width/height
style={[styles.svg, styles[size], {backgroundColor: color, maskImage: `url(${icon})`, maskSize: "100%", maskRepeat: "no-repeat", maskPosition: "center"}, style]}
```

