### PR TITLE
Add embedded content color tokens for learning experiences

### DIFF
--- a/.changeset/embedded-content-color-tokens.md
+++ b/.changeset/embedded-content-color-tokens.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": minor
+---
+
+Add `semanticColor.learning.embeddedContent.background.default` and `semanticColor.learning.embeddedContent.foreground.default` tokens. These use the Thunderblocks `black_100` and `gray_90` primitives respectively and remain consistent across all themes.

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -227,6 +227,13 @@ in the UI.
 
 <Canvas of={SemanticColorGroups.LearningShadow} layout="fullscreen" />
 
+#### Embedded content
+
+For content (e.g. interactive widgets, simulations) that is embedded within a
+learning experience.
+
+<Canvas of={SemanticColorGroups.LearningEmbeddedContent} layout="fullscreen" />
+
 
 ### Graphics
 

--- a/__docs__/foundations-color.mdx
+++ b/__docs__/foundations-color.mdx
@@ -229,7 +229,7 @@ in the UI.
 
 #### Embedded content
 
-For content (e.g. interactive widgets, simulations) that is embedded within a
+For content (e.g. image previews, video players) that is embedded within a
 learning experience.
 
 <Canvas of={SemanticColorGroups.LearningEmbeddedContent} layout="fullscreen" />

--- a/__docs__/wonder-blocks-tokens/semantic-color-groups.stories.tsx
+++ b/__docs__/wonder-blocks-tokens/semantic-color-groups.stories.tsx
@@ -219,6 +219,15 @@ export const LearningShadow = () => {
     );
 };
 
+export const LearningEmbeddedContent = () => {
+    return (
+        <ColorGroupStory
+            category={semanticColor.learning.embeddedContent}
+            group="learning.embeddedContent"
+        />
+    );
+};
+
 export const Khanmigo = () => {
     return (
         <ColorGroup

--- a/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
+++ b/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
@@ -400,6 +400,8 @@ import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 | \`semanticColor.learning.math.foreground.purpleD\` | \`--wb-semanticColor-learning-math-foreground-purpleD\` | \`#8351E8\` | \`#363498\` | \`#8DA2FF\` |
 | \`semanticColor.learning.math.foreground.pink\` | \`--wb-semanticColor-learning-math-foreground-pink\` | \`#B25071\` | \`#84275E\` | \`#F8A2D6\` |
 | \`semanticColor.learning.math.foreground.red\` | \`--wb-semanticColor-learning-math-foreground-red\` | \`#D92916\` | \`#BE2626\` | \`#FBB1B1\` |
+| \`semanticColor.learning.embeddedContent.background.default\` | \`--wb-semanticColor-learning-embeddedContent-background-default\` | \`#151521\` | \`#151521\` | \`#151521\` |
+| \`semanticColor.learning.embeddedContent.foreground.default\` | \`--wb-semanticColor-learning-embeddedContent-foreground-default\` | \`#F6F6F6\` | \`#F6F6F6\` | \`#F6F6F6\` |
 | \`semanticColor.learning.background.gems.subtle\` | \`--wb-semanticColor-learning-background-gems-subtle\` | \`#FCEEF7\` | \`#FCEEF7\` | \`#84275E\` |
 | \`semanticColor.learning.background.gems.default\` | \`--wb-semanticColor-learning-background-gems-default\` | \`#FFE3F4\` | \`#FFE3F4\` | \`#33182E\` |
 | \`semanticColor.learning.background.gems.strong\` | \`--wb-semanticColor-learning-background-gems-strong\` | \`#84275E\` | \`#84275E\` | \`#BB3183\` |

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -379,11 +379,6 @@ export const semanticColor = {
                 red: "#D92916",
             },
         },
-        /**
-         * These colors are used for embedded content (e.g. interactive
-         * widgets, simulations) that is rendered within a learning
-         * experience. They remain consistent across all themes.
-         */
         embeddedContent: {
             background: {
                 default: thunderBlocksColor.black_100,

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -379,6 +379,19 @@ export const semanticColor = {
                 red: "#D92916",
             },
         },
+        /**
+         * These colors are used for embedded content (e.g. interactive
+         * widgets, simulations) that is rendered within a learning
+         * experience. They remain consistent across all themes.
+         */
+        embeddedContent: {
+            background: {
+                default: thunderBlocksColor.black_100,
+            },
+            foreground: {
+                default: thunderBlocksColor.gray_90,
+            },
+        },
         background: {
             gems: {
                 subtle: thunderBlocksColor.magenta_90,


### PR DESCRIPTION
## Summary
Add new semantic color tokens for embedded content (video player bars, image previews). These tokens provide consistent styling across all themes.

Issue: FEI-2421

## Test Plan

Confirm tokens in code line up with the tokens in design 

<img width="2262" height="1748" alt="image" src="https://github.com/user-attachments/assets/c1b21ca8-2e40-444a-96a1-2769f38ce273" />

Confirm new docs for it: `/?path=/docs/foundations-using-color--docs#embedded-content`