### PR TITLE
[WB-2328] 🚨 [CSS Modules] Migrate ActivityButton to CSS Modules

### DIFF
--- a/.changeset/css-modules-phase-4-activity-button.md
+++ b/.changeset/css-modules-phase-4-activity-button.md
@@ -1,0 +1,25 @@
+---
+"@khanacademy/wonder-blocks-button": minor
+---
+
+Migrate `ActivityButton` from Aphrodite to CSS Modules (WB-2328, CSS Modules
+Phase 4). The public component API is unchanged — same props, same DOM
+structure, and the same `styles.root` / `styles.box` / `styles.startIcon` /
+`styles.endIcon` / `styles.label` overrides — so this is an internal styling
+refactor.
+
+- The `actionType × kind` variant matrix now lives in
+  `activity-button.module.css`, expressed with `--wb-c-activity-button--*`
+  component tokens assigned by per-axis classes, so each interactive state
+  (hover / press / disabled / focus) is declared once instead of once-per-cell.
+  Theming (default / thunderblocks / syl-dark) is unchanged — the module
+  references the same `--wb-semanticColor-chonky-*` variables that switch on
+  `[data-wb-theme]`.
+- The "chonky" box's hover / press / disabled styling is now driven by
+  descendant selectors from the root element rather than by classes toggled in
+  JS. The box keeps its plain `chonky` class name in the DOM as a
+  consumer/test hook, it just no longer drives styling.
+- A focused *and* hovered disabled button now keeps the full global focus ring.
+  Previously the hover reset stripped its outline (leaving only the inner
+  box-shadow), which was an artifact of Aphrodite's rule ordering rather than
+  an intentional design.

--- a/packages/wonder-blocks-button/src/components/activity-button.module.css
+++ b/packages/wonder-blocks-button/src/components/activity-button.module.css
@@ -1,0 +1,380 @@
+/**
+ * ActivityButton styles (CSS Modules migration — WB-2328 / CSS Modules Phase 4).
+ *
+ * Component-token surface
+ * -----------------------
+ * Every value a variant axis can change is funnelled through a
+ * `--wb-c-activity-button--*` custom property ("component token"), following
+ * the convention `NodeIconButton` established with `--wb-c-node-icon-button--`
+ * and `Button` with `--wb-c-button--`.
+ *
+ *   --wb-c-activity-button--box-border-width      structural (all variants)
+ *   --wb-c-activity-button--box-shadow-y-rest
+ *   --wb-c-activity-button--box-shadow-y-hover
+ *   --wb-c-activity-button--box-shadow-y-press
+ *   --wb-c-activity-button--label-color           root text colour (actionType)
+ *   --wb-c-activity-button--box-bg-rest           box colours (actionType × kind)
+ *   --wb-c-activity-button--box-fg-rest
+ *   --wb-c-activity-button--box-border-rest
+ *   --wb-c-activity-button--box-shadow-color-rest
+ *   --wb-c-activity-button--box-bg-hover
+ *   --wb-c-activity-button--box-fg-hover
+ *   --wb-c-activity-button--box-border-hover
+ *   --wb-c-activity-button--box-shadow-color-hover
+ *   --wb-c-activity-button--box-bg-press
+ *   --wb-c-activity-button--box-fg-press
+ *   --wb-c-activity-button--box-border-press
+ *   --wb-c-activity-button--box-shadow-color-press
+ *   --wb-c-activity-button--box-bg-disabled       disabled colours (kind)
+ *   --wb-c-activity-button--box-fg-disabled
+ *   --wb-c-activity-button--box-border-disabled
+ *   --wb-c-activity-button--box-shadow-color-disabled
+ *
+ * Every rule below does exactly one of two jobs, never both:
+ *
+ * - **Variant classes assign tokens.** One class per axis value
+ *   (`.progressive`, `.primary`) sets token values and nothing else.
+ *   `activity-button` composes them through the existing `style` prop (Wonder
+ *   Blocks' `processStyleList` routes class-name strings to `className`), so
+ *   the axes stay orthogonal and no `clsx` dependency is needed.
+ * - **Base and state rules only read tokens.** `.button` / `.box` plus one
+ *   rule per interactive state, so each state is declared once rather than
+ *   once-per-cell of the variant matrix.
+ *
+ * Colour is the one place the axes aren't orthogonal: the semantic tokens are
+ * keyed by `actionType` *and* `kind`
+ * (`--wb-semanticColor-chonky-<actionType>-<property>-<kind>-<state>`), so
+ * those six cells are spelled out as compound `.progressive.primary` rules.
+ * Collapsing them would mean interpolating token names, which only JS can do.
+ * Disabled colours are keyed by `kind` alone, so they live on the kind classes.
+ *
+ * The token values themselves are *not* codegen'd per theme (unlike
+ * `--wb-c-button-root-*`): every theme reuses the same structural values, so
+ * they're written literally here, matching the note on the `theme` object the
+ * Aphrodite version carried. Colour tokens still resolve against the per-theme
+ * `[data-wb-theme]` blocks shipped in `@khanacademy/wonder-blocks-tokens`, so
+ * theming (default / thunderblocks / syl-dark) keeps working unchanged.
+ *
+ * Specificity: the box state rules all sit at (0,3,0) — `.button` plus a
+ * pseudo-class/attribute plus `.box` — so source order alone decides
+ * precedence. They are declared hover → active → disabled → focus, which is
+ * the priority we want: press has to survive hover, disabled resets both, and
+ * the focus ring has to survive all of them.
+ *
+ * `disabled` is selected via the `[aria-disabled="true"]` attribute that
+ * `button-unstyled` already sets (the element stays focusable). The build wraps
+ * every rule below in `@layer shared { … }` via the wrap-in-layer PostCSS
+ * plugin.
+ */
+
+@import "@khanacademy/wonder-blocks-styles/focus-styles.css";
+
+/**
+ * Root element. Assigns the structural component tokens (identical across
+ * every variant) and otherwise only reads tokens.
+ */
+.button {
+    --wb-c-activity-button--box-border-width: var(--wb-border-width-thin);
+
+    /* NOTE: We use px units to prevent a bug in Safari where the shadow
+     * animation flickers when using rem units. */
+    --wb-c-activity-button--box-shadow-y-rest: 6px;
+    --wb-c-activity-button--box-shadow-y-hover: 8px;
+    --wb-c-activity-button--box-shadow-y-press: var(--wb-sizing-size_0);
+
+    /* Applying a transparent background to allow the chonky box to show
+     * through. */
+    background: transparent;
+
+    /* Used for the focus ring. */
+    border-radius: var(--wb-border-radius-radius_120);
+    color: var(--wb-c-activity-button--label-color);
+
+    /* Layout */
+    block-size: auto;
+    flex-direction: column;
+    gap: var(--wb-sizing-size_020);
+
+    /* `align-self: flex-start` + `justify-self: center`. */
+    place-self: flex-start center;
+}
+
+/**
+ * `actionType` axis. Owns the root text colour only — the box colours depend on
+ * `kind` as well and are set by the colour matrix below.
+ */
+.progressive {
+    --wb-c-activity-button--label-color: var(
+        --wb-semanticColor-core-foreground-instructive-default
+    );
+}
+
+.neutral {
+    --wb-c-activity-button--label-color: var(
+        --wb-semanticColor-core-foreground-neutral-default
+    );
+}
+
+/**
+ * `kind` axis. Owns the disabled colours, which depend on `kind` only.
+ */
+.primary {
+    --wb-c-activity-button--box-bg-disabled: var(--wb-semanticColor-chonky-disabled-background-primary);
+    --wb-c-activity-button--box-fg-disabled: var(--wb-semanticColor-chonky-disabled-foreground-primary);
+    --wb-c-activity-button--box-border-disabled: var(--wb-semanticColor-chonky-disabled-border-primary);
+    --wb-c-activity-button--box-shadow-color-disabled: var(--wb-semanticColor-chonky-disabled-shadow-primary);
+}
+
+.secondary {
+    --wb-c-activity-button--box-bg-disabled: var(--wb-semanticColor-chonky-disabled-background-secondary);
+    --wb-c-activity-button--box-fg-disabled: var(--wb-semanticColor-chonky-disabled-foreground-secondary);
+    --wb-c-activity-button--box-border-disabled: var(--wb-semanticColor-chonky-disabled-border-secondary);
+    --wb-c-activity-button--box-shadow-color-disabled: var(--wb-semanticColor-chonky-disabled-shadow-secondary);
+}
+
+.tertiary {
+    --wb-c-activity-button--box-bg-disabled: var(--wb-semanticColor-chonky-disabled-background-tertiary);
+    --wb-c-activity-button--box-fg-disabled: var(--wb-semanticColor-chonky-disabled-foreground-tertiary);
+    --wb-c-activity-button--box-border-disabled: var(--wb-semanticColor-chonky-disabled-border-tertiary);
+    --wb-c-activity-button--box-shadow-color-disabled: var(--wb-semanticColor-chonky-disabled-shadow-tertiary);
+}
+
+/**
+ * Colour matrix: `actionType × kind`. Each cell sets the bg / fg / border /
+ * shadow tokens for the rest, hover and press states.
+ */
+.progressive.primary {
+    --wb-c-activity-button--box-bg-rest: var(--wb-semanticColor-chonky-progressive-background-primary-rest);
+    --wb-c-activity-button--box-fg-rest: var(--wb-semanticColor-chonky-progressive-foreground-primary-rest);
+    --wb-c-activity-button--box-border-rest: var(--wb-semanticColor-chonky-progressive-border-primary-rest);
+    --wb-c-activity-button--box-shadow-color-rest: var(--wb-semanticColor-chonky-progressive-shadow-primary-rest);
+    --wb-c-activity-button--box-bg-hover: var(--wb-semanticColor-chonky-progressive-background-primary-hover);
+    --wb-c-activity-button--box-fg-hover: var(--wb-semanticColor-chonky-progressive-foreground-primary-hover);
+    --wb-c-activity-button--box-border-hover: var(--wb-semanticColor-chonky-progressive-border-primary-hover);
+    --wb-c-activity-button--box-shadow-color-hover: var(--wb-semanticColor-chonky-progressive-shadow-primary-hover);
+    --wb-c-activity-button--box-bg-press: var(--wb-semanticColor-chonky-progressive-background-primary-press);
+    --wb-c-activity-button--box-fg-press: var(--wb-semanticColor-chonky-progressive-foreground-primary-press);
+    --wb-c-activity-button--box-border-press: var(--wb-semanticColor-chonky-progressive-border-primary-press);
+    --wb-c-activity-button--box-shadow-color-press: var(--wb-semanticColor-chonky-progressive-shadow-primary-press);
+}
+
+.progressive.secondary {
+    --wb-c-activity-button--box-bg-rest: var(--wb-semanticColor-chonky-progressive-background-secondary-rest);
+    --wb-c-activity-button--box-fg-rest: var(--wb-semanticColor-chonky-progressive-foreground-secondary-rest);
+    --wb-c-activity-button--box-border-rest: var(--wb-semanticColor-chonky-progressive-border-secondary-rest);
+    --wb-c-activity-button--box-shadow-color-rest: var(--wb-semanticColor-chonky-progressive-shadow-secondary-rest);
+    --wb-c-activity-button--box-bg-hover: var(--wb-semanticColor-chonky-progressive-background-secondary-hover);
+    --wb-c-activity-button--box-fg-hover: var(--wb-semanticColor-chonky-progressive-foreground-secondary-hover);
+    --wb-c-activity-button--box-border-hover: var(--wb-semanticColor-chonky-progressive-border-secondary-hover);
+    --wb-c-activity-button--box-shadow-color-hover: var(--wb-semanticColor-chonky-progressive-shadow-secondary-hover);
+    --wb-c-activity-button--box-bg-press: var(--wb-semanticColor-chonky-progressive-background-secondary-press);
+    --wb-c-activity-button--box-fg-press: var(--wb-semanticColor-chonky-progressive-foreground-secondary-press);
+    --wb-c-activity-button--box-border-press: var(--wb-semanticColor-chonky-progressive-border-secondary-press);
+    --wb-c-activity-button--box-shadow-color-press: var(--wb-semanticColor-chonky-progressive-shadow-secondary-press);
+}
+
+.progressive.tertiary {
+    --wb-c-activity-button--box-bg-rest: var(--wb-semanticColor-chonky-progressive-background-tertiary-rest);
+    --wb-c-activity-button--box-fg-rest: var(--wb-semanticColor-chonky-progressive-foreground-tertiary-rest);
+    --wb-c-activity-button--box-border-rest: var(--wb-semanticColor-chonky-progressive-border-tertiary-rest);
+    --wb-c-activity-button--box-shadow-color-rest: var(--wb-semanticColor-chonky-progressive-shadow-tertiary-rest);
+    --wb-c-activity-button--box-bg-hover: var(--wb-semanticColor-chonky-progressive-background-tertiary-hover);
+    --wb-c-activity-button--box-fg-hover: var(--wb-semanticColor-chonky-progressive-foreground-tertiary-hover);
+    --wb-c-activity-button--box-border-hover: var(--wb-semanticColor-chonky-progressive-border-tertiary-hover);
+    --wb-c-activity-button--box-shadow-color-hover: var(--wb-semanticColor-chonky-progressive-shadow-tertiary-hover);
+    --wb-c-activity-button--box-bg-press: var(--wb-semanticColor-chonky-progressive-background-tertiary-press);
+    --wb-c-activity-button--box-fg-press: var(--wb-semanticColor-chonky-progressive-foreground-tertiary-press);
+    --wb-c-activity-button--box-border-press: var(--wb-semanticColor-chonky-progressive-border-tertiary-press);
+    --wb-c-activity-button--box-shadow-color-press: var(--wb-semanticColor-chonky-progressive-shadow-tertiary-press);
+}
+
+.neutral.primary {
+    --wb-c-activity-button--box-bg-rest: var(--wb-semanticColor-chonky-neutral-background-primary-rest);
+    --wb-c-activity-button--box-fg-rest: var(--wb-semanticColor-chonky-neutral-foreground-primary-rest);
+    --wb-c-activity-button--box-border-rest: var(--wb-semanticColor-chonky-neutral-border-primary-rest);
+    --wb-c-activity-button--box-shadow-color-rest: var(--wb-semanticColor-chonky-neutral-shadow-primary-rest);
+    --wb-c-activity-button--box-bg-hover: var(--wb-semanticColor-chonky-neutral-background-primary-hover);
+    --wb-c-activity-button--box-fg-hover: var(--wb-semanticColor-chonky-neutral-foreground-primary-hover);
+    --wb-c-activity-button--box-border-hover: var(--wb-semanticColor-chonky-neutral-border-primary-hover);
+    --wb-c-activity-button--box-shadow-color-hover: var(--wb-semanticColor-chonky-neutral-shadow-primary-hover);
+    --wb-c-activity-button--box-bg-press: var(--wb-semanticColor-chonky-neutral-background-primary-press);
+    --wb-c-activity-button--box-fg-press: var(--wb-semanticColor-chonky-neutral-foreground-primary-press);
+    --wb-c-activity-button--box-border-press: var(--wb-semanticColor-chonky-neutral-border-primary-press);
+    --wb-c-activity-button--box-shadow-color-press: var(--wb-semanticColor-chonky-neutral-shadow-primary-press);
+}
+
+.neutral.secondary {
+    --wb-c-activity-button--box-bg-rest: var(--wb-semanticColor-chonky-neutral-background-secondary-rest);
+    --wb-c-activity-button--box-fg-rest: var(--wb-semanticColor-chonky-neutral-foreground-secondary-rest);
+    --wb-c-activity-button--box-border-rest: var(--wb-semanticColor-chonky-neutral-border-secondary-rest);
+    --wb-c-activity-button--box-shadow-color-rest: var(--wb-semanticColor-chonky-neutral-shadow-secondary-rest);
+    --wb-c-activity-button--box-bg-hover: var(--wb-semanticColor-chonky-neutral-background-secondary-hover);
+    --wb-c-activity-button--box-fg-hover: var(--wb-semanticColor-chonky-neutral-foreground-secondary-hover);
+    --wb-c-activity-button--box-border-hover: var(--wb-semanticColor-chonky-neutral-border-secondary-hover);
+    --wb-c-activity-button--box-shadow-color-hover: var(--wb-semanticColor-chonky-neutral-shadow-secondary-hover);
+    --wb-c-activity-button--box-bg-press: var(--wb-semanticColor-chonky-neutral-background-secondary-press);
+    --wb-c-activity-button--box-fg-press: var(--wb-semanticColor-chonky-neutral-foreground-secondary-press);
+    --wb-c-activity-button--box-border-press: var(--wb-semanticColor-chonky-neutral-border-secondary-press);
+    --wb-c-activity-button--box-shadow-color-press: var(--wb-semanticColor-chonky-neutral-shadow-secondary-press);
+}
+
+.neutral.tertiary {
+    --wb-c-activity-button--box-bg-rest: var(--wb-semanticColor-chonky-neutral-background-tertiary-rest);
+    --wb-c-activity-button--box-fg-rest: var(--wb-semanticColor-chonky-neutral-foreground-tertiary-rest);
+    --wb-c-activity-button--box-border-rest: var(--wb-semanticColor-chonky-neutral-border-tertiary-rest);
+    --wb-c-activity-button--box-shadow-color-rest: var(--wb-semanticColor-chonky-neutral-shadow-tertiary-rest);
+    --wb-c-activity-button--box-bg-hover: var(--wb-semanticColor-chonky-neutral-background-tertiary-hover);
+    --wb-c-activity-button--box-fg-hover: var(--wb-semanticColor-chonky-neutral-foreground-tertiary-hover);
+    --wb-c-activity-button--box-border-hover: var(--wb-semanticColor-chonky-neutral-border-tertiary-hover);
+    --wb-c-activity-button--box-shadow-color-hover: var(--wb-semanticColor-chonky-neutral-shadow-tertiary-hover);
+    --wb-c-activity-button--box-bg-press: var(--wb-semanticColor-chonky-neutral-background-tertiary-press);
+    --wb-c-activity-button--box-fg-press: var(--wb-semanticColor-chonky-neutral-foreground-tertiary-press);
+    --wb-c-activity-button--box-border-press: var(--wb-semanticColor-chonky-neutral-border-tertiary-press);
+    --wb-c-activity-button--box-shadow-color-press: var(--wb-semanticColor-chonky-neutral-shadow-tertiary-press);
+}
+
+/**
+ * The "chonky" box. Reads the component tokens the root assigns — custom
+ * properties inherit, so the box picks up whichever variant classes the root
+ * carries.
+ */
+.box {
+    /* Layout. `gap` is the spacing between the icon(s) and the label. */
+    flex-direction: row;
+    gap: var(--wb-sizing-size_080);
+    border-radius: var(--wb-border-radius-radius_120);
+    margin-block-end: var(--wb-c-activity-button--box-shadow-y-rest);
+    max-inline-size: 100%;
+    padding-block: var(--wb-sizing-size_140);
+    padding-inline: var(--wb-sizing-size_480);
+
+    /* Theming */
+    background: var(--wb-c-activity-button--box-bg-rest);
+    border: var(--wb-c-activity-button--box-border-width) solid
+        var(--wb-c-activity-button--box-border-rest);
+    color: var(--wb-c-activity-button--box-fg-rest);
+
+    /* Gives the button a "chonky" look and feel. */
+    box-shadow: 0 var(--wb-c-activity-button--box-shadow-y-rest) 0 0
+        var(--wb-c-activity-button--box-shadow-color-rest);
+
+    /* Motion */
+    transition: all 0.12s ease-out;
+}
+
+@media not (hover: hover) {
+    .box {
+        transition: none;
+    }
+}
+
+/**
+ * Hover. Note this is deliberately *not* gated behind `@media (hover: hover)`
+ * — only the transition above is. The box lifts by the difference between the
+ * hover and rest shadow depths so its top edge stays put.
+ */
+.button:hover .box {
+    background: var(--wb-c-activity-button--box-bg-hover);
+    border: var(--wb-c-activity-button--box-border-width) solid
+        var(--wb-c-activity-button--box-border-hover);
+    box-shadow: 0 var(--wb-c-activity-button--box-shadow-y-hover) 0 0
+        var(--wb-c-activity-button--box-shadow-color-hover);
+    color: var(--wb-c-activity-button--box-fg-hover);
+    transform: translateY(
+        calc(
+            (
+                    var(--wb-c-activity-button--box-shadow-y-hover) -
+                        var(--wb-c-activity-button--box-shadow-y-rest)
+                ) * -1
+        )
+    );
+}
+
+/**
+ * Active / pressed. The `:active` pseudo-class covers pointer presses; the
+ * `.pressed` class covers programmatic (keyboard) presses tracked by
+ * `ClickableBehavior`. The box drops by the rest shadow depth so it looks
+ * pushed flat against the shadow.
+ */
+.button:active .box,
+.button.pressed .box {
+    background: var(--wb-c-activity-button--box-bg-press);
+    border: var(--wb-c-activity-button--box-border-width) solid
+        var(--wb-c-activity-button--box-border-press);
+    box-shadow: 0 var(--wb-c-activity-button--box-shadow-y-press) 0 0
+        var(--wb-c-activity-button--box-shadow-color-press);
+    color: var(--wb-c-activity-button--box-fg-press);
+    transform: translateY(var(--wb-c-activity-button--box-shadow-y-rest));
+}
+
+/**
+ * Disabled. Selected via `aria-disabled` so the element stays focusable.
+ * Declared after hover / active so it resets them; the `:hover` / `:active`
+ * variants below only exist to outrank those rules.
+ */
+.button[aria-disabled="true"] {
+    cursor: not-allowed;
+    color: var(--wb-semanticColor-core-foreground-disabled-default);
+    outline: none;
+    transform: none;
+}
+
+.button[aria-disabled="true"]:hover,
+.button[aria-disabled="true"]:active {
+    outline: none;
+    transform: none;
+}
+
+.button[aria-disabled="true"] .box,
+.button[aria-disabled="true"]:hover .box,
+.button[aria-disabled="true"]:active .box {
+    background: var(--wb-c-activity-button--box-bg-disabled);
+
+    /* `border-width` / `border-color` rather than the `border` shorthand so
+     * the `solid` style set on `.box` survives. */
+    border-width: var(--wb-c-activity-button--box-border-width);
+    border-color: var(--wb-c-activity-button--box-border-disabled);
+    box-shadow: 0 var(--wb-c-activity-button--box-shadow-y-rest) 0 0
+        var(--wb-c-activity-button--box-shadow-color-disabled);
+    color: var(--wb-c-activity-button--box-fg-disabled);
+    transform: none;
+}
+
+/**
+ * Focus. `:focus-visible` provides keyboard-only focus styling; the `.focused`
+ * class enables programmatic focus (set by `ClickableBehavior`).
+ *
+ * Declared last so the ring survives hover / press. The disabled variant is
+ * spelled out separately because `.button[aria-disabled="true"]:hover` above
+ * outranks the plain `.button:focus-visible` rule and would otherwise strip the
+ * outline off a focused-and-hovered disabled button.
+ */
+.button:focus-visible,
+.button.focused {
+    @apply --wb-focus-visible;
+}
+
+.button[aria-disabled="true"]:focus-visible {
+    @apply --wb-focus-visible;
+}
+
+/**
+ * Icon and label.
+ *
+ * Both are qualified with `.box` so they outrank the single-class rules that
+ * `PhosphorIcon` (`.medium`) and `BodyText` (`.mediumSemi`) ship in the same
+ * `@layer shared` — at equal specificity the winner would come down to the
+ * order the two packages' stylesheets happen to load in.
+ */
+.box .icon {
+    align-self: center;
+    inline-size: var(--wb-sizing-size_200);
+    block-size: var(--wb-sizing-size_200);
+}
+
+.box .label {
+    /* NOTE: This is intended by design to correctly align the text with the
+     * icon in the button. */
+    line-height: var(--wb-sizing-size_140);
+    padding-block: var(--wb-sizing-size_040) var(--wb-sizing-size_060);
+}

--- a/packages/wonder-blocks-button/src/components/activity-button.module.css
+++ b/packages/wonder-blocks-button/src/components/activity-button.module.css
@@ -1,12 +1,10 @@
 /**
- * ActivityButton styles (CSS Modules migration — WB-2328 / CSS Modules Phase 4).
+ * ActivityButton styles
  *
  * Component-token surface
  * -----------------------
  * Every value a variant axis can change is funnelled through a
- * `--wb-c-activity-button--*` custom property ("component token"), following
- * the convention `NodeIconButton` established with `--wb-c-node-icon-button--`
- * and `Button` with `--wb-c-button--`.
+ * `--wb-c-activity-button--*` custom property ("component token").
  *
  *   --wb-c-activity-button--box-border-width      structural (all variants)
  *   --wb-c-activity-button--box-shadow-y-rest
@@ -48,13 +46,6 @@
  * Collapsing them would mean interpolating token names, which only JS can do.
  * Disabled colours are keyed by `kind` alone, so they live on the kind classes.
  *
- * The token values themselves are *not* codegen'd per theme (unlike
- * `--wb-c-button-root-*`): every theme reuses the same structural values, so
- * they're written literally here, matching the note on the `theme` object the
- * Aphrodite version carried. Colour tokens still resolve against the per-theme
- * `[data-wb-theme]` blocks shipped in `@khanacademy/wonder-blocks-tokens`, so
- * theming (default / thunderblocks / syl-dark) keeps working unchanged.
- *
  * Specificity: the box state rules all sit at (0,3,0) — `.button` plus a
  * pseudo-class/attribute plus `.box` — so source order alone decides
  * precedence. They are declared hover → active → disabled → focus, which is
@@ -94,8 +85,6 @@
     block-size: auto;
     flex-direction: column;
     gap: var(--wb-sizing-size_020);
-
-    /* `align-self: flex-start` + `justify-self: center`. */
     place-self: flex-start center;
 }
 

--- a/packages/wonder-blocks-button/src/components/activity-button.tsx
+++ b/packages/wonder-blocks-button/src/components/activity-button.tsx
@@ -71,12 +71,7 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
             type={type}
         >
             <>
-                {/* NOTE: The descendant selectors for the hover and press
-                    states now live in `activity-button.module.css` and target
-                    the hashed `styles.box` class. The plain `chonky` className
-                    is kept as a consumer/test hook, it just no longer drives
-                    styling. */}
-                <View style={chonkyStyles} className="chonky">
+                <View style={chonkyStyles}>
                     {/* If startIcon is a string, we use the `PhosphorIcon` component to render it. Otherwise, we render the element directly */}
                     {startIcon &&
                         (typeof startIcon === "string" ? (

--- a/packages/wonder-blocks-button/src/components/activity-button.tsx
+++ b/packages/wonder-blocks-button/src/components/activity-button.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
-import {CSSProperties, StyleSheet} from "aphrodite";
 import {useInRouterContext} from "react-router-dom-v5-compat";
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {focusStyles} from "@khanacademy/wonder-blocks-styles";
-import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {
@@ -13,14 +10,10 @@ import {
     ClickableState,
     getClickableBehavior,
 } from "@khanacademy/wonder-blocks-clickable";
-import type {
-    ActivityButtonActionType,
-    ButtonKind,
-    ActivityButtonProps,
-    ButtonRef,
-} from "../util/button.types";
+import type {ActivityButtonProps, ButtonRef} from "../util/button.types";
 
 import {ButtonUnstyled} from "./button-unstyled";
+import styles from "./activity-button.module.css";
 
 type ButtonCoreProps = ActivityButtonProps & ChildrenProps & ClickableState;
 
@@ -46,23 +39,27 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
         ...restProps
     } = props;
 
-    const buttonStyles = _generateStyles(actionType, disabled, kind);
-
+    // One class per variant axis. Each of these only assigns the
+    // `--wb-c-activity-button--*` component tokens that its axis owns;
+    // `styles.button` / `styles.box` and the state rules in the module read
+    // those tokens. `disabled` is selected in CSS via the
+    // `[aria-disabled="true"]` attribute (set by `ButtonUnstyled`), which keeps
+    // the element focusable. Class-name strings are composed through the
+    // `style` prop — `processStyleList` routes them to `className`.
     const sharedStyles = [
-        buttonStyles.button,
-        disabled && buttonStyles.disabled,
-        !disabled && pressed && buttonStyles.pressed,
-        // Enables programmatic focus.
-        !disabled && !pressed && focused && buttonStyles.focused,
+        styles.button,
+        styles[actionType],
+        styles[kind],
+        // Enable the press / focus states for programmatic (keyboard)
+        // interaction tracked by `ClickableBehavior`.
+        !disabled && pressed && styles.pressed,
+        !disabled && !pressed && focused && styles.focused,
         stylesProp?.root,
     ];
 
-    const chonkyStyles = [
-        buttonStyles.chonky,
-        disabled && buttonStyles.chonkyDisabled,
-        !disabled && pressed && buttonStyles.chonkyPressed,
-        stylesProp?.box,
-    ];
+    // The box's own rest / hover / press / disabled styling is driven by the
+    // root's state selectors in the module, so this only needs the base class.
+    const chonkyStyles = [styles.box, stylesProp?.box];
 
     return (
         <ButtonUnstyled
@@ -74,7 +71,11 @@ const ActivityButtonCore: React.ForwardRefExoticComponent<
             type={type}
         >
             <>
-                {/* NOTE: Using a regular className to be able to use descendant selectors to account for the hover and press states */}
+                {/* NOTE: The descendant selectors for the hover and press
+                    states now live in `activity-button.module.css` and target
+                    the hashed `styles.box` class. The plain `chonky` className
+                    is kept as a consumer/test hook, it just no longer drives
+                    styling. */}
                 <View style={chonkyStyles} className="chonky">
                     {/* If startIcon is a string, we use the `PhosphorIcon` component to render it. Otherwise, we render the element directly */}
                     {startIcon &&
@@ -228,215 +229,3 @@ export const ActivityButton = React.forwardRef(function ActivityButton(
         </ClickableBehavior>
     );
 });
-
-// NOTE: Theme is defined in the file directly to avoid generating CSS variables
-// as we are reusing the following tokens in all themes.
-const theme = {
-    root: {
-        border: {
-            width: {
-                primary: {
-                    rest: border.width.thin,
-                    hover: border.width.thin,
-                    press: border.width.thin,
-                },
-                secondary: {
-                    rest: border.width.thin,
-                    hover: border.width.thin,
-                    press: border.width.thin,
-                },
-                tertiary: {
-                    rest: border.width.thin,
-                    hover: border.width.thin,
-                    press: border.width.thin,
-                },
-            },
-            radius: border.radius.radius_120,
-        },
-        layout: {
-            padding: {
-                block: sizing.size_140,
-                inline: sizing.size_480,
-            },
-        },
-        shadow: {
-            y: {
-                // NOTE: We use px units to prevent a bug in Safari where the
-                // shadow animation flickers when using rem units.
-                rest: "6px",
-                hover: "8px",
-                press: sizing.size_0,
-            },
-        },
-    },
-    label: {
-        color: {
-            progressive: semanticColor.core.foreground.instructive.default,
-            neutral: semanticColor.core.foreground.neutral.default,
-            disabled: semanticColor.core.foreground.disabled.default,
-        },
-        font: {
-            // NOTE: This is intended by design to correctly align the text
-            // with the icon in the button.
-            lineHeight: sizing.size_140,
-        },
-        layout: {
-            padding: {
-                blockStart: sizing.size_040,
-                blockEnd: sizing.size_060,
-            },
-            width: sizing.size_640,
-        },
-    },
-    icon: {
-        sizing: {
-            height: sizing.size_200,
-            width: sizing.size_200,
-        },
-    },
-};
-
-// Static styles for the button.
-const styles = {
-    icon: {
-        alignSelf: "center",
-        width: theme.icon.sizing.width,
-        height: theme.icon.sizing.height,
-    },
-    label: {
-        lineHeight: theme.label.font.lineHeight,
-        paddingBlockStart: theme.label.layout.padding.blockStart,
-        paddingBlockEnd: theme.label.layout.padding.blockEnd,
-    },
-};
-
-const stateStyles: Record<string, any> = {};
-
-// Dynamically generate styles for the button based on the different variants.
-const _generateStyles = (
-    actionType: ActivityButtonActionType = "progressive",
-    disabled: boolean,
-    kind: ButtonKind,
-) => {
-    const buttonType = `${actionType}-d_${disabled}-${kind}`;
-    if (stateStyles[buttonType]) {
-        return stateStyles[buttonType];
-    }
-
-    const borderWidthKind = theme.root.border.width[kind];
-    const themeVariant = semanticColor.chonky[actionType];
-    const disabledState = semanticColor.chonky.disabled;
-
-    const disabledStatesStyles = {
-        outline: "none",
-        transform: "none",
-    };
-    const chonkyDisabled = {
-        background: disabledState.background[kind],
-        borderWidth: borderWidthKind.rest,
-        borderColor: disabledState.border[kind],
-        color: disabledState.foreground[kind],
-        boxShadow: `0 ${theme.root.shadow.y.rest} 0 0 ${disabledState.shadow[kind]}`,
-        transform: "none",
-    };
-
-    const chonkyPressed = {
-        // theming
-        background: themeVariant.background[kind].press,
-        border: `${borderWidthKind.press} solid ${themeVariant.border[kind].press}`,
-        boxShadow: `0 ${theme.root.shadow.y.press} 0 0 ${themeVariant.shadow[kind].press}`,
-        color: themeVariant.foreground[kind].press,
-        // motion
-        transform: `translateY(${theme.root.shadow.y.rest})`,
-    };
-
-    const newStyles: Record<string, CSSProperties> = {
-        button: {
-            // theming
-            // Applying a transparent background to allow the chonky box to show
-            // through.
-            background: "transparent",
-            // Used for the focus ring.
-            borderRadius: theme.root.border.radius,
-            color: theme.label.color[actionType],
-            // layout
-            height: "auto",
-            flexDirection: "column",
-            gap: sizing.size_020,
-            alignSelf: "flex-start",
-            justifySelf: "center",
-            /**
-             * States
-             *
-             * Defined in the following order: hover, active, focus.
-             *
-             * This is important as we want to give more priority to the
-             * :focus-visible styles.
-             */
-            [":is(:hover) .chonky" as any]: {
-                background: themeVariant.background[kind].hover,
-                border: `${borderWidthKind.hover} solid ${themeVariant.border[kind].hover}`,
-                boxShadow: `0 ${theme.root.shadow.y.hover} 0 0 ${themeVariant.shadow[kind].hover}`,
-                color: themeVariant.foreground[kind].hover,
-                // motion
-                transform: `translateY(calc((${theme.root.shadow.y.hover} - ${theme.root.shadow.y.rest}) * -1))`,
-            },
-
-            [":is(:active) .chonky" as any]: chonkyPressed,
-
-            // :focus-visible -> Provide focus styles for keyboard users only.
-            ...focusStyles.focus,
-        },
-        // To receive programmatic focus.
-        focused: focusStyles.focus[":focus-visible"],
-        disabled: {
-            cursor: "not-allowed",
-            color: theme.label.color.disabled,
-            ...disabledStatesStyles,
-            // Reset hover and active styles on disabled buttons.
-            ":hover": disabledStatesStyles,
-            ":active": disabledStatesStyles,
-            ":focus-visible": {
-                transform: "none",
-            },
-            // Reset hover and active styles on the chonky element.
-            [":is(:hover) .chonky" as any]: chonkyDisabled,
-            [":is(:active) .chonky" as any]: chonkyDisabled,
-        },
-        // Enable keyboard support for press styles.
-        pressed: {
-            [".chonky" as any]: chonkyPressed,
-        },
-
-        chonky: {
-            // layout
-            // Spacing between the icon(s) and the label.
-            flexDirection: "row",
-            gap: sizing.size_080,
-            // Used for the chonky box.
-            borderRadius: theme.root.border.radius,
-            marginBlockEnd: theme.root.shadow.y.rest,
-            maxWidth: "100%",
-            paddingBlock: theme.root.layout.padding.block,
-            paddingInline: theme.root.layout.padding.inline,
-            // theming
-            background: themeVariant.background[kind].rest,
-            border: `${borderWidthKind.rest} solid ${themeVariant.border[kind].rest}`,
-            color: themeVariant.foreground[kind].rest,
-
-            // Gives the button a "chonky" look and feel.
-            boxShadow: `0 ${theme.root.shadow.y.rest} 0 0 ${themeVariant.shadow[kind].rest}`,
-            // motion
-            transition: "all 0.12s ease-out",
-
-            ["@media not (hover: hover)" as any]: {
-                transition: "none",
-            },
-        },
-        chonkyPressed,
-        chonkyDisabled,
-    } as const;
-
-    stateStyles[buttonType] = StyleSheet.create(newStyles);
-    return stateStyles[buttonType];
-};


### PR DESCRIPTION
Migrate `ActivityButton` from Aphrodite to CSS Modules, the piece that was
deliberately deferred when `Button` moved over (it had its own
`_generateStyles`). The public API is unchanged — same props, DOM structure and
`styles.root` / `styles.box` / `styles.startIcon` / `styles.endIcon` /
`styles.label` overrides — so this is an internal styling refactor.

The new `activity-button.module.css` follows the component-token surface
`Button` settled on: every value a variant axis can change is a
`--wb-c-activity-button--*` custom property, variant classes only *assign*
tokens, and the base + state rules only *read* them. The `actionType × kind`
colour matrix is six compound rules (`.progressive.primary`, …) because the
semantic tokens are keyed by both axes; disabled colours are keyed by `kind`
alone so they live on the kind classes. Structural values (border width, the
6px/8px/0 shadow depths) are written literally rather than codegen'd per theme,
matching the note the Aphrodite `theme` object carried — every theme reused
them.

The "chonky" box no longer gets its state styling from classes toggled in JS.
`chonkyPressed` / `chonkyDisabled` are gone; the box is styled by descendant
selectors from the root (`.button:hover .box`, `.button.pressed .box`,
`.button[aria-disabled="true"] .box`), all at the same specificity so source
order alone decides precedence: hover -> active -> disabled -> focus. The
plain `chonky` className stays on the element as a consumer/test hook, it just
no longer drives styling — same treatment `data-kind` got in `Button`.

The icon and label rules are qualified with `.box` on purpose. `PhosphorIcon`
(`.medium`) and `BodyText` (`.mediumSemi`) ship single-class rules in the same
`@layer shared`, and Aphrodite's `!important` used to settle that contest for
us; the compound selector makes the outcome depend on specificity instead of
which package's stylesheet happens to load first.

One intentional behaviour change: a disabled button that is both focused and
hovered now keeps the full focus ring. Previously the disabled `:hover` reset
was emitted after the `:focus-visible` rule at equal specificity and stripped
the outline, leaving only the inner box-shadow. That was an artifact of
Aphrodite's rule ordering, and `Button` already made the same call
(68ea60e34).

Verified: `pnpm jest packages/wonder-blocks-button` (all 5 suites), typecheck,
eslint, stylelint, prettier, and a full rollup build all pass — the build emits
the ActivityButton rules into the package's `dist/index.css` with `@apply
--wb-focus-visible` expanded and everything wrapped in `@layer shared`. Visual
parity still needs a Chromatic diff review on this PR.

Issue: WB-2328

## Test plan:

Automated checks are green and cover behavior/structure/aria:
- `pnpm jest packages/wonder-blocks-button` — all 5 suites pass
- `pnpm typecheck`, `eslint`, `stylelint` — clean
- `pnpm rollup -c ./build-settings/rollup.config.mjs` — emits the 28
  `wb-activity-button-*` selectors into `packages/wonder-blocks-button/dist/index.css`

Manual (visual — not covered by the above):
1. Review the Chromatic diff on this PR. The only expected diff is the disabled
   + focus + hover cell of the ActivityButton StateSheet (see above); anything
   else must be investigated.
2. In Storybook, spot-check `ActivityButton` across `kind`
   (primary/secondary/tertiary) x `actionType` (progressive/neutral) and the
   hover / active / focus-visible / disabled states, in the default,
   thunderblocks and syl-dark themes. Confirm the box still lifts on hover and
   drops flat on press, and that the `WithCustomStyles` story's overrides
   (root/box/startIcon/endIcon/label) still take effect.
   http://localhost:6061/?path=/docs/packages-button-activitybutton--docs

## Review plan:

Please review these risky changes

1. 🚨 [`activity-button.module.css`](https://github.com/Khan/wonder-blocks/pull/3168#discussion_r3721886693)
2. ⚠️ [`activity-button.tsx`](https://github.com/Khan/wonder-blocks/pull/3168#discussion_r3721886876)
