### PR TITLE
Fix Tooltip tail position in RTL contexts

### DIFF
--- a/.changeset/wb-509-tooltip-tail-rtl.md
+++ b/.changeset/wb-509-tooltip-tail-rtl.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tooltip": patch
+---
+
+Fix the Tooltip tail being mispositioned in RTL contexts. The tail is now positioned from a physical origin, matching the coordinate space Popper.js reports its offset in, instead of relying on the bubble's direction-aware flex flow. This also fixes the Popover tail, which renders `TooltipTail`.

--- a/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip-tail.test.tsx
@@ -48,9 +48,14 @@ describe("TooltipTail", () => {
             expect(container).toMatchInlineSnapshot(`
 <div>
   <div
+    aria-hidden="true"
+    class=""
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0; block-size: 20px; flex-shrink: 0;"
+  />
+  <div
     class=""
     data-placement="top"
-    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
+    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: absolute; z-index: 0; min-block-size: 0; min-inline-size: 0; pointer-events: none; left: 0px; bottom: 1px; width: 40px; height: 20px;"
   >
     <svg
       aria-hidden="true"
@@ -118,9 +123,14 @@ describe("TooltipTail", () => {
             expect(container).toMatchInlineSnapshot(`
                 <div>
                   <div
+                    aria-hidden="true"
+                    class=""
+                    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0; block-size: 20px; flex-shrink: 0;"
+                  />
+                  <div
                     class=""
                     data-placement="top"
-                    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: relative; z-index: 0; min-block-size: 0; min-inline-size: 0; pointer-events: none; top: -1px; width: 40px; height: 20px;"
+                    style="align-items: stretch; border-width: 0px; border-style: solid; box-sizing: border-box; display: flex; flex-direction: column; margin: 0px; padding: 0px; position: absolute; z-index: 0; min-block-size: 0; min-inline-size: 0; pointer-events: none; left: 0px; bottom: 1px; width: 40px; height: 20px;"
                   >
                     <div
                       aria-hidden="true"

--- a/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
+++ b/packages/wonder-blocks-tooltip/src/components/tooltip-tail.tsx
@@ -272,14 +272,28 @@ export default class TooltipTail extends React.Component<Props> {
          * NOTE: The widths and heights refer to the downward-pointing tail
          * (i.e. placement="top"). When the tail points to the left or right
          * instead, the width/height are inverted.
+         *
+         * These insets are intentionally physical rather than logical.
+         * Popper.js reports the tail's offset as a physical distance from the
+         * bubble's left/top edge, so the tail has to resolve against that same
+         * physical origin in both writing directions. Using logical properties
+         * here would flip the origin under `dir="rtl"` while Popper's offset
+         * stayed physical, placing the tail outside the bubble entirely. The
+         * tail is a pure shape with no text, so it has no directional reading
+         * order of its own. `placement` is likewise physical: a tail for
+         * placement="right" faces the anchor on the bubble's left side
+         * regardless of direction.
          */
         const fullTailWidth = this._getFullTailWidth();
         const fullTailHeight = this._getFullTailHeight();
 
         switch (placement) {
             case "top":
+                // The tail sits at the bubble's bottom edge, nudged 1px up so
+                // its outline overlaps the content's border.
                 return {
-                    top: -1,
+                    left: 0,
+                    bottom: 1,
                     width: fullTailWidth,
                     height: fullTailHeight,
                 };
@@ -287,12 +301,14 @@ export default class TooltipTail extends React.Component<Props> {
             case "right":
                 return {
                     left: 1,
+                    top: 0,
                     width: fullTailHeight,
                     height: fullTailWidth,
                 };
 
             case "bottom":
                 return {
+                    left: 0,
                     top: 1,
                     width: fullTailWidth,
                     height: fullTailHeight,
@@ -300,7 +316,8 @@ export default class TooltipTail extends React.Component<Props> {
 
             case "left":
                 return {
-                    left: -1,
+                    right: 1,
+                    top: 0,
                     width: fullTailHeight,
                     height: fullTailWidth,
                 };
@@ -308,6 +325,31 @@ export default class TooltipTail extends React.Component<Props> {
             default:
                 throw new Error(`Unknown placement: ${placement}`);
         }
+    }
+
+    /**
+     * The space the tail occupies in the bubble's flex layout.
+     *
+     * The tail itself is absolutely positioned (see `_getContainerStyle`), so
+     * it no longer contributes to the bubble's layout. This spacer reserves the
+     * same room the tail used to take along the bubble's stacking axis, keeping
+     * the gap between the bubble content and the anchor.
+     */
+    _renderLayoutSpacer(): React.ReactNode {
+        const {placement} = this.props;
+        const isHorizontal = placement === "left" || placement === "right";
+        const fullTailHeight = this._getFullTailHeight();
+
+        return (
+            <View
+                aria-hidden
+                style={
+                    isHorizontal
+                        ? {inlineSize: fullTailHeight, flexShrink: 0}
+                        : {blockSize: fullTailHeight, flexShrink: 0}
+                }
+            />
+        );
     }
 
     _getArrowStyle(): React.CSSProperties {
@@ -424,17 +466,20 @@ export default class TooltipTail extends React.Component<Props> {
     render(): React.ReactNode {
         const {offset, placement, updateRef} = this.props;
         return (
-            <View
-                style={[
-                    styles.tailContainer,
-                    {...offset},
-                    this._getContainerStyle(),
-                ]}
-                data-placement={placement}
-                ref={updateRef}
-            >
-                {this._renderArrow()}
-            </View>
+            <React.Fragment>
+                {this._renderLayoutSpacer()}
+                <View
+                    style={[
+                        styles.tailContainer,
+                        {...offset},
+                        this._getContainerStyle(),
+                    ]}
+                    data-placement={placement}
+                    ref={updateRef}
+                >
+                    {this._renderArrow()}
+                </View>
+            </React.Fragment>
         );
     }
 }
@@ -459,7 +504,7 @@ const styles = StyleSheet.create({
      * Container
      */
     tailContainer: {
-        position: "relative",
+        position: "absolute",
         pointerEvents: "none",
     },
 


### PR DESCRIPTION
## Summary

The Tooltip tail is mispositioned in RTL. Because Popover renders `TooltipTail`, this fixes Popover in RTL too, which is what [WB-2069](https://khanacademy.atlassian.net/browse/WB-2069) is really about.

## Root cause

`TooltipTail` spreads Popper.js's arrow offset straight onto its container:

- `tooltip-popper.tsx` copies `popperProps.arrowProps.style.transform` into `tailOffset`
- `tooltip-tail.tsx` spreads it via `{...offset}` onto a `position: relative` element

Popper reports that offset as a **physical** distance from the bubble's left edge. But the tail is a `position: relative` flex item, so its static origin flips to the bubble's **right** edge under `dir="rtl"`. A physical offset applied to a flipped origin puts the tail a constant `bubbleWidth - tailWidth` too far along the inline axis — **248px** at the default popover size, entirely outside the bubble.

The bubble itself is unaffected because it's `position: absolute`, which is direction-independent. Only the tail sits in flow.

This is really Popper's arrow contract: the arrow element is meant to be absolutely positioned. Using `position: relative` in flex flow is what broke it.

## Screenshots

https://github.com/user-attachments/assets/444abd84-c904-43e4-9037-0e7656a2a209

<img width="1712" height="490" alt="Screenshot 2026-08-04 at 3 12 26 PM" src="https://github.com/user-attachments/assets/fed0890f-be98-42df-bbd6-30426116b2ef" />
<img width="1704" height="630" alt="Screenshot 2026-08-04 at 3 13 24 PM" src="https://github.com/user-attachments/assets/f26925ed-1b91-468e-8890-270719a4a9a8" />
<img width="1413" height="251" alt="Screenshot 2026-08-04 at 3 17 44 PM" src="https://github.com/user-attachments/assets/19160a9a-6af8-472f-ad1a-07903956d000" />
<img width="1130" height="702" alt="Screenshot 2026-08-04 at 3 20 21 PM" src="https://github.com/user-
<img width="1306" height="712" alt="Screenshot 2026-08-04 at 3 21 14 PM" src="https://github.com/user-attachments/assets/20257ccc-b51d-4553-a5b7-31167e293d77" />
<img width="1720" height="609" alt="Screenshot 2026-08-04 at 3 22 00 PM" src="https://github.com/user-attachments/assets/c7f7a43f-c864-4d68-a4df-288090d4209b" />


`pnpm run jest --testPathPattern="wonder-blocks-(tooltip|popover)"` passes (16 suites). `pnpm lint` and `pnpm typecheck` clean.

To see it: open `Packages / Popover / Popover` -> `In Corners`, set the toolbar direction to RTL, and open all four popovers.


[WB-509]: https://khanacademy.atlassian.net/browse/WB-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-2069]: https://khanacademy.atlassian.net/browse/WB-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ