### PR TITLE
Fix useCachedEffect refetching with unmemoized onResultChanged

### DIFF
--- a/.changeset/thick-pugs-cheat.md
+++ b/.changeset/thick-pugs-cheat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": patch
+---
+
+Fix `useCachedEffect` refetching forever when an unmemoized `onResultChanged` callback is passed with the `CacheAndNetwork` or `NetworkOnly` fetch policies. The callback is now tracked via a latest-value ref so its identity no longer invalidates the memoized fetch function (which cancelled the inflight request and restarted the fetch); the most recently supplied callback is still the one invoked when a result arrives.

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.tsx
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.tsx
@@ -846,10 +846,41 @@ describe("#useCachedEffect", () => {
                 });
 
                 // Assert
-                expect(firstCallback).not.toHaveBeenCalled();
                 expect(latestCallback).toHaveBeenCalledWith(
                     Status.success("DATA"),
                 );
+            },
+        );
+
+        it.each([FetchPolicy.CacheAndNetwork, FetchPolicy.NetworkOnly])(
+            "should not invoke a replaced onResultChanged for FetchPolicy.%s",
+            async (fetchPolicy: any) => {
+                // Arrange
+                let resolveResponse: (value: string) => void;
+                const response: any = new Promise((resolve) => {
+                    resolveResponse = resolve;
+                });
+                const fakeHandler = jest.fn().mockReturnValue(response);
+                const firstCallback = jest.fn();
+                const latestCallback = jest.fn();
+                const {rerender} = clientRenderHook(
+                    ({onResultChanged}: any) =>
+                        useCachedEffect("ID", fakeHandler, {
+                            onResultChanged,
+                            fetchPolicy,
+                        }),
+                    {initialProps: {onResultChanged: firstCallback}},
+                );
+
+                // Act
+                rerender({onResultChanged: latestCallback});
+                await act(async () => {
+                    resolveResponse("DATA");
+                    await response;
+                });
+
+                // Assert
+                expect(firstCallback).not.toHaveBeenCalled();
             },
         );
     });

--- a/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.tsx
+++ b/packages/wonder-blocks-data/src/hooks/__tests__/use-cached-effect.test.tsx
@@ -784,5 +784,73 @@ describe("#useCachedEffect", () => {
                 expect(onResultChanged).toHaveBeenCalledTimes(1);
             },
         );
+
+        it.each([FetchPolicy.CacheAndNetwork, FetchPolicy.NetworkOnly])(
+            "should not restart the inflight fetch when onResultChanged identity changes for FetchPolicy.%s",
+            async (fetchPolicy: any) => {
+                // Arrange
+                let resolveResponse: (value: string) => void;
+                const response: any = new Promise((resolve) => {
+                    resolveResponse = resolve;
+                });
+                const fakeHandler = jest.fn().mockReturnValue(response);
+                const {rerender} = clientRenderHook(
+                    () =>
+                        useCachedEffect("ID", fakeHandler, {
+                            // A fresh callback identity on every render, as
+                            // an unmemoized consumer would pass.
+                            onResultChanged: () => {},
+                            fetchPolicy,
+                        }),
+                    {initialProps: {}},
+                );
+
+                // Act
+                rerender({});
+                rerender({});
+                await act(async () => {
+                    resolveResponse("DATA");
+                    await response;
+                });
+
+                // Assert
+                expect(fakeHandler).toHaveBeenCalledTimes(1);
+            },
+        );
+
+        it.each([FetchPolicy.CacheAndNetwork, FetchPolicy.NetworkOnly])(
+            "should invoke the most recently supplied onResultChanged for FetchPolicy.%s",
+            async (fetchPolicy: any) => {
+                // Arrange
+                let resolveResponse: (value: string) => void;
+                const response: any = new Promise((resolve) => {
+                    resolveResponse = resolve;
+                });
+                const fakeHandler = jest.fn().mockReturnValue(response);
+                const firstCallback = jest.fn();
+                const latestCallback = jest.fn();
+                const {rerender} = clientRenderHook(
+                    ({onResultChanged}: any) =>
+                        useCachedEffect("ID", fakeHandler, {
+                            onResultChanged,
+                            fetchPolicy,
+                        }),
+                    {initialProps: {onResultChanged: firstCallback}},
+                );
+
+                // Act
+                rerender({onResultChanged: latestCallback});
+                await act(async () => {
+                    resolveResponse("DATA");
+                    await response;
+                });
+
+                // Assert
+                expect(firstCallback).not.toHaveBeenCalled();
+                expect(latestCallback).toHaveBeenCalledWith(
+                    Status.success("DATA"),
+                );
+            },
+        );
     });
 });

--- a/packages/wonder-blocks-data/src/hooks/use-cached-effect.ts
+++ b/packages/wonder-blocks-data/src/hooks/use-cached-effect.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {useForceUpdate} from "@khanacademy/wonder-blocks-core";
+import {useForceUpdate, useLatestRef} from "@khanacademy/wonder-blocks-core";
 import {DataError, DataErrors} from "../util/data-error";
 
 import {RequestFulfillment} from "../util/request-fulfillment";
@@ -136,6 +136,13 @@ export const useCachedEffect = <TData extends ValidCacheData>(
         scope,
     );
     const forceUpdate = useForceUpdate();
+    // We keep the latest onResultChanged callback in a ref so that the
+    // fetch function below can invoke the most recently supplied callback
+    // without the callback's identity invalidating the memoized fetch
+    // function (which would cancel inflight requests and, for network-based
+    // fetch policies, trigger an endless refetch loop when callers pass an
+    // unmemoized callback).
+    const onResultChangedRef = useLatestRef(onResultChanged);
     // For the NetworkOnly fetch policy, we ignore the cached value.
     // So we need somewhere else to store the network value.
     const networkResultRef = React.useRef<Result<TData> | null>();
@@ -208,6 +215,7 @@ export const useCachedEffect = <TData extends ValidCacheData>(
                 setMostRecentResult(result);
                 networkResultRef.current = result;
 
+                const onResultChanged = onResultChangedRef.current;
                 if (onResultChanged != null) {
                     // If we have a callback, call it to let our caller know we
                     // got a result.
@@ -239,13 +247,7 @@ export const useCachedEffect = <TData extends ValidCacheData>(
         // really make sense - the same requestId should be handled the same as
         // each other.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [
-        requestId,
-        onResultChanged,
-        forceUpdate,
-        setMostRecentResult,
-        fetchPolicy,
-    ]);
+    }, [requestId, forceUpdate, setMostRecentResult, fetchPolicy]);
 
     // Calculate if we want to fetch the result or not.
     // If this is true, we will do a new fetch, cancelling the previous fetch


### PR DESCRIPTION
## Summary

Issue: FEI-8109

Fixed `useCachedEffect` entering an endless refetch loop when an unmemoized `onResultChanged` callback is passed with the `CacheAndNetwork` or `NetworkOnly` fetch policies.

## Changes

- **Use `useLatestRef` for `onResultChanged`**: The callback is now tracked via a latest-value ref so its identity no longer invalidates the memoized fetch function. This prevents cancellation and restart of inflight requests when the callback's identity changes between renders.
- **Remove `onResultChanged` from dependency array**: Since the callback is accessed via ref, it's no longer needed in the memo's dependencies, preventing unnecessary fetch restarts.
- **Preserve callback invocation semantics**: The most recently supplied `onResultChanged` callback is still invoked when a result arrives, maintaining the expected behavior for callers who update the callback between renders.

## Implementation Details

The fix uses `useLatestRef` from `@khanacademy/wonder-blocks-core` to maintain a reference to the latest `onResultChanged` callback without affecting the memoized fetch function's dependencies. This allows the fetch logic to invoke the current callback while preventing identity changes from triggering fetch cancellation and restart cycles.

Added test coverage to verify:
- Inflight fetches are not restarted when callback identity changes
- The most recently supplied callback is invoked with results
- Previously supplied callbacks are not invoked after being replaced

Includes a patch changeset for `@khanacademy/wonder-blocks-data`.

https://claude.ai/code/session_01Firs1rBtyAXz4LJKGB1wbZ