### PR TITLE
Allow more aria attrs on combobox; consume style

### DIFF
--- a/.changeset/gentle-shoes-arrive.md
+++ b/.changeset/gentle-shoes-arrive.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": minor
+---
+
+Allow more aria attributes on combobox & consume "style" prop that was ignored

--- a/__docs__/wonder-blocks-dropdown/combobox.argtypes.ts
+++ b/__docs__/wonder-blocks-dropdown/combobox.argtypes.ts
@@ -1,6 +1,9 @@
 import {ArgTypes} from "@storybook/react-vite";
+import AriaArgTypes from "../wonder-blocks-core/aria.argtypes";
 
 const argTypes: ArgTypes = {
+    ...AriaArgTypes,
+
     autoComplete: {
         options: ["none", "list"],
         control: {type: "select"},

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/combobox.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/combobox.test.tsx
@@ -1,6 +1,7 @@
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
 import {render, screen, waitFor} from "@testing-library/react";
 import * as React from "react";
+import {StyleSheet} from "aphrodite";
 import magnifyingGlassIcon from "@phosphor-icons/core/regular/magnifying-glass.svg";
 
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
@@ -455,6 +456,107 @@ describe("Combobox", () => {
             expect(screen.getByRole("combobox")).toHaveAttribute(
                 "aria-invalid",
                 "false",
+            );
+        });
+    });
+
+    describe("aria attributes", () => {
+        it("should use the aria-label as the accessible name", () => {
+            // Arrange
+
+            // Act
+            doRender(
+                <Combobox
+                    selectionType="single"
+                    value=""
+                    aria-label="Choose an option"
+                >
+                    <OptionItem label="option 1" value="option1" />
+                    <OptionItem label="option 2" value="option2" />
+                    <OptionItem label="option 3" value="option3" />
+                </Combobox>,
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("combobox", {name: "Choose an option"}),
+            ).toBeInTheDocument();
+        });
+
+        it.each([
+            ["aria-describedby", "some-hint-id"],
+            ["aria-labelledby", "some-label-id"],
+            ["aria-details", "some-details-id"],
+            ["aria-errormessage", "some-error-id"],
+            ["aria-required", "true"],
+        ])("should pass %s to the input element", (attribute, value) => {
+            // Arrange
+
+            // Act
+            doRender(
+                <Combobox
+                    selectionType="single"
+                    value=""
+                    {...{[attribute]: value}}
+                >
+                    <OptionItem label="option 1" value="option1" />
+                    <OptionItem label="option 2" value="option2" />
+                    <OptionItem label="option 3" value="option3" />
+                </Combobox>,
+            );
+
+            // Assert
+            expect(screen.getByRole("combobox")).toHaveAttribute(
+                attribute,
+                value,
+            );
+        });
+
+        it("should keep the internal aria-controls when a consumer passes another aria attribute", () => {
+            // Arrange
+
+            // Act
+            doRender(
+                <Combobox
+                    selectionType="single"
+                    value=""
+                    opened={true}
+                    aria-describedby="some-hint-id"
+                >
+                    <OptionItem label="option 1" value="option1" />
+                    <OptionItem label="option 2" value="option2" />
+                    <OptionItem label="option 3" value="option3" />
+                </Combobox>,
+            );
+
+            // Assert
+            expect(screen.getByRole("combobox")).toHaveAttribute(
+                "aria-controls",
+            );
+        });
+    });
+
+    describe("style", () => {
+        // NOTE: This is a regression test for a prop that was declared but
+        // silently dropped, not an assertion about visual appearance.
+        it("should apply the style prop to the combobox input", () => {
+            // Arrange
+            const styles = StyleSheet.create({
+                custom: {minInlineSize: 250},
+            });
+
+            // Act
+            doRender(
+                <Combobox selectionType="single" value="" style={styles.custom}>
+                    <OptionItem label="option 1" value="option1" />
+                    <OptionItem label="option 2" value="option2" />
+                    <OptionItem label="option 3" value="option3" />
+                </Combobox>,
+            );
+
+            // Assert
+            expect(screen.getByRole("combobox")).toHaveStyle(
+                "min-inline-size: 250px",
             );
         });
     });

--- a/packages/wonder-blocks-dropdown/src/components/combobox.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/combobox.tsx
@@ -4,7 +4,11 @@ import * as React from "react";
 import caretDownIcon from "@phosphor-icons/core/regular/caret-down.svg";
 import xIcon from "@phosphor-icons/core/regular/x.svg";
 
-import {StyleType, View} from "@khanacademy/wonder-blocks-core";
+import {
+    type AriaAttributes,
+    type StyleType,
+    View,
+} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
@@ -131,11 +135,6 @@ type Props = {
     startIcon?: React.ReactElement<
         React.ComponentProps<typeof PhosphorIcon>
     > | null;
-
-    /**
-     * An optional aria-label to display on the combobox.
-     */
-    "aria-label"?: string;
 };
 
 /**
@@ -165,8 +164,10 @@ export default function Combobox({
     startIcon,
     testId,
     value = "",
-    "aria-label": ariaLabel,
-}: Props) {
+    loading,
+    style,
+    ...ariaAttrs
+}: Props & AriaAttributes) {
     // eslint-disable-next-line import/no-deprecated
     const generatedUniqueId = useId();
     const uniqueId = id ?? generatedUniqueId;
@@ -586,10 +587,9 @@ export default function Combobox({
                 {maybeRenderStartIcon()}
 
                 <TextField
-                    aria-label={ariaLabel}
                     id={textFieldId}
                     testId={testId}
-                    style={styles.combobox}
+                    style={[styles.combobox, style]}
                     value={inputValue}
                     onChange={handleTextFieldChange}
                     disabled={disabled}
@@ -613,6 +613,7 @@ export default function Combobox({
                     // the combobox is already providing suggestions.
                     autoComplete="off"
                     role="combobox"
+                    {...ariaAttrs}
                 />
 
                 {inputValue && !disabled && (


### PR DESCRIPTION
## Problem
I tried to use the combobox like this, and realized that while React allowed me to pass these attributes, they did nothing:

```
...
const id = useId()

return (
    <LabeledField
        id={id}
        field={
            <Combobox
                aria-labelledby={${id}-label}
                aria-describedby={caption ? ${id}-description : undefined}
                selectionType="multiple"
                value={values}
                onChange={handleChange}
            >
                {options.map((option) => (
                    <OptionItem
                        key={option.id}
                        label={option.label}
                        value={option.value}
                    />
                ))}
            </Combobox>
        }
        label={title}
        description={caption}
    />
);
};
```

Then I realized that unlike many of our WB components, the combobox didn't take in all aria-props and pass them through to the underlying component. It specifically only accepted aria-label. This felt fishy to me and also made it incompatible with `LabeledField` features.

## Solution
I am replacing that prop with the AriaAttributes interface so that any aria override will be respected.

Additionally, I noticed that two other props, `loading` and `style`, were completely unused. While `loading` has a comment indicating it's a WIP, `style` had a comment that lied! So I made the comment true by adding it to the combobox text input.

Please let me know if the exclusions were on purpose! I know the combobox has some sensitive aria machinery, but people won't add those attributes unless they know what they are doing, and this allows us to fully take advantage of `LabeledField`.