### PR TITLE
Update SYL Dark action.secondary.neutral background tokens

### DIFF
--- a/.changeset/syl-dark-action-secondary-neutral-background.md
+++ b/.changeset/syl-dark-action-secondary-neutral-background.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update the SYL Dark `action.secondary.neutral` background tokens (default, hover, and press states) to use `core.background.base.default`

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color-syl-dark.ts
@@ -265,17 +265,17 @@ export const semanticColor = mergeTheme(thunderblocksSemanticColor, {
             neutral: {
                 default: {
                     border: core.border.neutral.default,
-                    background: core.transparent,
+                    background: core.background.base.default,
                     foreground: core.foreground.neutral.default,
                 },
                 hover: {
                     border: core.border.neutral.strong,
-                    background: core.transparent,
+                    background: core.background.base.default,
                     foreground: core.foreground.neutral.strong,
                 },
                 press: {
                     border: core.border.neutral.strong,
-                    background: core.transparent,
+                    background: core.background.base.default,
                     foreground: core.foreground.neutral.strong,
                 },
             },


### PR DESCRIPTION
## Summary
Updates the SYL Dark theme's `action.secondary.neutral` background tokens to use `core.background.base.default` instead of `core.transparent` across all interactive states.

This makes it so secondary neutral buttons have a fill. This is also consistent with the thunderblocks theme

Issue: WB-2419

## Test Plan
Confirm secondary neutral buttons in SYL dark have `core.background.base.default` as the background color now
<img width="1722" height="1004" alt="image" src="https://github.com/user-attachments/assets/d7dc270a-9774-45ce-97fc-3eb147cca1e9" />
