### PR TITLE
🚨 [CSS Modules] Migrate Button to CSS Modules

### DIFF
--- a/.changeset/css-modules-phase-4-button.md
+++ b/.changeset/css-modules-phase-4-button.md
@@ -18,9 +18,11 @@ styling refactor.
 - `data-kind` is still set on the rendered element and remains available as a
   consumer/test hook, but it no longer drives any styling.
 - The shared element reset (`button-unstyled`) also moves to a CSS Module
-  (`button-unstyled.module.css`) so the reset lives in `@layer shared` alongside
-  the component styles rather than as unlayered Aphrodite (which would otherwise
-  override the layered focus ring / border / underline).
+  (`button-unstyled.module.css`) rather than staying as unlayered Aphrodite
+  (which would otherwise override the layered focus ring / border / underline).
+  It is emitted into the nested layer `shared.reset`, so the component styles —
+  which sit directly in `shared` — always outrank it regardless of the order the
+  bundler emits the two stylesheets in.
 - The package now ships its bundled stylesheet at `dist/index.css` (imported
   automatically as a side-effect of the JS entry) and exposes it explicitly via
   the new `@khanacademy/wonder-blocks-button/css` subpath. `sideEffects` is set

--- a/.changeset/css-modules-phase-4-button.md
+++ b/.changeset/css-modules-phase-4-button.md
@@ -8,11 +8,15 @@ same `style` / `styles` / `labelStyle` overrides — so this is an internal
 styling refactor.
 
 - The `kind × actionType × size` variant matrix is now expressed in
-  `button.module.css` using CSS custom-property "slots" set by the `[data-kind]`
-  attribute plus per-`actionType` classes, so each interactive state is declared
-  once instead of once-per-cell. Theming (default / thunderblocks / syl-dark) is
-  unchanged — the module references the same `--wb-*` token variables that switch
-  on `[data-wb-theme]`.
+  `button.module.css` around a component-token surface: every value a variant
+  axis can change is a `--wb-c-button--*` custom property, assigned by one class
+  per axis value (`.primary`, `.progressive`, `.small`) and read by the base and
+  state rules, so each interactive state is declared once instead of
+  once-per-cell. Theming (default / thunderblocks / syl-dark) is unchanged — the
+  module references the same `--wb-*` token variables that switch on
+  `[data-wb-theme]`.
+- `data-kind` is still set on the rendered element and remains available as a
+  consumer/test hook, but it no longer drives any styling.
 - The shared element reset (`button-unstyled`) also moves to a CSS Module
   (`button-unstyled.module.css`) so the reset lives in `@layer shared` alongside
   the component styles rather than as unlayered Aphrodite (which would otherwise
@@ -23,3 +27,11 @@ styling refactor.
   so bundlers keep the side-effect import. Standard webpack / Vite / Next.js
   setups pick this up with no changes; SSR consumers that can't process CSS
   imports may need a CSS loader / mock in their build.
+- Note for consumers who override Button styles: Aphrodite emitted these rules
+  unlayered and with `!important`, whereas the CSS Modules build emits them in
+  `@layer shared`. Unlayered consumer CSS now wins over Button's own styles
+  regardless of specificity, so overrides that previously needed `!important`
+  may no longer, and stylesheets that were previously losing to Button may now
+  start taking effect. Overrides passed through the `style` / `styles` /
+  `labelStyle` props are unaffected — those still route through Aphrodite and
+  continue to win.

--- a/.changeset/css-modules-phase-4-button.md
+++ b/.changeset/css-modules-phase-4-button.md
@@ -1,0 +1,25 @@
+---
+"@khanacademy/wonder-blocks-button": minor
+---
+
+Migrate `Button` from Aphrodite to CSS Modules (WB-2328, CSS Modules Phase 4).
+The public component API is unchanged — same props, same DOM structure, and the
+same `style` / `styles` / `labelStyle` overrides — so this is an internal
+styling refactor.
+
+- The `kind × actionType × size` variant matrix is now expressed in
+  `button.module.css` using CSS custom-property "slots" set by the `[data-kind]`
+  attribute plus per-`actionType` classes, so each interactive state is declared
+  once instead of once-per-cell. Theming (default / thunderblocks / syl-dark) is
+  unchanged — the module references the same `--wb-*` token variables that switch
+  on `[data-wb-theme]`.
+- The shared element reset (`button-unstyled`) also moves to a CSS Module
+  (`button-unstyled.module.css`) so the reset lives in `@layer shared` alongside
+  the component styles rather than as unlayered Aphrodite (which would otherwise
+  override the layered focus ring / border / underline).
+- The package now ships its bundled stylesheet at `dist/index.css` (imported
+  automatically as a side-effect of the JS entry) and exposes it explicitly via
+  the new `@khanacademy/wonder-blocks-button/css` subpath. `sideEffects` is set
+  so bundlers keep the side-effect import. Standard webpack / Vite / Next.js
+  setups pick this up with no changes; SSR consumers that can't process CSS
+  imports may need a CSS loader / mock in their build.

--- a/packages/wonder-blocks-button/package.json
+++ b/packages/wonder-blocks-button/package.json
@@ -19,12 +19,16 @@
   "main": "dist/index.js",
   "module": "dist/es/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
       "import": "./dist/es/index.js",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./css": "./dist/index.css",
     "./styles.css": "./dist/css/vars.css"
   },
   "scripts": {

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {CSSProperties, StyleSheet} from "aphrodite";
 
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -9,19 +8,11 @@ import type {
     ChildrenProps,
     ClickableState,
 } from "@khanacademy/wonder-blocks-clickable";
-import {focusStyles} from "@khanacademy/wonder-blocks-styles";
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
-import type {
-    ButtonActionType,
-    ButtonKind,
-    ButtonSize,
-    ButtonProps,
-    ButtonRef,
-} from "../util/button.types";
+import type {ButtonProps, ButtonRef} from "../util/button.types";
 import {ButtonIcon} from "./button-icon";
 
-import theme from "../theme";
 import {ButtonUnstyled} from "./button-unstyled";
+import styles from "./button.module.css";
 
 type Props = ButtonProps & ChildrenProps & ClickableState;
 
@@ -58,21 +49,23 @@ const ButtonCore: React.ForwardRefExoticComponent<
         ...restProps
     } = props;
 
-    const buttonStyles = _generateStyles(actionType, kind, size);
-
     const disabled = spinner || disabledProp;
 
+    // The `kind` and `actionType` axes of the variant matrix are selected in
+    // CSS via the `[data-kind]` attribute (set by `ButtonUnstyled`) combined
+    // with the `actionType` class below. `disabled` is selected via the
+    // `[aria-disabled="true"]` attribute (also set by `ButtonUnstyled`), which
+    // keeps the element focusable. Class-name strings are composed through the
+    // `style` prop — `processStyleList` routes them to `className`.
     const defaultStyle = [
-        sharedStyles.shared,
-        startIcon && sharedStyles.withStartIcon,
-        endIcon && sharedStyles.withEndIcon,
-        buttonStyles.default,
-        disabled && buttonStyles.disabled,
-        !disabled && pressed && buttonStyles.pressed,
-        // Enables programmatic focus.
-        !disabled && !pressed && focused && buttonStyles.focused,
-        size === "small" && sharedStyles.small,
-        size === "large" && sharedStyles.large,
+        styles.button,
+        actionType && styles[actionType],
+        size === "small" && styles.small,
+        size === "large" && styles.large,
+        // Enable the press / focus states for programmatic (keyboard)
+        // interaction tracked by `ClickableBehavior`.
+        !disabled && pressed && styles.pressed,
+        !disabled && !pressed && focused && styles.focused,
     ];
 
     const label = (
@@ -81,11 +74,11 @@ const ButtonCore: React.ForwardRefExoticComponent<
             weight={size === "large" ? "bold" : undefined}
             tag="span"
             style={[
-                sharedStyles.text,
-                size === "small" && sharedStyles.smallText,
-                size === "large" && sharedStyles.largeText,
+                styles.text,
+                size === "small" && styles.smallText,
+                size === "large" && styles.largeText,
                 labelStyle,
-                spinner && sharedStyles.hiddenText,
+                spinner && styles.hiddenText,
             ]}
             testId={testId ? `${testId}-inner-label` : undefined}
         >
@@ -111,15 +104,14 @@ const ButtonCore: React.ForwardRefExoticComponent<
                     // in the Khanmigo theme, but we wrap it with
                     // iconWrapper anyway to give it the same spacing
                     // as the end icon so the button is symmetrical.
-                    style={sharedStyles.iconWrapper}
+                    style={styles.iconWrapper}
                 >
                     <ButtonIcon
                         size={iconSize}
                         icon={startIcon}
                         style={[
-                            sharedStyles.startIcon,
-                            kind === "tertiary" &&
-                                sharedStyles.tertiaryStartIcon,
+                            styles.startIcon,
+                            kind === "tertiary" && styles.tertiaryStartIcon,
                             stylesProp?.startIcon,
                         ]}
                         testId={testId ? `${testId}-start-icon` : undefined}
@@ -129,7 +121,7 @@ const ButtonCore: React.ForwardRefExoticComponent<
             {label}
             {spinner && (
                 <CircularSpinner
-                    style={sharedStyles.spinner}
+                    style={styles.spinner}
                     size={sizeMapping[size]}
                     light={kind === "primary"}
                     testId={`${testId || "button"}-spinner`}
@@ -139,11 +131,10 @@ const ButtonCore: React.ForwardRefExoticComponent<
                 <View
                     testId={testId ? `${testId}-end-icon-wrapper` : undefined}
                     style={[
-                        sharedStyles.endIcon,
-                        sharedStyles.iconWrapper,
-                        sharedStyles.endIconWrapper,
-                        kind === "tertiary" &&
-                            sharedStyles.endIconWrapperTertiary,
+                        styles.endIcon,
+                        styles.iconWrapper,
+                        styles.endIconWrapper,
+                        kind === "tertiary" && styles.endIconWrapperTertiary,
                     ]}
                 >
                     <ButtonIcon
@@ -181,241 +172,3 @@ const ButtonCore: React.ForwardRefExoticComponent<
 });
 
 export default ButtonCore;
-
-const sharedStyles = StyleSheet.create({
-    shared: {
-        height: theme.root.sizing.height.medium,
-        paddingBlock: 0,
-    },
-    small: {
-        height: theme.root.sizing.height.small,
-    },
-    large: {
-        height: theme.root.sizing.height.large,
-    },
-    text: {
-        alignItems: "center",
-        fontWeight: theme.root.font.weight.default,
-        whiteSpace: "nowrap",
-        overflow: "hidden",
-        // To account for the underline-offset in tertiary buttons
-        lineHeight: theme.root.font.lineHeight.default,
-        textOverflow: "ellipsis",
-        display: "inline-block", // allows the button text to truncate
-        pointerEvents: "none", // fix Safari bug where the browser was eating mouse events
-    },
-    smallText: {
-        lineHeight: theme.root.font.lineHeight.small,
-    },
-    largeText: {
-        fontSize: theme.root.font.size.large,
-        lineHeight: theme.root.font.lineHeight.large,
-    },
-    hiddenText: {
-        visibility: "hidden",
-    },
-    spinner: {
-        position: "absolute",
-    },
-    startIcon: {
-        marginInlineStart: theme.icon.margin.inline.outer,
-        marginInlineEnd: theme.icon.margin.inline.inner,
-    },
-    tertiaryStartIcon: {
-        // Undo the negative padding from startIcon since tertiary
-        // buttons don't have extra padding.
-        marginInlineStart: 0,
-    },
-    endIcon: {
-        marginInlineStart: theme.icon.margin.inline.inner,
-    },
-    iconWrapper: {
-        padding: theme.icon.padding,
-        // View has a default minInlineSize of 0, which causes the label text
-        // to encroach on the icon when it needs to truncate. We can fix
-        // this by setting the minInlineSize to auto.
-        minInlineSize: "auto",
-    },
-    endIconWrapper: {
-        marginInlineStart: theme.icon.margin.inline.inner,
-        marginInlineEnd: theme.icon.margin.inline.outer,
-    },
-    endIconWrapperTertiary: {
-        marginInlineEnd: 0,
-    },
-});
-
-type ButtonStylesKey = "default" | "pressed" | "disabled" | "focused";
-
-const styles: Record<string, Record<ButtonStylesKey, object>> = {};
-
-// export for testing only
-export const _generateStyles = (
-    actionType: ButtonActionType = "progressive",
-    kind: ButtonKind,
-    size: ButtonSize,
-): Record<ButtonStylesKey, object> => {
-    const buttonType = `${actionType}-${kind}-${size}`;
-
-    if (styles[buttonType]) {
-        return styles[buttonType];
-    }
-
-    const paddingInline = theme.root.layout.padding.inline[kind][size];
-
-    const borderWidthKind = theme.root.border.width[kind];
-    const outlineOffsetKind = theme.root.border.offset[kind];
-    const themeVariant = semanticColor.action[kind][actionType];
-    const disabledState = semanticColor.action[kind].disabled;
-
-    const disabledStatesStyles = {
-        borderColor: disabledState.border,
-        borderWidth: borderWidthKind.default,
-        borderRadius: theme.root.border.radius.default,
-        background: disabledState.background,
-        color: disabledState.foreground,
-    };
-
-    const disabledStatesOverrides = {
-        ...disabledStatesStyles,
-        // primary overrides
-        outline: "none",
-        // secondary overrides
-        boxShadow: "none",
-        // tertiary overrides
-        textDecoration: "none",
-        textDecorationThickness: "unset",
-        textUnderlineOffset: "unset",
-    };
-
-    const pressStyles = {
-        // shared
-        background: themeVariant.press.background,
-        borderRadius: theme.root.border.radius.press,
-        color: themeVariant.press.foreground,
-        // primary
-        ...(kind === "primary"
-            ? {
-                  outline: `${borderWidthKind.press} solid ${themeVariant.press.border}`,
-                  outlineOffset: outlineOffsetKind,
-              }
-            : undefined),
-        // secondary
-        ...(kind !== "primary"
-            ? {
-                  borderColor: themeVariant.press.border,
-                  boxShadow: `inset 0 0 0 ${borderWidthKind.press} ${themeVariant.press.border}`,
-              }
-            : undefined),
-
-        // tertiary-specific styles
-        ...(kind === "tertiary"
-            ? {
-                  textUnderlineOffset: theme.root.font.offset.default,
-                  textDecoration: `${theme.root.font.decoration.press} ${theme.root.sizing.underline.press}`,
-              }
-            : undefined),
-    };
-
-    const newStyles: Record<ButtonStylesKey, CSSProperties> = {
-        default: {
-            borderRadius: theme.root.border.radius.default,
-            paddingInline: paddingInline,
-            // theming
-            borderStyle: "solid",
-            borderWidth: borderWidthKind.default,
-            borderColor: themeVariant.default.border,
-            background: themeVariant.default.background,
-            color: themeVariant.default.foreground,
-            // animation
-            transition: "border-radius 0.1s ease-in-out",
-
-            /**
-             * States
-             *
-             * Defined in the following order: hover, active, focus.
-             *
-             * This is important as we want to give more priority to the
-             * :focus-visible styles.
-             */
-            // :focus-visible -> Provide focus styles for keyboard users only.
-
-            // Allow hover styles on non-touch devices only. This prevents an
-            // issue with hover being sticky on touch devices (e.g. mobile).
-            // @ts-expect-error - TS2353 - aphrodite doesn't recognize this, but it's valid and works
-            ["@media (hover: hover)"]: {
-                ":hover": {
-                    // shared
-                    background: themeVariant.hover.background,
-                    borderRadius: theme.root.border.radius.hover,
-                    color: themeVariant.hover.foreground,
-                    ...(kind === "primary"
-                        ? {
-                              outline: `${borderWidthKind.hover} solid ${themeVariant.hover.border}`,
-                              outlineOffset: outlineOffsetKind,
-                          }
-                        : undefined),
-                    ...(kind !== "primary"
-                        ? {
-                              borderColor: themeVariant.hover.border,
-                              boxShadow: `inset 0 0 0 ${borderWidthKind.hover} ${themeVariant.hover.border}`,
-                          }
-                        : undefined),
-
-                    // tertiary-specific styles
-                    ...(kind === "tertiary"
-                        ? {
-                              textUnderlineOffset:
-                                  theme.root.font.offset.default,
-                              textDecoration: `${theme.root.font.decoration.hover} ${theme.root.sizing.underline.hover}`,
-                          }
-                        : undefined),
-                },
-            } satisfies CSSProperties,
-
-            ":active": pressStyles,
-
-            ...focusStyles.focus,
-            // These overrides are needed to ensure that the boxShadow is
-            // properly applied to the button when it is focused +
-            // hovered/pressed.
-            ...(kind === "secondary"
-                ? {
-                      ":focus-visible:hover": {
-                          ...focusStyles.focus[":focus-visible"],
-                          boxShadow: `inset 0 0 0 ${borderWidthKind.hover} ${themeVariant.hover.border}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
-                      },
-                      ":focus-visible:active": {
-                          ...focusStyles.focus[":focus-visible"],
-                          boxShadow: `inset 0 0 0 ${borderWidthKind.press} ${themeVariant.press.border}, ${focusStyles.focus[":focus-visible"].boxShadow}`,
-                      },
-                  }
-                : {}),
-        },
-        pressed: pressStyles,
-        // To receive programmatic focus.
-        focused: focusStyles.focus[":focus-visible"],
-        disabled: {
-            cursor: "not-allowed",
-            ...disabledStatesStyles,
-            // NOTE: Even that browsers recommend to specify pseudo-classes in
-            // this order: link, visited, hover, focus, active, we need to
-            // specify focus after hover to override hover styles. By doing this
-            // we are able to reset the border/outline styles to the default
-            // ones (rest state).
-            // For order reference: https://css-tricks.com/snippets/css/link-pseudo-classes-in-order/
-            ":hover": disabledStatesOverrides,
-            ":active": disabledStatesOverrides,
-            ":focus-visible": disabledStatesStyles,
-        },
-    };
-
-    // aphrodite v1 doesn't support generics, so we need to cast the result
-    // to the correct type. we can trust this cast because we typed the input
-    // correctly above, and aphrodite will return whatever keys we passed in.
-    styles[buttonType] = StyleSheet.create(newStyles) as Record<
-        ButtonStylesKey,
-        object
-    >;
-    return styles[buttonType];
-};

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -51,14 +51,16 @@ const ButtonCore: React.ForwardRefExoticComponent<
 
     const disabled = spinner || disabledProp;
 
-    // The `kind` and `actionType` axes of the variant matrix are selected in
-    // CSS via the `[data-kind]` attribute (set by `ButtonUnstyled`) combined
-    // with the `actionType` class below. `disabled` is selected via the
-    // `[aria-disabled="true"]` attribute (also set by `ButtonUnstyled`), which
-    // keeps the element focusable. Class-name strings are composed through the
-    // `style` prop — `processStyleList` routes them to `className`.
+    // One class per variant axis. Each of these only assigns the
+    // `--wb-c-button--*` component tokens that its axis owns; `styles.button`
+    // and the state rules in the module read those tokens. `disabled` is
+    // selected in CSS via the `[aria-disabled="true"]` attribute (set by
+    // `ButtonUnstyled`), which keeps the element focusable. Class-name strings
+    // are composed through the `style` prop — `processStyleList` routes them
+    // to `className`.
     const defaultStyle = [
         styles.button,
+        styles[kind],
         actionType && styles[actionType],
         size === "small" && styles.small,
         size === "large" && styles.large,

--- a/packages/wonder-blocks-button/src/components/button-core.tsx
+++ b/packages/wonder-blocks-button/src/components/button-core.tsx
@@ -22,7 +22,7 @@ const ButtonCore: React.ForwardRefExoticComponent<
     const {
         children,
         skipClientNav,
-        actionType,
+        actionType = "progressive",
         disabled: disabledProp,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars -- make sure it is not included in restProps
         focused,
@@ -61,7 +61,7 @@ const ButtonCore: React.ForwardRefExoticComponent<
     const defaultStyle = [
         styles.button,
         styles[kind],
-        actionType && styles[actionType],
+        styles[actionType],
         size === "small" && styles.small,
         size === "large" && styles.large,
         // Enable the press / focus states for programmatic (keyboard)

--- a/packages/wonder-blocks-button/src/components/button-unstyled.module.css
+++ b/packages/wonder-blocks-button/src/components/button-unstyled.module.css
@@ -1,0 +1,38 @@
+/**
+ * Reset styles shared by the rendered `<button>` / `<a>` / `Link` element of
+ * `Button` (CSS Modules migration — WB-2328).
+ *
+ * Cascade note: this reset and the per-component styles (`button.module.css`)
+ * all live in `@layer shared`, so ordering matters. The reset deliberately does
+ * NOT zero `border` — `button.module.css` fully specifies the border for every
+ * kind, so zeroing it here (at the same specificity as the component rules)
+ * would risk wiping the component border depending on emission order.
+ * `outline` / `text-decoration` are safe to reset here because the component
+ * re-applies them at higher specificity (`:focus-visible`, the tertiary
+ * `:hover`/`:active` underline). Keeping the reset in `@layer shared` (instead
+ * of Aphrodite, which injects *unlayered* styles that beat everything in
+ * `@layer shared`) is what lets those win.
+ */
+
+.reset {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    padding: 0;
+    cursor: pointer;
+    outline: none;
+    text-decoration: none;
+    box-sizing: border-box;
+
+    /* Removes the 300ms click delay on mobile browsers by indicating that
+     * "double-tap to zoom" shouldn't be used on this element. */
+    touch-action: manipulation;
+    user-select: none;
+}
+
+.reset:focus {
+    /* Mobile: removes the blue highlight shown when the user taps a button. */
+    -webkit-tap-highlight-color: transparent;
+}

--- a/packages/wonder-blocks-button/src/components/button-unstyled.module.css
+++ b/packages/wonder-blocks-button/src/components/button-unstyled.module.css
@@ -3,15 +3,11 @@
  * `Button` (CSS Modules migration — WB-2328).
  *
  * Cascade note: this reset and the per-component styles (`button.module.css`)
- * all live in `@layer shared`, so ordering matters. The reset deliberately does
- * NOT zero `border` — `button.module.css` fully specifies the border for every
- * kind, so zeroing it here (at the same specificity as the component rules)
- * would risk wiping the component border depending on emission order.
- * `outline` / `text-decoration` are safe to reset here because the component
- * re-applies them at higher specificity (`:focus-visible`, the tertiary
- * `:hover`/`:active` underline). Keeping the reset in `@layer shared` (instead
- * of Aphrodite, which injects *unlayered* styles that beat everything in
- * `@layer shared`) is what lets those win.
+ * all live in `@layer shared`. `outline` / `text-decoration` are safe to reset
+ * here because the component re-applies them at higher specificity
+ * (`:focus-visible`, the tertiary `:hover`/`:active` underline). Keeping the
+ * reset in `@layer shared` (instead of Aphrodite, which injects *unlayered*
+ * styles that beat everything in `@layer shared`) is what lets those win.
  */
 
 .reset {
@@ -21,6 +17,7 @@
     justify-content: center;
     margin: 0;
     padding: 0;
+    border: none;
     cursor: pointer;
     outline: none;
     text-decoration: none;

--- a/packages/wonder-blocks-button/src/components/button-unstyled.module.css
+++ b/packages/wonder-blocks-button/src/components/button-unstyled.module.css
@@ -1,35 +1,34 @@
 /**
- * Reset styles shared by the rendered `<button>` / `<a>` / `Link` element of
- * `Button` (CSS Modules migration — WB-2328).
- *
- * Cascade note: this reset and the per-component styles (`button.module.css`)
- * all live in `@layer shared`. `outline` / `text-decoration` are safe to reset
- * here because the component re-applies them at higher specificity
- * (`:focus-visible`, the tertiary `:hover`/`:active` underline). Keeping the
- * reset in `@layer shared` (instead of Aphrodite, which injects *unlayered*
- * styles that beat everything in `@layer shared`) is what lets those win.
+ * The build wraps every `*.module.css` in `@layer shared`, so this file becomes
+ * `@layer shared { @layer reset { … } }` — the sub-layer `shared.reset`.
+ * Component styles have no inner layer, so they sit directly in `shared`, and
+ * rules directly in a layer outrank that layer's named sub-layers. The cascade
+ * is therefore decided by the layer, not by bundle order.
  */
 
-.reset {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0;
-    padding: 0;
-    border: none;
-    cursor: pointer;
-    outline: none;
-    text-decoration: none;
-    box-sizing: border-box;
+@layer reset {
+    .reset {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        padding: 0;
+        border: none;
+        cursor: pointer;
+        outline: none;
+        text-decoration: none;
+        box-sizing: border-box;
 
-    /* Removes the 300ms click delay on mobile browsers by indicating that
-     * "double-tap to zoom" shouldn't be used on this element. */
-    touch-action: manipulation;
-    user-select: none;
-}
+        /* Removes the 300ms click delay on mobile browsers by indicating that
+         * "double-tap to zoom" shouldn't be used on this element. */
+        touch-action: manipulation;
+        user-select: none;
+    }
 
-.reset:focus {
-    /* Mobile: removes the blue highlight shown when the user taps a button. */
-    -webkit-tap-highlight-color: transparent;
+    .reset:focus {
+        /* Mobile: removes the blue highlight shown when the user taps a
+         * button. */
+        -webkit-tap-highlight-color: transparent;
+    }
 }

--- a/packages/wonder-blocks-button/src/components/button-unstyled.tsx
+++ b/packages/wonder-blocks-button/src/components/button-unstyled.tsx
@@ -6,8 +6,8 @@ import {Link, useInRouterContext} from "react-router-dom-v5-compat";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {isClientSideUrl} from "@khanacademy/wonder-blocks-clickable";
-import {StyleSheet} from "aphrodite";
 import {ButtonProps} from "../util/button.types";
+import styles from "./button-unstyled.module.css";
 
 const StyledA = addStyle("a");
 const StyledButton = addStyle("button");
@@ -81,30 +81,6 @@ const ButtonUnstyled: React.ForwardRefExoticComponent<
             </StyledButton>
         );
     }
-});
-
-const styles = StyleSheet.create({
-    reset: {
-        position: "relative",
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        margin: 0,
-        padding: 0,
-        border: "none",
-        cursor: "pointer",
-        outline: "none",
-        textDecoration: "none",
-        boxSizing: "border-box",
-        // This removes the 300ms click delay on mobile browsers by indicating that
-        // "double-tap to zoom" shouldn't be used on this element.
-        touchAction: "manipulation",
-        userSelect: "none",
-        ":focus": {
-            // Mobile: Removes a blue highlight style shown when the user clicks a button
-            WebkitTapHighlightColor: "rgba(0,0,0,0)",
-        },
-    },
 });
 
 export {ButtonUnstyled};

--- a/packages/wonder-blocks-button/src/components/button.module.css
+++ b/packages/wonder-blocks-button/src/components/button.module.css
@@ -1,0 +1,466 @@
+/**
+ * Button styles (CSS Modules migration — WB-2328 / CSS Modules Phase 4).
+ *
+ * Design notes:
+ * - The colour matrix (`kind × actionType`) is expressed with CSS custom
+ *   property "slots" (`--button-bg-*`, `--button-fg-*`, `--button-border-*`).
+ *   The `[data-kind]` attribute (set by `button-unstyled`) combined with the
+ *   per-`actionType` class (`.progressive` / `.destructive` / `.neutral`) sets
+ *   the slot values from the semantic-colour token variables. The base `.button`
+ *   rule and the pseudo-state rules only ever read the slots, so each state is
+ *   declared once instead of once-per-cell.
+ * - Structural differences between kinds (primary uses `outline`, secondary /
+ *   tertiary use an inset `box-shadow`, tertiary adds an underline) are handled
+ *   with `[data-kind="…"]` rule blocks.
+ * - Orthogonal axes (`size`, icon presence) and the JS-driven programmatic
+ *   states (`.focused` / `.pressed`) are compound classes composed through the
+ *   existing `style` prop (Wonder Blocks' `processStyleList` routes class-name
+ *   strings to `className`), so no `clsx` dependency is needed.
+ * - `disabled` is selected via the `[aria-disabled="true"]` attribute that
+ *   `button-unstyled` already sets (the element stays focusable).
+ * - All token references resolve against the per-theme `[data-wb-theme]` blocks
+ *   shipped in `@khanacademy/wonder-blocks-tokens`, so theming (default /
+ *   thunderblocks / syl-dark) keeps working unchanged. The build wraps every
+ *   rule below in `@layer shared { … }` via the wrap-in-layer PostCSS plugin.
+ */
+
+@import "@khanacademy/wonder-blocks-styles/focus-styles.css";
+
+.button {
+    /* Layout (was `sharedStyles.shared`). Height is the medium default; the
+     * `.small` / `.large` size classes override it. */
+    block-size: var(--wb-c-button-root-sizing-height-medium);
+    padding-block: 0;
+    padding-inline: var(--button-padding-inline);
+
+    /* Theming, driven by the colour slots set in the matrix rules below. */
+    border-radius: var(--wb-c-button-root-border-radius-default);
+    border-style: solid;
+    border-width: var(--button-border-width-default);
+    border-color: var(--button-border-default);
+    background: var(--button-bg-default);
+    color: var(--button-fg-default);
+
+    /* Animation */
+    transition: border-radius 0.1s ease-in-out;
+}
+
+/**
+ * Size axis (orthogonal compound classes). `medium` is the base.
+ */
+.small {
+    block-size: var(--wb-c-button-root-sizing-height-small);
+}
+
+.large {
+    block-size: var(--wb-c-button-root-sizing-height-large);
+}
+
+/**
+ * Per-kind slots: border widths, the primary outline offset, the
+ * `kind × size` inline padding and the disabled-state colours (disabled
+ * colours depend on `kind` only, not `actionType`).
+ */
+.button[data-kind="primary"] {
+    --button-border-width-default: var(
+        --wb-c-button-root-border-width-primary-default
+    );
+    --button-border-width-hover: var(
+        --wb-c-button-root-border-width-primary-hover
+    );
+    --button-border-width-press: var(
+        --wb-c-button-root-border-width-primary-press
+    );
+    --button-outline-offset: var(--wb-c-button-root-border-offset-primary);
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-primary-medium
+    );
+    --button-bg-disabled: var(--wb-semanticColor-action-primary-disabled-background);
+    --button-fg-disabled: var(--wb-semanticColor-action-primary-disabled-foreground);
+    --button-border-disabled: var(--wb-semanticColor-action-primary-disabled-border);
+}
+
+.button[data-kind="primary"].small {
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-primary-small
+    );
+}
+
+.button[data-kind="primary"].large {
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-primary-large
+    );
+}
+
+.button[data-kind="secondary"] {
+    --button-border-width-default: var(
+        --wb-c-button-root-border-width-secondary-default
+    );
+    --button-border-width-hover: var(
+        --wb-c-button-root-border-width-secondary-hover
+    );
+    --button-border-width-press: var(
+        --wb-c-button-root-border-width-secondary-press
+    );
+    --button-outline-offset: var(--wb-c-button-root-border-offset-secondary);
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-secondary-medium
+    );
+    --button-bg-disabled: var(--wb-semanticColor-action-secondary-disabled-background);
+    --button-fg-disabled: var(--wb-semanticColor-action-secondary-disabled-foreground);
+    --button-border-disabled: var(--wb-semanticColor-action-secondary-disabled-border);
+}
+
+.button[data-kind="secondary"].small {
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-secondary-small
+    );
+}
+
+.button[data-kind="secondary"].large {
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-secondary-large
+    );
+}
+
+.button[data-kind="tertiary"] {
+    --button-border-width-default: var(
+        --wb-c-button-root-border-width-tertiary-default
+    );
+    --button-border-width-hover: var(
+        --wb-c-button-root-border-width-tertiary-hover
+    );
+    --button-border-width-press: var(
+        --wb-c-button-root-border-width-tertiary-press
+    );
+    --button-outline-offset: var(--wb-c-button-root-border-offset-tertiary);
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-tertiary-medium
+    );
+    --button-bg-disabled: var(--wb-semanticColor-action-tertiary-disabled-background);
+    --button-fg-disabled: var(--wb-semanticColor-action-tertiary-disabled-foreground);
+    --button-border-disabled: var(--wb-semanticColor-action-tertiary-disabled-border);
+}
+
+.button[data-kind="tertiary"].small {
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-tertiary-small
+    );
+}
+
+.button[data-kind="tertiary"].large {
+    --button-padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-tertiary-large
+    );
+}
+
+/**
+ * Colour matrix: `kind × actionType`. Each cell sets the bg / fg / border slots
+ * for the rest, hover and press states from the semantic-colour tokens.
+ */
+.button[data-kind="primary"].progressive {
+    --button-bg-default: var(--wb-semanticColor-action-primary-progressive-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-primary-progressive-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-primary-progressive-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-primary-progressive-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-primary-progressive-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-primary-progressive-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-primary-progressive-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-primary-progressive-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-primary-progressive-press-border);
+}
+
+.button[data-kind="primary"].destructive {
+    --button-bg-default: var(--wb-semanticColor-action-primary-destructive-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-primary-destructive-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-primary-destructive-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-primary-destructive-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-primary-destructive-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-primary-destructive-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-primary-destructive-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-primary-destructive-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-primary-destructive-press-border);
+}
+
+.button[data-kind="primary"].neutral {
+    --button-bg-default: var(--wb-semanticColor-action-primary-neutral-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-primary-neutral-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-primary-neutral-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-primary-neutral-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-primary-neutral-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-primary-neutral-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-primary-neutral-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-primary-neutral-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-primary-neutral-press-border);
+}
+
+.button[data-kind="secondary"].progressive {
+    --button-bg-default: var(--wb-semanticColor-action-secondary-progressive-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-secondary-progressive-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-secondary-progressive-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-secondary-progressive-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-secondary-progressive-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-secondary-progressive-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-secondary-progressive-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-secondary-progressive-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-secondary-progressive-press-border);
+}
+
+.button[data-kind="secondary"].destructive {
+    --button-bg-default: var(--wb-semanticColor-action-secondary-destructive-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-secondary-destructive-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-secondary-destructive-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-secondary-destructive-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-secondary-destructive-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-secondary-destructive-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-secondary-destructive-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-secondary-destructive-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-secondary-destructive-press-border);
+}
+
+.button[data-kind="secondary"].neutral {
+    --button-bg-default: var(--wb-semanticColor-action-secondary-neutral-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-secondary-neutral-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-secondary-neutral-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-secondary-neutral-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-secondary-neutral-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-secondary-neutral-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-secondary-neutral-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-secondary-neutral-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-secondary-neutral-press-border);
+}
+
+.button[data-kind="tertiary"].progressive {
+    --button-bg-default: var(--wb-semanticColor-action-tertiary-progressive-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-tertiary-progressive-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-tertiary-progressive-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-tertiary-progressive-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-tertiary-progressive-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-tertiary-progressive-press-border);
+}
+
+.button[data-kind="tertiary"].destructive {
+    --button-bg-default: var(--wb-semanticColor-action-tertiary-destructive-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-tertiary-destructive-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-tertiary-destructive-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-tertiary-destructive-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-tertiary-destructive-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-tertiary-destructive-press-border);
+}
+
+.button[data-kind="tertiary"].neutral {
+    --button-bg-default: var(--wb-semanticColor-action-tertiary-neutral-default-background);
+    --button-fg-default: var(--wb-semanticColor-action-tertiary-neutral-default-foreground);
+    --button-border-default: var(--wb-semanticColor-action-tertiary-neutral-default-border);
+    --button-bg-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-background);
+    --button-fg-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-foreground);
+    --button-border-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-border);
+    --button-bg-press: var(--wb-semanticColor-action-tertiary-neutral-press-background);
+    --button-fg-press: var(--wb-semanticColor-action-tertiary-neutral-press-foreground);
+    --button-border-press: var(--wb-semanticColor-action-tertiary-neutral-press-border);
+}
+
+/**
+ * Hover. Allowed on non-touch devices only so the hover state isn't "sticky"
+ * on touch devices.
+ */
+@media (hover: hover) {
+    .button:hover {
+        background: var(--button-bg-hover);
+        border-radius: var(--wb-c-button-root-border-radius-hover);
+        color: var(--button-fg-hover);
+    }
+
+    .button[data-kind="primary"]:hover {
+        outline: var(--button-border-width-hover) solid
+            var(--button-border-hover);
+        outline-offset: var(--button-outline-offset);
+    }
+
+    .button[data-kind="secondary"]:hover,
+    .button[data-kind="tertiary"]:hover {
+        border-color: var(--button-border-hover);
+        box-shadow: inset 0 0 0 var(--button-border-width-hover)
+            var(--button-border-hover);
+    }
+
+    .button[data-kind="tertiary"]:hover {
+        text-underline-offset: var(--wb-c-button-root-font-offset-default);
+        text-decoration: var(--wb-c-button-root-font-decoration-hover)
+            var(--wb-c-button-root-sizing-underline-hover);
+    }
+}
+
+/**
+ * Active / pressed. The `:active` pseudo-class covers pointer presses; the
+ * `.pressed` class covers programmatic (keyboard) presses tracked by
+ * `ClickableBehavior`.
+ */
+.button:active,
+.button.pressed {
+    background: var(--button-bg-press);
+    border-radius: var(--wb-c-button-root-border-radius-press);
+    color: var(--button-fg-press);
+}
+
+.button[data-kind="primary"]:active,
+.button[data-kind="primary"].pressed {
+    outline: var(--button-border-width-press) solid var(--button-border-press);
+    outline-offset: var(--button-outline-offset);
+}
+
+.button[data-kind="secondary"]:active,
+.button[data-kind="secondary"].pressed,
+.button[data-kind="tertiary"]:active,
+.button[data-kind="tertiary"].pressed {
+    border-color: var(--button-border-press);
+    box-shadow: inset 0 0 0 var(--button-border-width-press)
+        var(--button-border-press);
+}
+
+.button[data-kind="tertiary"]:active,
+.button[data-kind="tertiary"].pressed {
+    text-underline-offset: var(--wb-c-button-root-font-offset-default);
+    text-decoration: var(--wb-c-button-root-font-decoration-press)
+        var(--wb-c-button-root-sizing-underline-press);
+}
+
+/**
+ * Focus. `:focus-visible` provides keyboard-only focus styling; the `.focused`
+ * class enables programmatic focus (set by `ClickableBehavior`).
+ */
+.button:focus-visible,
+.button.focused {
+    @apply --wb-focus-visible;
+}
+
+/**
+ * Secondary buttons keep their inset border `box-shadow` while focused, so the
+ * focus ring is composited with the hover / press border shadow.
+ */
+.button[data-kind="secondary"]:focus-visible:hover {
+    @apply --wb-focus-visible;
+
+    box-shadow:
+        inset 0 0 0 var(--button-border-width-hover) var(--button-border-hover),
+        0 0 0 var(--wb-border-width-medium) var(--wb-semanticColor-focus-inner);
+}
+
+.button[data-kind="secondary"]:focus-visible:active {
+    @apply --wb-focus-visible;
+
+    box-shadow:
+        inset 0 0 0 var(--button-border-width-press) var(--button-border-press),
+        0 0 0 var(--wb-border-width-medium) var(--wb-semanticColor-focus-inner);
+}
+
+/**
+ * Disabled. Selected via `aria-disabled` so the element stays focusable.
+ */
+.button[aria-disabled="true"] {
+    cursor: not-allowed;
+    border-width: var(--button-border-width-default);
+    border-color: var(--button-border-disabled);
+    border-radius: var(--wb-c-button-root-border-radius-default);
+    background: var(--button-bg-disabled);
+    color: var(--button-fg-disabled);
+}
+
+/**
+ * Reset hover / active styling on disabled buttons. NOTE: focus is intentionally
+ * specified after hover so it can reset hover styling back to the rest state.
+ */
+.button[aria-disabled="true"]:hover,
+.button[aria-disabled="true"]:active {
+    border-width: var(--button-border-width-default);
+    border-color: var(--button-border-disabled);
+    border-radius: var(--wb-c-button-root-border-radius-default);
+    background: var(--button-bg-disabled);
+    color: var(--button-fg-disabled);
+    outline: none;
+    box-shadow: none;
+    text-decoration: none;
+    text-decoration-thickness: unset;
+    text-underline-offset: unset;
+}
+
+.button[aria-disabled="true"]:focus-visible {
+    border-width: var(--button-border-width-default);
+    border-color: var(--button-border-disabled);
+    border-radius: var(--wb-c-button-root-border-radius-default);
+    background: var(--button-bg-disabled);
+    color: var(--button-fg-disabled);
+}
+
+/**
+ * Label (rendered by `BodyText`).
+ */
+.text {
+    align-items: center;
+    font-weight: var(--wb-c-button-root-font-weight-default);
+    white-space: nowrap;
+    overflow: hidden;
+
+    /* To account for the underline-offset in tertiary buttons */
+    line-height: var(--wb-c-button-root-font-lineHeight-default);
+    text-overflow: ellipsis;
+    display: inline-block; /* allows the button text to truncate */
+    pointer-events: none; /* fix Safari bug where the browser was eating mouse events */
+}
+
+.smallText {
+    line-height: var(--wb-c-button-root-font-lineHeight-small);
+}
+
+.largeText {
+    font-size: var(--wb-c-button-root-font-size-large);
+    line-height: var(--wb-c-button-root-font-lineHeight-large);
+}
+
+.hiddenText {
+    visibility: hidden;
+}
+
+/**
+ * Icons + spinner.
+ */
+.spinner {
+    position: absolute;
+}
+
+.startIcon {
+    margin-inline: var(--wb-c-button-icon-margin-inline-outer) var(--wb-c-button-icon-margin-inline-inner);
+}
+
+.tertiaryStartIcon {
+    /* Undo the negative padding from startIcon since tertiary buttons don't
+     * have extra padding. */
+    margin-inline-start: 0;
+}
+
+.endIcon {
+    margin-inline-start: var(--wb-c-button-icon-margin-inline-inner);
+}
+
+.iconWrapper {
+    padding: var(--wb-c-button-icon-padding);
+
+    /* View has a default minInlineSize of 0, which causes the label text to
+     * encroach on the icon when it needs to truncate. We can fix this by
+     * setting the minInlineSize to auto. */
+    min-inline-size: auto;
+}
+
+.endIconWrapper {
+    margin-inline: var(--wb-c-button-icon-margin-inline-inner) var(--wb-c-button-icon-margin-inline-outer);
+}
+
+.endIconWrapperTertiary {
+    margin-inline-end: 0;
+}

--- a/packages/wonder-blocks-button/src/components/button.module.css
+++ b/packages/wonder-blocks-button/src/components/button.module.css
@@ -267,6 +267,24 @@
 }
 
 /**
+ * Re-assert the rest-state border for the kinds that show one (secondary /
+ * tertiary). `button-unstyled`'s `.reset` sets `border: none` in the same
+ * `@layer shared` at equal specificity but later source order, which would
+ * otherwise clear the base `.button` border. The `[data-kind]` attribute bumps
+ * this to a higher specificity so the visible border wins regardless of
+ * emission order. `border-style` is re-declared too because `border: none`
+ * resets it to `none`. Hover / press (higher specificity) and disabled (later
+ * source order, equal specificity) still override as intended. Primary is
+ * intentionally excluded — it has a zero-width border and uses `outline`.
+ */
+.button[data-kind="secondary"],
+.button[data-kind="tertiary"] {
+    border-style: solid;
+    border-width: var(--button-border-width-default);
+    border-color: var(--button-border-default);
+}
+
+/**
  * Hover. Allowed on non-touch devices only so the hover state isn't "sticky"
  * on touch devices.
  */

--- a/packages/wonder-blocks-button/src/components/button.module.css
+++ b/packages/wonder-blocks-button/src/components/button.module.css
@@ -367,15 +367,21 @@
 }
 
 /**
- * Secondary buttons keep their inset border `box-shadow` while focused, so the
- * focus ring is composited with the hover / press border shadow (the plain
- * focus rule above would otherwise replace the inset border with just the
- * ring). These are higher specificity than that rule so they win for every
+ * Secondary and tertiary buttons keep their inset border `box-shadow` while
+ * focused, so the focus ring is composited with the hover / press border shadow
+ * (the plain focus rule above would otherwise replace the inset border with just
+ * the ring). These are higher specificity than that rule so they win for every
  * focus + state combination, including the programmatic `.focused` / `.pressed`
  * classes.
+ *
+ * Tertiary only has a visible inset border in the thunderblocks theme (where its
+ * hover / press border-width is non-zero); in the default theme the inset is
+ * 0-width, so the composite collapses to the plain focus ring.
  */
 .button[data-kind="secondary"]:focus-visible:hover,
-.button[data-kind="secondary"].focused:hover {
+.button[data-kind="secondary"].focused:hover,
+.button[data-kind="tertiary"]:focus-visible:hover,
+.button[data-kind="tertiary"].focused:hover {
     @apply --wb-focus-visible;
 
     box-shadow:
@@ -386,7 +392,11 @@
 .button[data-kind="secondary"]:focus-visible:active,
 .button[data-kind="secondary"]:focus-visible.pressed,
 .button[data-kind="secondary"].focused:active,
-.button[data-kind="secondary"].focused.pressed {
+.button[data-kind="secondary"].focused.pressed,
+.button[data-kind="tertiary"]:focus-visible:active,
+.button[data-kind="tertiary"]:focus-visible.pressed,
+.button[data-kind="tertiary"].focused:active,
+.button[data-kind="tertiary"].focused.pressed {
     @apply --wb-focus-visible;
 
     box-shadow:

--- a/packages/wonder-blocks-button/src/components/button.module.css
+++ b/packages/wonder-blocks-button/src/components/button.module.css
@@ -267,24 +267,6 @@
 }
 
 /**
- * Re-assert the rest-state border for the kinds that show one (secondary /
- * tertiary). `button-unstyled`'s `.reset` sets `border: none` in the same
- * `@layer shared` at equal specificity but later source order, which would
- * otherwise clear the base `.button` border. The `[data-kind]` attribute bumps
- * this to a higher specificity so the visible border wins regardless of
- * emission order. `border-style` is re-declared too because `border: none`
- * resets it to `none`. Hover / press (higher specificity) and disabled (later
- * source order, equal specificity) still override as intended. Primary is
- * intentionally excluded — it has a zero-width border and uses `outline`.
- */
-.button[data-kind="secondary"],
-.button[data-kind="tertiary"] {
-    border-style: solid;
-    border-width: var(--button-border-width-default);
-    border-color: var(--button-border-default);
-}
-
-/**
  * Hover. Allowed on non-touch devices only so the hover state isn't "sticky"
  * on touch devices.
  */
@@ -352,36 +334,17 @@
 /**
  * Focus. `:focus-visible` provides keyboard-only focus styling; the `.focused`
  * class enables programmatic focus (set by `ClickableBehavior`).
- *
- * The `[data-kind]` attribute is included so this rule matches the specificity
- * of the kind-specific hover / active rules above (which are all qualified by
- * `[data-kind]`). At equal specificity the later rule wins, and this focus rule
- * is emitted after hover / active — so the focus ring keeps priority when a
- * button is focused *and* hovered or pressed (otherwise the primary `outline`
- * and secondary/tertiary inset `box-shadow` would paint over the ring). This
- * mirrors the original Aphrodite ordering (hover, active, then focus).
  */
-.button[data-kind]:focus-visible,
-.button[data-kind].focused {
+.button:focus-visible,
+.button.focused {
     @apply --wb-focus-visible;
 }
 
 /**
- * Secondary and tertiary buttons keep their inset border `box-shadow` while
- * focused, so the focus ring is composited with the hover / press border shadow
- * (the plain focus rule above would otherwise replace the inset border with just
- * the ring). These are higher specificity than that rule so they win for every
- * focus + state combination, including the programmatic `.focused` / `.pressed`
- * classes.
- *
- * Tertiary only has a visible inset border in the thunderblocks theme (where its
- * hover / press border-width is non-zero); in the default theme the inset is
- * 0-width, so the composite collapses to the plain focus ring.
+ * Secondary buttons keep their inset border `box-shadow` while focused, so the
+ * focus ring is composited with the hover / press border shadow.
  */
-.button[data-kind="secondary"]:focus-visible:hover,
-.button[data-kind="secondary"].focused:hover,
-.button[data-kind="tertiary"]:focus-visible:hover,
-.button[data-kind="tertiary"].focused:hover {
+.button[data-kind="secondary"]:focus-visible:hover {
     @apply --wb-focus-visible;
 
     box-shadow:
@@ -389,14 +352,7 @@
         0 0 0 var(--wb-border-width-medium) var(--wb-semanticColor-focus-inner);
 }
 
-.button[data-kind="secondary"]:focus-visible:active,
-.button[data-kind="secondary"]:focus-visible.pressed,
-.button[data-kind="secondary"].focused:active,
-.button[data-kind="secondary"].focused.pressed,
-.button[data-kind="tertiary"]:focus-visible:active,
-.button[data-kind="tertiary"]:focus-visible.pressed,
-.button[data-kind="tertiary"].focused:active,
-.button[data-kind="tertiary"].focused.pressed {
+.button[data-kind="secondary"]:focus-visible:active {
     @apply --wb-focus-visible;
 
     box-shadow:
@@ -435,6 +391,9 @@
 }
 
 .button[aria-disabled="true"]:focus-visible {
+    /* overrides focus styling so disabled buttons get the global focus */
+    @apply --wb-focus-visible;
+
     border-width: var(--button-border-width-default);
     border-color: var(--button-border-disabled);
     border-radius: var(--wb-c-button-root-border-radius-default);

--- a/packages/wonder-blocks-button/src/components/button.module.css
+++ b/packages/wonder-blocks-button/src/components/button.module.css
@@ -352,17 +352,30 @@
 /**
  * Focus. `:focus-visible` provides keyboard-only focus styling; the `.focused`
  * class enables programmatic focus (set by `ClickableBehavior`).
+ *
+ * The `[data-kind]` attribute is included so this rule matches the specificity
+ * of the kind-specific hover / active rules above (which are all qualified by
+ * `[data-kind]`). At equal specificity the later rule wins, and this focus rule
+ * is emitted after hover / active — so the focus ring keeps priority when a
+ * button is focused *and* hovered or pressed (otherwise the primary `outline`
+ * and secondary/tertiary inset `box-shadow` would paint over the ring). This
+ * mirrors the original Aphrodite ordering (hover, active, then focus).
  */
-.button:focus-visible,
-.button.focused {
+.button[data-kind]:focus-visible,
+.button[data-kind].focused {
     @apply --wb-focus-visible;
 }
 
 /**
  * Secondary buttons keep their inset border `box-shadow` while focused, so the
- * focus ring is composited with the hover / press border shadow.
+ * focus ring is composited with the hover / press border shadow (the plain
+ * focus rule above would otherwise replace the inset border with just the
+ * ring). These are higher specificity than that rule so they win for every
+ * focus + state combination, including the programmatic `.focused` / `.pressed`
+ * classes.
  */
-.button[data-kind="secondary"]:focus-visible:hover {
+.button[data-kind="secondary"]:focus-visible:hover,
+.button[data-kind="secondary"].focused:hover {
     @apply --wb-focus-visible;
 
     box-shadow:
@@ -370,7 +383,10 @@
         0 0 0 var(--wb-border-width-medium) var(--wb-semanticColor-focus-inner);
 }
 
-.button[data-kind="secondary"]:focus-visible:active {
+.button[data-kind="secondary"]:focus-visible:active,
+.button[data-kind="secondary"]:focus-visible.pressed,
+.button[data-kind="secondary"].focused:active,
+.button[data-kind="secondary"].focused.pressed {
     @apply --wb-focus-visible;
 
     box-shadow:

--- a/packages/wonder-blocks-button/src/components/button.module.css
+++ b/packages/wonder-blocks-button/src/components/button.module.css
@@ -1,52 +1,157 @@
 /**
  * Button styles (CSS Modules migration — WB-2328 / CSS Modules Phase 4).
  *
- * Design notes:
- * - The colour matrix (`kind × actionType`) is expressed with CSS custom
- *   property "slots" (`--button-bg-*`, `--button-fg-*`, `--button-border-*`).
- *   The `[data-kind]` attribute (set by `button-unstyled`) combined with the
- *   per-`actionType` class (`.progressive` / `.destructive` / `.neutral`) sets
- *   the slot values from the semantic-colour token variables. The base `.button`
- *   rule and the pseudo-state rules only ever read the slots, so each state is
- *   declared once instead of once-per-cell.
- * - Structural differences between kinds (primary uses `outline`, secondary /
- *   tertiary use an inset `box-shadow`, tertiary adds an underline) are handled
- *   with `[data-kind="…"]` rule blocks.
- * - Orthogonal axes (`size`, icon presence) and the JS-driven programmatic
- *   states (`.focused` / `.pressed`) are compound classes composed through the
- *   existing `style` prop (Wonder Blocks' `processStyleList` routes class-name
- *   strings to `className`), so no `clsx` dependency is needed.
- * - `disabled` is selected via the `[aria-disabled="true"]` attribute that
- *   `button-unstyled` already sets (the element stays focusable).
- * - All token references resolve against the per-theme `[data-wb-theme]` blocks
- *   shipped in `@khanacademy/wonder-blocks-tokens`, so theming (default /
- *   thunderblocks / syl-dark) keeps working unchanged. The build wraps every
- *   rule below in `@layer shared { … }` via the wrap-in-layer PostCSS plugin.
+ * Component-token surface
+ * -----------------------
+ * Every value a variant axis can change is funnelled through a
+ * `--wb-c-button--*` custom property ("component token"), following the
+ * convention `NodeIconButton` established with `--wb-c-node-icon-button--`.
+ * The double dash keeps this namespace distinct from the codegen'd design
+ * tokens these read from (`--wb-c-button-root-*`, `--wb-semanticColor-*`).
+ *
+ *   --wb-c-button--padding-inline        inline padding      (kind × size)
+ *   --wb-c-button--border-width-default  per-state widths    (kind)
+ *   --wb-c-button--border-width-hover
+ *   --wb-c-button--border-width-press
+ *   --wb-c-button--outline-offset        primary's outline   (kind)
+ *   --wb-c-button--bg-default            per-state colours   (kind × actionType)
+ *   --wb-c-button--fg-default
+ *   --wb-c-button--border-default
+ *   --wb-c-button--bg-hover
+ *   --wb-c-button--fg-hover
+ *   --wb-c-button--border-hover
+ *   --wb-c-button--bg-press
+ *   --wb-c-button--fg-press
+ *   --wb-c-button--border-press
+ *   --wb-c-button--bg-disabled           disabled colours    (kind)
+ *   --wb-c-button--fg-disabled
+ *   --wb-c-button--border-disabled
+ *
+ * Every rule below does exactly one of two jobs, never both:
+ *
+ * - **Variant classes assign tokens.** One class per axis value (`.primary`,
+ *   `.progressive`, `.small`) sets token values and nothing else.
+ *   `button-core` composes them through the existing `style` prop (Wonder
+ *   Blocks' `processStyleList` routes class-name strings to `className`), so
+ *   the axes stay orthogonal and no `clsx` dependency is needed.
+ * - **Base and state rules only read tokens.** `.button` plus one rule per
+ *   interactive state, so each state is declared once rather than
+ *   once-per-cell of the variant matrix.
+ *
+ * Colour is the one place the axes aren't orthogonal: the semantic tokens are
+ * keyed by `kind` *and* `actionType`
+ * (`--wb-semanticColor-action-<kind>-<actionType>-<state>-*`), so those nine
+ * cells are spelled out as compound `.primary.progressive` rules. Collapsing
+ * them would mean interpolating token names, which only JS can do.
+ *
+ * Specificity: state rules qualify the kind with `:where(…)`, which
+ * contributes no specificity of its own. Every state rule therefore sits at
+ * the same specificity and source order alone decides precedence. They are
+ * declared hover → active → focus → disabled, which is the priority we want:
+ * focus has to survive hover/press, and disabled resets everything.
+ *
+ * `disabled` is selected via the `[aria-disabled="true"]` attribute that
+ * `button-unstyled` already sets (the element stays focusable). All token
+ * references resolve against the per-theme `[data-wb-theme]` blocks shipped
+ * in `@khanacademy/wonder-blocks-tokens`, so theming (default /
+ * thunderblocks / syl-dark) keeps working unchanged. The build wraps every
+ * rule below in `@layer shared { … }` via the wrap-in-layer PostCSS plugin.
  */
 
 @import "@khanacademy/wonder-blocks-styles/focus-styles.css";
 
+/**
+ * Base. Reads component tokens only — never assigns them.
+ */
 .button {
     /* Layout (was `sharedStyles.shared`). Height is the medium default; the
      * `.small` / `.large` size classes override it. */
     block-size: var(--wb-c-button-root-sizing-height-medium);
     padding-block: 0;
-    padding-inline: var(--button-padding-inline);
+    padding-inline: var(--wb-c-button--padding-inline);
 
-    /* Theming, driven by the colour slots set in the matrix rules below. */
+    /* Theming, driven by the colour tokens set by the variant classes. */
     border-radius: var(--wb-c-button-root-border-radius-default);
     border-style: solid;
-    border-width: var(--button-border-width-default);
-    border-color: var(--button-border-default);
-    background: var(--button-bg-default);
-    color: var(--button-fg-default);
+    border-width: var(--wb-c-button--border-width-default);
+    border-color: var(--wb-c-button--border-default);
+    background: var(--wb-c-button--bg-default);
+    color: var(--wb-c-button--fg-default);
 
     /* Animation */
     transition: border-radius 0.1s ease-in-out;
 }
 
 /**
- * Size axis (orthogonal compound classes). `medium` is the base.
+ * `kind` axis. Sets the border widths, the primary outline offset, the
+ * medium-size inline padding and the disabled-state colours (which depend on
+ * `kind` only, not `actionType`).
+ */
+.primary {
+    --wb-c-button--border-width-default: var(
+        --wb-c-button-root-border-width-primary-default
+    );
+    --wb-c-button--border-width-hover: var(
+        --wb-c-button-root-border-width-primary-hover
+    );
+    --wb-c-button--border-width-press: var(
+        --wb-c-button-root-border-width-primary-press
+    );
+    --wb-c-button--outline-offset: var(--wb-c-button-root-border-offset-primary);
+    --wb-c-button--padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-primary-medium
+    );
+    --wb-c-button--bg-disabled: var(--wb-semanticColor-action-primary-disabled-background);
+    --wb-c-button--fg-disabled: var(--wb-semanticColor-action-primary-disabled-foreground);
+    --wb-c-button--border-disabled: var(--wb-semanticColor-action-primary-disabled-border);
+}
+
+.secondary {
+    --wb-c-button--border-width-default: var(
+        --wb-c-button-root-border-width-secondary-default
+    );
+    --wb-c-button--border-width-hover: var(
+        --wb-c-button-root-border-width-secondary-hover
+    );
+    --wb-c-button--border-width-press: var(
+        --wb-c-button-root-border-width-secondary-press
+    );
+    --wb-c-button--outline-offset: var(
+        --wb-c-button-root-border-offset-secondary
+    );
+    --wb-c-button--padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-secondary-medium
+    );
+    --wb-c-button--bg-disabled: var(--wb-semanticColor-action-secondary-disabled-background);
+    --wb-c-button--fg-disabled: var(--wb-semanticColor-action-secondary-disabled-foreground);
+    --wb-c-button--border-disabled: var(--wb-semanticColor-action-secondary-disabled-border);
+}
+
+.tertiary {
+    --wb-c-button--border-width-default: var(
+        --wb-c-button-root-border-width-tertiary-default
+    );
+    --wb-c-button--border-width-hover: var(
+        --wb-c-button-root-border-width-tertiary-hover
+    );
+    --wb-c-button--border-width-press: var(
+        --wb-c-button-root-border-width-tertiary-press
+    );
+    --wb-c-button--outline-offset: var(
+        --wb-c-button-root-border-offset-tertiary
+    );
+    --wb-c-button--padding-inline: var(
+        --wb-c-button-root-layout-padding-inline-tertiary-medium
+    );
+    --wb-c-button--bg-disabled: var(--wb-semanticColor-action-tertiary-disabled-background);
+    --wb-c-button--fg-disabled: var(--wb-semanticColor-action-tertiary-disabled-foreground);
+    --wb-c-button--border-disabled: var(--wb-semanticColor-action-tertiary-disabled-border);
+}
+
+/**
+ * `size` axis. `medium` is the base, so only `small` / `large` appear here.
+ * Height is kind-independent; inline padding is not, so it needs one compound
+ * rule per cell.
  */
 .small {
     block-size: var(--wb-c-button-root-sizing-height-small);
@@ -56,214 +161,152 @@
     block-size: var(--wb-c-button-root-sizing-height-large);
 }
 
-/**
- * Per-kind slots: border widths, the primary outline offset, the
- * `kind × size` inline padding and the disabled-state colours (disabled
- * colours depend on `kind` only, not `actionType`).
- */
-.button[data-kind="primary"] {
-    --button-border-width-default: var(
-        --wb-c-button-root-border-width-primary-default
-    );
-    --button-border-width-hover: var(
-        --wb-c-button-root-border-width-primary-hover
-    );
-    --button-border-width-press: var(
-        --wb-c-button-root-border-width-primary-press
-    );
-    --button-outline-offset: var(--wb-c-button-root-border-offset-primary);
-    --button-padding-inline: var(
-        --wb-c-button-root-layout-padding-inline-primary-medium
-    );
-    --button-bg-disabled: var(--wb-semanticColor-action-primary-disabled-background);
-    --button-fg-disabled: var(--wb-semanticColor-action-primary-disabled-foreground);
-    --button-border-disabled: var(--wb-semanticColor-action-primary-disabled-border);
-}
-
-.button[data-kind="primary"].small {
-    --button-padding-inline: var(
+.primary.small {
+    --wb-c-button--padding-inline: var(
         --wb-c-button-root-layout-padding-inline-primary-small
     );
 }
 
-.button[data-kind="primary"].large {
-    --button-padding-inline: var(
+.primary.large {
+    --wb-c-button--padding-inline: var(
         --wb-c-button-root-layout-padding-inline-primary-large
     );
 }
 
-.button[data-kind="secondary"] {
-    --button-border-width-default: var(
-        --wb-c-button-root-border-width-secondary-default
-    );
-    --button-border-width-hover: var(
-        --wb-c-button-root-border-width-secondary-hover
-    );
-    --button-border-width-press: var(
-        --wb-c-button-root-border-width-secondary-press
-    );
-    --button-outline-offset: var(--wb-c-button-root-border-offset-secondary);
-    --button-padding-inline: var(
-        --wb-c-button-root-layout-padding-inline-secondary-medium
-    );
-    --button-bg-disabled: var(--wb-semanticColor-action-secondary-disabled-background);
-    --button-fg-disabled: var(--wb-semanticColor-action-secondary-disabled-foreground);
-    --button-border-disabled: var(--wb-semanticColor-action-secondary-disabled-border);
-}
-
-.button[data-kind="secondary"].small {
-    --button-padding-inline: var(
+.secondary.small {
+    --wb-c-button--padding-inline: var(
         --wb-c-button-root-layout-padding-inline-secondary-small
     );
 }
 
-.button[data-kind="secondary"].large {
-    --button-padding-inline: var(
+.secondary.large {
+    --wb-c-button--padding-inline: var(
         --wb-c-button-root-layout-padding-inline-secondary-large
     );
 }
 
-.button[data-kind="tertiary"] {
-    --button-border-width-default: var(
-        --wb-c-button-root-border-width-tertiary-default
-    );
-    --button-border-width-hover: var(
-        --wb-c-button-root-border-width-tertiary-hover
-    );
-    --button-border-width-press: var(
-        --wb-c-button-root-border-width-tertiary-press
-    );
-    --button-outline-offset: var(--wb-c-button-root-border-offset-tertiary);
-    --button-padding-inline: var(
-        --wb-c-button-root-layout-padding-inline-tertiary-medium
-    );
-    --button-bg-disabled: var(--wb-semanticColor-action-tertiary-disabled-background);
-    --button-fg-disabled: var(--wb-semanticColor-action-tertiary-disabled-foreground);
-    --button-border-disabled: var(--wb-semanticColor-action-tertiary-disabled-border);
-}
-
-.button[data-kind="tertiary"].small {
-    --button-padding-inline: var(
+.tertiary.small {
+    --wb-c-button--padding-inline: var(
         --wb-c-button-root-layout-padding-inline-tertiary-small
     );
 }
 
-.button[data-kind="tertiary"].large {
-    --button-padding-inline: var(
+.tertiary.large {
+    --wb-c-button--padding-inline: var(
         --wb-c-button-root-layout-padding-inline-tertiary-large
     );
 }
 
 /**
- * Colour matrix: `kind × actionType`. Each cell sets the bg / fg / border slots
- * for the rest, hover and press states from the semantic-colour tokens.
+ * Colour matrix: `kind × actionType`. Each cell sets the bg / fg / border
+ * tokens for the rest, hover and press states from the semantic-colour tokens.
  */
-.button[data-kind="primary"].progressive {
-    --button-bg-default: var(--wb-semanticColor-action-primary-progressive-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-primary-progressive-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-primary-progressive-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-primary-progressive-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-primary-progressive-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-primary-progressive-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-primary-progressive-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-primary-progressive-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-primary-progressive-press-border);
+.primary.progressive {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-primary-progressive-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-primary-progressive-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-primary-progressive-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-primary-progressive-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-primary-progressive-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-primary-progressive-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-primary-progressive-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-primary-progressive-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-primary-progressive-press-border);
 }
 
-.button[data-kind="primary"].destructive {
-    --button-bg-default: var(--wb-semanticColor-action-primary-destructive-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-primary-destructive-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-primary-destructive-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-primary-destructive-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-primary-destructive-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-primary-destructive-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-primary-destructive-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-primary-destructive-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-primary-destructive-press-border);
+.primary.destructive {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-primary-destructive-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-primary-destructive-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-primary-destructive-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-primary-destructive-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-primary-destructive-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-primary-destructive-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-primary-destructive-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-primary-destructive-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-primary-destructive-press-border);
 }
 
-.button[data-kind="primary"].neutral {
-    --button-bg-default: var(--wb-semanticColor-action-primary-neutral-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-primary-neutral-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-primary-neutral-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-primary-neutral-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-primary-neutral-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-primary-neutral-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-primary-neutral-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-primary-neutral-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-primary-neutral-press-border);
+.primary.neutral {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-primary-neutral-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-primary-neutral-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-primary-neutral-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-primary-neutral-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-primary-neutral-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-primary-neutral-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-primary-neutral-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-primary-neutral-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-primary-neutral-press-border);
 }
 
-.button[data-kind="secondary"].progressive {
-    --button-bg-default: var(--wb-semanticColor-action-secondary-progressive-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-secondary-progressive-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-secondary-progressive-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-secondary-progressive-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-secondary-progressive-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-secondary-progressive-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-secondary-progressive-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-secondary-progressive-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-secondary-progressive-press-border);
+.secondary.progressive {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-secondary-progressive-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-secondary-progressive-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-secondary-progressive-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-secondary-progressive-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-secondary-progressive-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-secondary-progressive-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-secondary-progressive-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-secondary-progressive-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-secondary-progressive-press-border);
 }
 
-.button[data-kind="secondary"].destructive {
-    --button-bg-default: var(--wb-semanticColor-action-secondary-destructive-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-secondary-destructive-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-secondary-destructive-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-secondary-destructive-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-secondary-destructive-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-secondary-destructive-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-secondary-destructive-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-secondary-destructive-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-secondary-destructive-press-border);
+.secondary.destructive {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-secondary-destructive-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-secondary-destructive-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-secondary-destructive-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-secondary-destructive-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-secondary-destructive-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-secondary-destructive-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-secondary-destructive-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-secondary-destructive-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-secondary-destructive-press-border);
 }
 
-.button[data-kind="secondary"].neutral {
-    --button-bg-default: var(--wb-semanticColor-action-secondary-neutral-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-secondary-neutral-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-secondary-neutral-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-secondary-neutral-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-secondary-neutral-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-secondary-neutral-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-secondary-neutral-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-secondary-neutral-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-secondary-neutral-press-border);
+.secondary.neutral {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-secondary-neutral-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-secondary-neutral-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-secondary-neutral-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-secondary-neutral-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-secondary-neutral-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-secondary-neutral-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-secondary-neutral-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-secondary-neutral-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-secondary-neutral-press-border);
 }
 
-.button[data-kind="tertiary"].progressive {
-    --button-bg-default: var(--wb-semanticColor-action-tertiary-progressive-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-tertiary-progressive-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-tertiary-progressive-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-tertiary-progressive-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-tertiary-progressive-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-tertiary-progressive-press-border);
+.tertiary.progressive {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-tertiary-progressive-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-tertiary-progressive-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-tertiary-progressive-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-tertiary-progressive-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-tertiary-progressive-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-tertiary-progressive-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-tertiary-progressive-press-border);
 }
 
-.button[data-kind="tertiary"].destructive {
-    --button-bg-default: var(--wb-semanticColor-action-tertiary-destructive-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-tertiary-destructive-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-tertiary-destructive-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-tertiary-destructive-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-tertiary-destructive-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-tertiary-destructive-press-border);
+.tertiary.destructive {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-tertiary-destructive-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-tertiary-destructive-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-tertiary-destructive-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-tertiary-destructive-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-tertiary-destructive-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-tertiary-destructive-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-tertiary-destructive-press-border);
 }
 
-.button[data-kind="tertiary"].neutral {
-    --button-bg-default: var(--wb-semanticColor-action-tertiary-neutral-default-background);
-    --button-fg-default: var(--wb-semanticColor-action-tertiary-neutral-default-foreground);
-    --button-border-default: var(--wb-semanticColor-action-tertiary-neutral-default-border);
-    --button-bg-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-background);
-    --button-fg-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-foreground);
-    --button-border-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-border);
-    --button-bg-press: var(--wb-semanticColor-action-tertiary-neutral-press-background);
-    --button-fg-press: var(--wb-semanticColor-action-tertiary-neutral-press-foreground);
-    --button-border-press: var(--wb-semanticColor-action-tertiary-neutral-press-border);
+.tertiary.neutral {
+    --wb-c-button--bg-default: var(--wb-semanticColor-action-tertiary-neutral-default-background);
+    --wb-c-button--fg-default: var(--wb-semanticColor-action-tertiary-neutral-default-foreground);
+    --wb-c-button--border-default: var(--wb-semanticColor-action-tertiary-neutral-default-border);
+    --wb-c-button--bg-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-background);
+    --wb-c-button--fg-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-foreground);
+    --wb-c-button--border-hover: var(--wb-semanticColor-action-tertiary-neutral-hover-border);
+    --wb-c-button--bg-press: var(--wb-semanticColor-action-tertiary-neutral-press-background);
+    --wb-c-button--fg-press: var(--wb-semanticColor-action-tertiary-neutral-press-foreground);
+    --wb-c-button--border-press: var(--wb-semanticColor-action-tertiary-neutral-press-border);
 }
 
 /**
@@ -272,25 +315,24 @@
  */
 @media (hover: hover) {
     .button:hover {
-        background: var(--button-bg-hover);
+        background: var(--wb-c-button--bg-hover);
         border-radius: var(--wb-c-button-root-border-radius-hover);
-        color: var(--button-fg-hover);
+        color: var(--wb-c-button--fg-hover);
     }
 
-    .button[data-kind="primary"]:hover {
-        outline: var(--button-border-width-hover) solid
-            var(--button-border-hover);
-        outline-offset: var(--button-outline-offset);
+    .button:where(.primary):hover {
+        outline: var(--wb-c-button--border-width-hover) solid
+            var(--wb-c-button--border-hover);
+        outline-offset: var(--wb-c-button--outline-offset);
     }
 
-    .button[data-kind="secondary"]:hover,
-    .button[data-kind="tertiary"]:hover {
-        border-color: var(--button-border-hover);
-        box-shadow: inset 0 0 0 var(--button-border-width-hover)
-            var(--button-border-hover);
+    .button:where(.secondary, .tertiary):hover {
+        border-color: var(--wb-c-button--border-hover);
+        box-shadow: inset 0 0 0 var(--wb-c-button--border-width-hover)
+            var(--wb-c-button--border-hover);
     }
 
-    .button[data-kind="tertiary"]:hover {
+    .button:where(.tertiary):hover {
         text-underline-offset: var(--wb-c-button-root-font-offset-default);
         text-decoration: var(--wb-c-button-root-font-decoration-hover)
             var(--wb-c-button-root-sizing-underline-hover);
@@ -304,28 +346,27 @@
  */
 .button:active,
 .button.pressed {
-    background: var(--button-bg-press);
+    background: var(--wb-c-button--bg-press);
     border-radius: var(--wb-c-button-root-border-radius-press);
-    color: var(--button-fg-press);
+    color: var(--wb-c-button--fg-press);
 }
 
-.button[data-kind="primary"]:active,
-.button[data-kind="primary"].pressed {
-    outline: var(--button-border-width-press) solid var(--button-border-press);
-    outline-offset: var(--button-outline-offset);
+.button:where(.primary):active,
+.button:where(.primary).pressed {
+    outline: var(--wb-c-button--border-width-press) solid
+        var(--wb-c-button--border-press);
+    outline-offset: var(--wb-c-button--outline-offset);
 }
 
-.button[data-kind="secondary"]:active,
-.button[data-kind="secondary"].pressed,
-.button[data-kind="tertiary"]:active,
-.button[data-kind="tertiary"].pressed {
-    border-color: var(--button-border-press);
-    box-shadow: inset 0 0 0 var(--button-border-width-press)
-        var(--button-border-press);
+.button:where(.secondary, .tertiary):active,
+.button:where(.secondary, .tertiary).pressed {
+    border-color: var(--wb-c-button--border-press);
+    box-shadow: inset 0 0 0 var(--wb-c-button--border-width-press)
+        var(--wb-c-button--border-press);
 }
 
-.button[data-kind="tertiary"]:active,
-.button[data-kind="tertiary"].pressed {
+.button:where(.tertiary):active,
+.button:where(.tertiary).pressed {
     text-underline-offset: var(--wb-c-button-root-font-offset-default);
     text-decoration: var(--wb-c-button-root-font-decoration-press)
         var(--wb-c-button-root-sizing-underline-press);
@@ -335,35 +376,38 @@
  * Focus. `:focus-visible` provides keyboard-only focus styling; the `.focused`
  * class enables programmatic focus (set by `ClickableBehavior`).
  *
- * The `[data-kind]` attribute is included so this rule matches the specificity
- * of the kind-specific hover / active rules above (which are all qualified by
- * `[data-kind]`). At equal specificity the later rule wins, and this focus rule
- * is emitted after hover / active — so the focus ring keeps priority when a
- * button is focused *and* hovered or pressed (otherwise the primary `outline`
- * and secondary/tertiary inset `box-shadow` would paint over the ring).
+ * Because the hover / active rules above qualify the kind with `:where(…)`,
+ * they sit at the same specificity as this rule, so being declared after them
+ * is enough for the focus ring to keep priority when a button is focused *and*
+ * hovered or pressed (otherwise the primary `outline` and the secondary /
+ * tertiary inset `box-shadow` would paint over the ring).
  */
-.button[data-kind]:focus-visible,
-.button[data-kind].focused {
+.button:focus-visible,
+.button.focused {
     @apply --wb-focus-visible;
 }
 
 /**
  * Secondary buttons keep their inset border `box-shadow` while focused, so the
- * focus ring is composited with the hover / press border shadow.
+ * focus ring is composited with the hover / press border shadow. These need to
+ * outrank the plain focus rule above, hence the real (non-`:where`) pseudo
+ * classes.
  */
-.button[data-kind="secondary"]:focus-visible:hover {
+.button:where(.secondary):focus-visible:hover {
     @apply --wb-focus-visible;
 
     box-shadow:
-        inset 0 0 0 var(--button-border-width-hover) var(--button-border-hover),
+        inset 0 0 0 var(--wb-c-button--border-width-hover)
+            var(--wb-c-button--border-hover),
         0 0 0 var(--wb-border-width-medium) var(--wb-semanticColor-focus-inner);
 }
 
-.button[data-kind="secondary"]:focus-visible:active {
+.button:where(.secondary):focus-visible:active {
     @apply --wb-focus-visible;
 
     box-shadow:
-        inset 0 0 0 var(--button-border-width-press) var(--button-border-press),
+        inset 0 0 0 var(--wb-c-button--border-width-press)
+            var(--wb-c-button--border-press),
         0 0 0 var(--wb-border-width-medium) var(--wb-semanticColor-focus-inner);
 }
 
@@ -372,11 +416,11 @@
  */
 .button[aria-disabled="true"] {
     cursor: not-allowed;
-    border-width: var(--button-border-width-default);
-    border-color: var(--button-border-disabled);
+    border-width: var(--wb-c-button--border-width-default);
+    border-color: var(--wb-c-button--border-disabled);
     border-radius: var(--wb-c-button-root-border-radius-default);
-    background: var(--button-bg-disabled);
-    color: var(--button-fg-disabled);
+    background: var(--wb-c-button--bg-disabled);
+    color: var(--wb-c-button--fg-disabled);
 }
 
 /**
@@ -387,11 +431,11 @@
  */
 .button[aria-disabled="true"]:hover,
 .button[aria-disabled="true"]:active {
-    border-width: var(--button-border-width-default);
-    border-color: var(--button-border-disabled);
+    border-width: var(--wb-c-button--border-width-default);
+    border-color: var(--wb-c-button--border-disabled);
     border-radius: var(--wb-c-button-root-border-radius-default);
-    background: var(--button-bg-disabled);
-    color: var(--button-fg-disabled);
+    background: var(--wb-c-button--bg-disabled);
+    color: var(--wb-c-button--fg-disabled);
     outline: none;
     box-shadow: none;
     text-decoration: none;
@@ -403,11 +447,11 @@
     /* overrides focus styling so disabled buttons get the global focus */
     @apply --wb-focus-visible;
 
-    border-width: var(--button-border-width-default);
-    border-color: var(--button-border-disabled);
+    border-width: var(--wb-c-button--border-width-default);
+    border-color: var(--wb-c-button--border-disabled);
     border-radius: var(--wb-c-button-root-border-radius-default);
-    background: var(--button-bg-disabled);
-    color: var(--button-fg-disabled);
+    background: var(--wb-c-button--bg-disabled);
+    color: var(--wb-c-button--fg-disabled);
 }
 
 /**

--- a/packages/wonder-blocks-button/src/components/button.module.css
+++ b/packages/wonder-blocks-button/src/components/button.module.css
@@ -1,5 +1,5 @@
 /**
- * Button styles (CSS Modules migration — WB-2328 / CSS Modules Phase 4).
+ * Button styles
  *
  * Component-token surface
  * -----------------------

--- a/packages/wonder-blocks-button/src/components/button.module.css
+++ b/packages/wonder-blocks-button/src/components/button.module.css
@@ -334,9 +334,16 @@
 /**
  * Focus. `:focus-visible` provides keyboard-only focus styling; the `.focused`
  * class enables programmatic focus (set by `ClickableBehavior`).
+ *
+ * The `[data-kind]` attribute is included so this rule matches the specificity
+ * of the kind-specific hover / active rules above (which are all qualified by
+ * `[data-kind]`). At equal specificity the later rule wins, and this focus rule
+ * is emitted after hover / active — so the focus ring keeps priority when a
+ * button is focused *and* hovered or pressed (otherwise the primary `outline`
+ * and secondary/tertiary inset `box-shadow` would paint over the ring).
  */
-.button:focus-visible,
-.button.focused {
+.button[data-kind]:focus-visible,
+.button[data-kind].focused {
     @apply --wb-focus-visible;
 }
 
@@ -373,8 +380,10 @@
 }
 
 /**
- * Reset hover / active styling on disabled buttons. NOTE: focus is intentionally
- * specified after hover so it can reset hover styling back to the rest state.
+ * Reset hover / active styling on disabled buttons.
+ *
+ * NOTE: focus is intentionally specified after hover so it can reset hover
+ * styling back to the rest state.
  */
 .button[aria-disabled="true"]:hover,
 .button[aria-disabled="true"]:active {


### PR DESCRIPTION
Migrate `Button` from Aphrodite to CSS Modules (CSS Modules Phase 4 of epic
WB-2120). This is a spike on the worst-case variant matrix (~36 cells across
`kind × actionType × size`) to validate the migration patterns before the
component waves. The public API is unchanged — same props, DOM structure, and
`style` / `styles` / `labelStyle` overrides — so this is an internal styling
refactor. `ActivityButton` (which has its own `_generateStyles`) is deferred.

Styling is organised around a **component-token surface**, following the
convention `NodeIconButton` established with `--wb-c-node-icon-button--`: every
value a variant axis can change is a `--wb-c-button--*` custom property, and
each rule does exactly one of two jobs, never both.

- **Variant classes assign tokens.** One class per axis value (`.primary`,
  `.progressive`, `.small`) sets token values and nothing else, so all three
  axes compose the same way — as class-name strings through the WB `style` prop
  via `processStyleList` (no `clsx`).
- **Base and state rules only read tokens.** Each interactive state is declared
  once instead of once-per-cell of the matrix.

Colour is the one place the axes aren't orthogonal — the semantic tokens are
keyed by `kind` *and* `actionType`
(`--wb-semanticColor-action-<kind>-<actionType>-<state>-*`) — so those nine
cells are spelled out as compound `.primary.progressive` rules. Collapsing them
would mean interpolating token names, which only JS can do.

State rules qualify the kind with `:where(…)`, which contributes no
specificity. Every state rule therefore sits at the same specificity and source
order alone decides precedence, declared hover → active → focus → disabled:
focus has to survive hover/press, and disabled resets everything. `data-kind`
is still set on the element as a consumer/test hook, but no longer drives
styling.

Theming is unchanged — the module references the same `--wb-*` token vars that
switch on `[data-wb-theme]`. The shared reset moves to a CSS Module too, emitted into the
nested layer `shared.reset` so the component styles — which sit directly in
`shared` — outrank it regardless of the order the bundler emits the two
stylesheets in. The package now ships
`dist/index.css` (auto side-effect import) and exposes it via the new
`@khanacademy/wonder-blocks-button/css` subpath.

Issue: WB-2328

## Test plan:

1. Review the Chromatic diff on this PR; any diff must be intentional (target: none).
2. In Storybook, spot-check `Button` across `kind` (primary/secondary/tertiary) ×
   `actionType` (progressive/destructive/neutral) × `size` (small/medium/large) and
   the hover / active / focus-visible / disabled states, in the default,
   thunderblocks, and syl-dark themes.
3. Specifically check the focus ring while *also* hovering and while pressed —
   that combination is what the `:where(…)` specificity flattening protects, for
   every `kind` (primary's `outline`, secondary/tertiary's inset `box-shadow`).
4. Check a disabled button's focus ring, and that hover/press leave a disabled
   button visually unchanged.
5. **Confirm secondary and tertiary buttons show a visible *rest-state* border**
   (all three themes). This one is not covered by CI: the reset now sits in the
   nested layer `shared.reset`, and that only beats the reset's late position in
   the bundle if rules directly in a layer outrank its named sub-layers — CSS
   Cascade 5 behaviour that could not be verified outside a browser. See the
   comment on `button-unstyled.module.css` for the fallback if it's wrong.
`/?path=/docs/packages-button-button--docs`

## Review plan:

Please review these risky changes

1. 🚨 [`button.module.css`](https://github.com/Khan/wonder-blocks/pull/3164#discussion_r3707838201)
2. 🚨 [`button-core.tsx`](https://github.com/Khan/wonder-blocks/pull/3164#discussion_r3707838315)
3. ⚠️ [`button-unstyled.tsx`](https://github.com/Khan/wonder-blocks/pull/3164#discussion_r3707838431)
4. ⚠️ [`package.json`](https://github.com/Khan/wonder-blocks/pull/3164#discussion_r3707838533)
5. ⚠️ [`button-unstyled.module.css`](https://github.com/Khan/wonder-blocks/pull/3164#discussion_r3732194754)

### Common patterns:

**2 Files (button-core.tsx, button-unstyled.tsx):** Replace Aphrodite `StyleSheet.create` / `_generateStyles` with a colocated `*.module.css` and compose the resulting class-name strings through the Wonder Blocks `style` prop (routed to `className` by `processStyleList`).

```tsx
// Before
import {StyleSheet} from "aphrodite";
const styles = StyleSheet.create({reset: {position: "relative", /* … */}});
style={[styles.reset, style]}

// After
import styles from "./button-unstyled.module.css";
style={[styles.reset, style]}
```

