### PR TITLE
Remove font.body.lineHeight.large token

### DIFF
--- a/.changeset/delete-body-lineheight-large.md
+++ b/.changeset/delete-body-lineheight-large.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": major
+---
+
+Remove the `font.body.lineHeight.large` token. This token was originally added to provide backwards compatibility with the default theme while building the ThunderBlocks theme. Now that typography uses the new `Heading` and `BodyText` components (which reference the correct tokens), this token is no longer needed.

--- a/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
+++ b/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
@@ -195,7 +195,6 @@ import {font} from "@khanacademy/wonder-blocks-tokens";
 | \`font.body.lineHeight.xsmall\` | \`--wb-font-body-lineHeight-xsmall\` | \`1.6rem\` | \`var(--wb-sizing-size_160)\` | \`var(--wb-sizing-size_160)\` |
 | \`font.body.lineHeight.small\` | \`--wb-font-body-lineHeight-small\` | \`1.8rem\` | \`var(--wb-sizing-size_180)\` | \`var(--wb-sizing-size_180)\` |
 | \`font.body.lineHeight.medium\` | \`--wb-font-body-lineHeight-medium\` | \`2rem\` | \`var(--wb-sizing-size_240)\` | \`var(--wb-sizing-size_240)\` |
-| \`font.body.lineHeight.large\` | \`--wb-font-body-lineHeight-large\` | \`2.2rem\` | \`2.2rem\` | \`2.2rem\` |
 | \`font.heading.size.small\` | \`--wb-font-heading-size-small\` | \`1.2rem\` | \`var(--wb-sizing-size_160)\` | \`var(--wb-sizing-size_160)\` |
 | \`font.heading.size.medium\` | \`--wb-font-heading-size-medium\` | \`2rem\` | \`var(--wb-sizing-size_180)\` | \`var(--wb-sizing-size_180)\` |
 | \`font.heading.size.large\` | \`--wb-font-heading-size-large\` | \`2.4rem\` | \`var(--wb-sizing-size_200)\` | \`var(--wb-sizing-size_200)\` |

--- a/packages/wonder-blocks-tokens/src/theme/primitive/font.ts
+++ b/packages/wonder-blocks-tokens/src/theme/primitive/font.ts
@@ -38,7 +38,6 @@ export const font = {
             xsmall: sizing.size_160,
             small: sizing.size_180,
             medium: sizing.size_200,
-            large: sizing.size_220,
         },
     },
     heading: {


### PR DESCRIPTION
## Summary

Removes the `font.body.lineHeight.large` token from `@khanacademy/wonder-blocks-tokens`.

This token was originally added to provide backwards compatibility with the default theme while building the ThunderBlocks theme. Now that typography uses the new `Heading` and `BodyText` components — which reference the correct tokens — this token is no longer needed. It has no functional usages anywhere in Wonder Blocks.

## Changes

- Removed `large: sizing.size_220` from `body.lineHeight` in `packages/wonder-blocks-tokens/src/theme/primitive/font.ts` (the unrelated `heading.lineHeight.large` is untouched).
- Regenerated the token-docs snapshot (`generate-token-docs.test.ts.snap`) to drop the now-removed row.
- Added a **major** changeset — removing a public token is a breaking change.

## ⚠️ Cross-repo coordination

This is a breaking change. Based on the Slack discussion:

- **`perseus`**: does not use this token — no action needed.
- **`webapp`/`frontend`**: uses it **once** (in `devadmin`). That usage must be updated to the closest match — `font.body.lineHeight.medium` — in a separate PR in that repo. The `frontend` fix should land **before or together with** this change so its build doesn't break when it picks up the new tokens version.

## Testing

- Tokens package tests pass.
- Full `typecheck` is clean (no consumer breakage inside Wonder Blocks).

## Context

Slack thread: https://khanacademy.slack.com/archives/C8Z9DSKC7/p1786550546633419?thread_ts=1786548443.300549&cid=C8Z9DSKC7

---
_Generated by [Claude Code](https://claude.ai/code/session_019c3ZnWfCeaJrqbNZx1LFjL)_