### PR TITLE
[Modal] Update default animations in DrawerLauncher

### DIFF
--- a/.changeset/quiet-drawers-glide.md
+++ b/.changeset/quiet-drawers-glide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-modal": minor
+---
+
+DrawerLauncher: update the default animation timing, easing, and slide distance, and add an `easing` prop and a `styles.backdrop` key

--- a/__docs__/wonder-blocks-modal/drawer-launcher.argtypes.ts
+++ b/__docs__/wonder-blocks-modal/drawer-launcher.argtypes.ts
@@ -27,7 +27,7 @@ export default {
             type: {summary: "{container?: StyleType; backdrop?: StyleType}"},
         },
         description:
-            "Optional styles for the launcher's container and its backdrop overlay. `backdrop` is applied last, so it overrides the backdrop's own styles, including its opacity animation.",
+            "Optional styles for the launcher's container and its backdrop overlay. `backdrop` is applied last, so it overrides the backdrop's own styles, including its opacity animation. Use `timingDuration` rather than setting `animationDuration` there, which desyncs the backdrop from the panel; `animationName: \"none\"` removes the fade in both directions.",
     },
 
     timingDuration: {

--- a/__docs__/wonder-blocks-modal/drawer-launcher.argtypes.ts
+++ b/__docs__/wonder-blocks-modal/drawer-launcher.argtypes.ts
@@ -24,19 +24,33 @@ export default {
     styles: {
         control: {type: undefined},
         table: {
-            type: {summary: "{container?: StyleType}"},
+            type: {summary: "{container?: StyleType; backdrop?: StyleType}"},
         },
-        description: "Optional styles for the DrawerLauncher container",
+        description:
+            "Optional styles for the launcher's container and its backdrop overlay. `backdrop` is applied last, so it overrides the backdrop's own styles, including its opacity animation.",
     },
 
     timingDuration: {
         control: {type: "number"},
-        defaultValue: 400,
         table: {
-            defaultValue: {summary: "400"},
+            defaultValue: {summary: "300ms enter / 150ms exit"},
             type: {summary: "number"},
         },
-        description: "Duration in milliseconds for slide-in animation",
+        description:
+            "Duration in milliseconds for the slide animations, overriding both phases. Also coordinates focus timing.",
+    },
+
+    easing: {
+        control: {type: "object"},
+        table: {
+            defaultValue: {
+                summary:
+                    "cubic-bezier(0.05, 0.7, 0.1, 1) enter / cubic-bezier(0.3, 0, 0.8, 0.15) exit",
+            },
+            type: {summary: "{enter?: string; exit?: string}"},
+        },
+        description:
+            "Per-phase easing for the panel's slide. Either phase can be omitted to keep its default curve; the backdrop's fade stays linear.",
     },
 
     animated: {

--- a/__docs__/wonder-blocks-modal/drawer-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/drawer-launcher.stories.tsx
@@ -55,7 +55,7 @@ export default {
 It can align a dialog on the \`inlineStart\` (left),  \`inlineEnd\` (right), or \`blockEnd\` (bottom).
 
 - Slide animations can be turned off with the \`animated\` prop.
-- Timing of animations can be fine-tuned with the \`timingDuration\` prop, used on enter and exit animations. It is also used to coordinate timing of focus management on open and close.
+- The drawer slides in over 300ms easing out, and leaves over 150ms easing in. Override the durations with \`timingDuration\` and the curves with \`easing\` — see the \`WithCustomAnimation\` example.
 
 **IMPORTANT**: This component should only be used with \`DrawerDialog\`. Using it with other
 dialog components may result in incorrect animations, positioning, and styling.
@@ -161,13 +161,11 @@ export const InlineEndAligned: StoryComponentType = {
 /**
  *
  * An blockEnd-aligned drawer. Uses the `alignment` prop to slide in from the
- * bottom in all writing modes, and a `timingDuration` of 400 milliseconds to
- * allow more time for animating-in vertically.
+ * bottom in all writing modes.
  */
 export const BlockEndAligned: StoryComponentType = {
     args: {
         alignment: "blockEnd",
-        timingDuration: 400,
     },
     render: (args) => (
         <DrawerLauncher modal={DefaultModal} alignment={args.alignment}>
@@ -192,6 +190,79 @@ export const WithNoAnimation: StoryComponentType = {
             animated={false}
             alignment={args.alignment}
         >
+            {({openModal}) => (
+                <Button onClick={openModal}>Click me to open the modal</Button>
+            )}
+        </DrawerLauncher>
+    ),
+};
+
+/**
+ * The drawer slides in over 300ms easing out and leaves over 150ms easing in. The
+ * panel slides without fading; the backdrop fades on the same durations, so the
+ * two finish together.
+ *
+ * Two props tune this independently:
+ *
+ * - `timingDuration` overrides the duration of both phases. Since the same value
+ *   coordinates focus management, a longer duration also delays the drawer's
+ *   initial focus and the return of focus to the trigger.
+ * - `easing` overrides the curves per phase, and applies to the panel only — the
+ *   backdrop's fade stays linear.
+ *
+ * This example exaggerates both: it slows the drawer down, overshoots past the
+ * resting position on the way in, and accelerates away on the way out. Set
+ * `animated` to false to skip the animation for reduced-motion preferences.
+ */
+export const WithCustomAnimation: StoryComponentType = {
+    args: {
+        alignment: "inlineEnd",
+        timingDuration: 700,
+        easing: {
+            enter: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+            exit: "cubic-bezier(0.5, 0, 0.75, 0)",
+        },
+    },
+    render: (args) => (
+        <DrawerLauncher {...args} modal={DefaultModal}>
+            {({openModal}) => (
+                <Button onClick={openModal}>Click me to open the modal</Button>
+            )}
+        </DrawerLauncher>
+    ),
+};
+
+/**
+ * `styles.backdrop` restyles the backdrop — the fixed overlay between the page and
+ * the drawer — and is applied after the backdrop's own styles, so it wins over any
+ * of them. It is also the only way to reach the backdrop's animation, whose sole
+ * property is opacity.
+ *
+ * This example overrides `animationTimingFunction` with a sharply ease-in curve,
+ * so the overlay holds light and darkens late instead of dimming evenly. It uses
+ * `timingDuration` to slow things enough to see the curve, which keeps the panel
+ * and backdrop in sync.
+ *
+ * Two animation properties to leave alone:
+ *
+ * - `animationDuration` desyncs the backdrop from the panel. Use `timingDuration`,
+ *   which drives both.
+ * - `animationName: "none"` drops the opacity animation in both directions, so the
+ *   overlay appears and disappears in a single frame each way, leaving the drawer
+ *   to slide away over solid grey that then snaps off.
+ */
+export const WithCustomBackdropStyles: StoryComponentType = {
+    args: {
+        alignment: "inlineEnd",
+        timingDuration: 600,
+        styles: {
+            backdrop: {
+                animationTimingFunction: "cubic-bezier(0.9, 0, 1, 1)",
+            },
+        },
+    },
+    render: (args) => (
+        <DrawerLauncher {...args} modal={DefaultModal}>
             {({openModal}) => (
                 <Button onClick={openModal}>Click me to open the modal</Button>
             )}

--- a/__docs__/wonder-blocks-modal/drawer-launcher.stories.tsx
+++ b/__docs__/wonder-blocks-modal/drawer-launcher.stories.tsx
@@ -7,7 +7,7 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {ActionMenu, ActionItem} from "@khanacademy/wonder-blocks-dropdown";
 import {RadioGroup, Choice} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
 import {DrawerDialog, DrawerLauncher} from "@khanacademy/wonder-blocks-modal";
@@ -198,29 +198,16 @@ export const WithNoAnimation: StoryComponentType = {
 };
 
 /**
- * The drawer slides in over 300ms easing out and leaves over 150ms easing in. The
- * panel slides without fading; the backdrop fades on the same durations, so the
- * two finish together.
- *
- * Two props tune this independently:
- *
- * - `timingDuration` overrides the duration of both phases. Since the same value
- *   coordinates focus management, a longer duration also delays the drawer's
- *   initial focus and the return of focus to the trigger.
- * - `easing` overrides the curves per phase, and applies to the panel only — the
- *   backdrop's fade stays linear.
- *
- * This example exaggerates both: it slows the drawer down, overshoots past the
- * resting position on the way in, and accelerates away on the way out. Set
- * `animated` to false to skip the animation for reduced-motion preferences.
+ * A drawer with a slower animation and custom curves. `timingDuration` sets the
+ * duration of both phases; `easing` sets the curve per phase, on the panel only.
  */
 export const WithCustomAnimation: StoryComponentType = {
     args: {
         alignment: "inlineEnd",
         timingDuration: 700,
         easing: {
-            enter: "cubic-bezier(0.34, 1.56, 0.64, 1)",
-            exit: "cubic-bezier(0.5, 0, 0.75, 0)",
+            enter: "ease-out",
+            exit: "ease-in",
         },
     },
     render: (args) => (
@@ -233,31 +220,16 @@ export const WithCustomAnimation: StoryComponentType = {
 };
 
 /**
- * `styles.backdrop` restyles the backdrop — the fixed overlay between the page and
- * the drawer — and is applied after the backdrop's own styles, so it wins over any
- * of them. It is also the only way to reach the backdrop's animation, whose sole
- * property is opacity.
- *
- * This example overrides `animationTimingFunction` with a sharply ease-in curve,
- * so the overlay holds light and darkens late instead of dimming evenly. It uses
- * `timingDuration` to slow things enough to see the curve, which keeps the panel
- * and backdrop in sync.
- *
- * Two animation properties to leave alone:
- *
- * - `animationDuration` desyncs the backdrop from the panel. Use `timingDuration`,
- *   which drives both.
- * - `animationName: "none"` drops the opacity animation in both directions, so the
- *   overlay appears and disappears in a single frame each way, leaving the drawer
- *   to slide away over solid grey that then snaps off.
+ * A drawer whose backdrop uses a solid color instead of the semi-transparent
+ * scrim, so it covers the page rather than dimming it. `styles.backdrop` is applied
+ * after the backdrop's own styles.
  */
 export const WithCustomBackdropStyles: StoryComponentType = {
     args: {
         alignment: "inlineEnd",
-        timingDuration: 600,
         styles: {
             backdrop: {
-                animationTimingFunction: "cubic-bezier(0.9, 0, 1, 1)",
+                background: semanticColor.core.background.neutral.default,
             },
         },
     },

--- a/packages/wonder-blocks-modal/src/components/__tests__/drawer-launcher.test.tsx
+++ b/packages/wonder-blocks-modal/src/components/__tests__/drawer-launcher.test.tsx
@@ -10,6 +10,7 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import DrawerLauncher from "../drawer-launcher";
 import FlexibleDialog from "../flexible-dialog";
+import {DRAWER_EXIT_DURATION_MS} from "../../util/drawer-animation";
 
 const exampleModal = (
     <FlexibleDialog
@@ -450,6 +451,41 @@ describe("DrawerLauncher", () => {
                     expect(onCloseMock).toHaveBeenCalled();
                 },
                 {timeout: 200}, // A bit longer than animation duration
+            );
+        });
+
+        test("Modal closes after the exit duration when timingDuration is not set", async () => {
+            // Arrange
+            const onCloseMock = jest.fn();
+            render(
+                <DrawerLauncher
+                    alignment="inlineEnd"
+                    animated={true}
+                    modal={
+                        <FlexibleDialog
+                            title="Animation test"
+                            content={<div data-testid="modal-content" />}
+                        />
+                    }
+                    opened={true}
+                    onClose={onCloseMock}
+                />,
+            );
+            const closeButton = await screen.findByRole("button", {
+                name: "Close modal",
+            });
+
+            // Act
+            await userEvent.click(closeButton);
+
+            // Assert
+            await waitFor(
+                () => {
+                    expect(onCloseMock).toHaveBeenCalled();
+                },
+                // Shorter than the enter duration, so this times out if the
+                // unmount timer uses the wrong phase.
+                {timeout: DRAWER_EXIT_DURATION_MS + 50},
             );
         });
 

--- a/packages/wonder-blocks-modal/src/components/drawer-backdrop.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-backdrop.tsx
@@ -63,7 +63,13 @@ const DrawerBackdrop = ({
         ? (timingDuration ?? DRAWER_ENTER_DURATION_MS)
         : 0;
 
-    const fadeStyles = getFadeStyles(isExiting ?? false, timingDuration);
+    const fadeStyle = isExiting ? styles.fadeOut : styles.fadeIn;
+    // Only computed when the consumer overrides the default duration, so the
+    // common case needs no per-render style object at all.
+    const fadeDurationOverride =
+        timingDuration != null
+            ? {animationDuration: `${timingDuration}ms`}
+            : undefined;
 
     /**
      * Returns an element specified by the user
@@ -178,7 +184,8 @@ const DrawerBackdrop = ({
             style={[
                 styles.drawerPositioner,
                 alignment && styles[alignment],
-                animated && fadeStyles.fade,
+                animated && fadeStyle,
+                animated && fadeDurationOverride,
                 // Last, so it overrides the styles above.
                 style,
             ].filter(Boolean)}
@@ -234,27 +241,23 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "flex-end",
     },
+    // The backdrop's fade. Shares the panel's durations by default, so the two
+    // finish together; `timingDuration` overrides that via a plain style object
+    // appended in the component.
+    fadeIn: {
+        // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
+        animationName: keyframes.fadeIn,
+        animationDuration: `${DRAWER_ENTER_DURATION_MS}ms`,
+        animationTimingFunction: "linear",
+        animationFillMode: "forwards",
+    },
+    fadeOut: {
+        // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
+        animationName: keyframes.fadeOut,
+        animationDuration: `${DRAWER_EXIT_DURATION_MS}ms`,
+        animationTimingFunction: "linear",
+        animationFillMode: "forwards",
+    },
 });
-
-/**
- * The backdrop's fade. It shares the panel's durations so the two finish
- * together, and stays linear.
- */
-const getFadeStyles = (
-    isExiting: boolean,
-    timingDuration: number | undefined,
-) =>
-    StyleSheet.create({
-        fade: {
-            // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
-            animationName: isExiting ? keyframes.fadeOut : keyframes.fadeIn,
-            animationDuration: `${
-                timingDuration ??
-                (isExiting ? DRAWER_EXIT_DURATION_MS : DRAWER_ENTER_DURATION_MS)
-            }ms`,
-            animationTimingFunction: "linear",
-            animationFillMode: "forwards",
-        },
-    });
 
 export default DrawerBackdrop;

--- a/packages/wonder-blocks-modal/src/components/drawer-backdrop.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-backdrop.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {View} from "@khanacademy/wonder-blocks-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import {StyleSheet} from "aphrodite";
 import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
@@ -8,6 +9,10 @@ import {ModalLauncherPortalAttributeName} from "../util/constants";
 import {findFocusableNodes} from "../util/find-focusable-nodes";
 import type {ModalElement} from "../util/types";
 import {useDrawerContext} from "../util/drawer-context";
+import {
+    DRAWER_ENTER_DURATION_MS,
+    DRAWER_EXIT_DURATION_MS,
+} from "../util/drawer-animation";
 
 type Props = {
     children: ModalElement;
@@ -22,6 +27,11 @@ type Props = {
      * Test ID used for e2e testing.
      */
     testId?: string;
+    /**
+     * Optional custom styles, applied last so they override the backdrop's own
+     * styles — including its opacity animation.
+     */
+    style?: StyleType;
 };
 
 /**
@@ -39,6 +49,7 @@ const DrawerBackdrop = ({
     testId,
     initialFocusId,
     onCloseModal,
+    style,
 }: Props) => {
     // Get drawer configuration from context
     const {alignment, animated, timingDuration, isExiting} = useDrawerContext();
@@ -47,7 +58,12 @@ const DrawerBackdrop = ({
 
     // If dialog opens with animation, handle focus management after specified duration.
     // If no animation, immediately handle focus management.
-    const computedTimingDuration = animated ? timingDuration : 0;
+    // An enter-side timer, so it tracks the enter duration.
+    const computedTimingDuration = animated
+        ? (timingDuration ?? DRAWER_ENTER_DURATION_MS)
+        : 0;
+
+    const fadeStyles = getFadeStyles(isExiting ?? false, timingDuration);
 
     /**
      * Returns an element specified by the user
@@ -162,7 +178,9 @@ const DrawerBackdrop = ({
             style={[
                 styles.drawerPositioner,
                 alignment && styles[alignment],
-                animated && (isExiting ? styles.fadeOut : styles.fadeIn),
+                animated && fadeStyles.fade,
+                // Last, so it overrides the styles above.
+                style,
             ].filter(Boolean)}
             onMouseDown={handleMouseDown}
             onMouseUp={handleMouseUp}
@@ -216,20 +234,27 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "flex-end",
     },
-    fadeIn: {
-        // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
-        animationName: keyframes.fadeIn,
-        animationDuration: "400ms",
-        animationTimingFunction: "linear",
-        animationFillMode: "forwards",
-    },
-    fadeOut: {
-        // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
-        animationName: keyframes.fadeOut,
-        animationDuration: "400ms",
-        animationTimingFunction: "linear",
-        animationFillMode: "forwards",
-    },
 });
+
+/**
+ * The backdrop's fade. It shares the panel's durations so the two finish
+ * together, and stays linear.
+ */
+const getFadeStyles = (
+    isExiting: boolean,
+    timingDuration: number | undefined,
+) =>
+    StyleSheet.create({
+        fade: {
+            // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
+            animationName: isExiting ? keyframes.fadeOut : keyframes.fadeIn,
+            animationDuration: `${
+                timingDuration ??
+                (isExiting ? DRAWER_EXIT_DURATION_MS : DRAWER_ENTER_DURATION_MS)
+            }ms`,
+            animationTimingFunction: "linear",
+            animationFillMode: "forwards",
+        },
+    });
 
 export default DrawerBackdrop;

--- a/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
@@ -208,22 +208,29 @@ const getTransformValue = (
     return `translate3d(${signedOffset}, 0, 0)`;
 };
 
-/** The panel slides only; opacity is left alone. */
+/**
+ * The panel fades as it slides. The slide covers only part of the panel's size,
+ * so the fade is what carries it the rest of the way in and out.
+ */
 const createKeyframes = (isRtl: boolean, alignment: DrawerAlignment) => ({
     slideIn: {
         "0%": {
             transform: getTransformValue(isRtl, alignment, DRAWER_SLIDE_OFFSET),
+            opacity: 0,
         },
         "100%": {
             transform: REST_TRANSFORM,
+            opacity: 1,
         },
     },
     slideOut: {
         "0%": {
             transform: REST_TRANSFORM,
+            opacity: 1,
         },
         "100%": {
             transform: getTransformValue(isRtl, alignment, DRAWER_SLIDE_OFFSET),
+            opacity: 0,
         },
     },
 });
@@ -305,7 +312,7 @@ const getComponentStyles = ({
             color: semanticColor.core.foreground.neutral.strong,
             overflow: "auto", // Prevent dialog from scrolling with background
             position: "relative",
-            willChange: "transform",
+            willChange: "transform, opacity",
 
             // Override FlexibleDialog defaults for drawer usage
             height: "100%",

--- a/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {breakpoint, semanticColor} from "@khanacademy/wonder-blocks-tokens";
-import type {DrawerAlignment, DrawerEasing} from "../util/types";
+import type {DrawerAlignment} from "../util/types";
 import {
     useDrawerContext,
     DEFAULT_DRAWER_ANIMATED,
@@ -136,7 +136,7 @@ const DrawerDialog = React.forwardRef(function DrawerDialog(
 ): React.ReactElement {
     // Get drawer props from context
     const contextProps = useDrawerContext();
-    const alignment = contextProps.alignment;
+    const alignment = contextProps.alignment ?? "inlineEnd";
     const animated = contextProps.animated ?? DEFAULT_DRAWER_ANIMATED;
     const isExiting = contextProps.isExiting ?? DEFAULT_DRAWER_IS_EXITING;
     const timingDuration = contextProps.timingDuration;
@@ -148,17 +148,25 @@ const DrawerDialog = React.forwardRef(function DrawerDialog(
     const direction = useDirectionDetection();
     const isRtl = direction === "rtl";
 
-    const componentStyles = getComponentStyles({
-        alignment,
-        isRtl,
-        animated,
-        isExiting,
-        timingDuration,
-        easing,
-    });
+    const phase = isExiting ? "exit" : "enter";
+    const defaultAnimationStyle =
+        DEFAULT_ANIMATION_STYLES[alignment][isRtl ? "rtl" : "ltr"][phase];
+    const phaseEasing = easing?.[phase];
 
-    const alignmentStyles =
-        (alignment && componentStyles[alignment]) || componentStyles.inlineEnd;
+    // Plain object — never passed to StyleSheet.create in this file.
+    const animationStyle = !animated
+        ? undefined
+        : timingDuration === undefined && phaseEasing === undefined
+          ? defaultAnimationStyle
+          : {
+                ...defaultAnimationStyle,
+                ...(timingDuration !== undefined && {
+                    animationDuration: `${timingDuration}ms`,
+                }),
+                ...(phaseEasing !== undefined && {
+                    animationTimingFunction: phaseEasing,
+                }),
+            };
 
     return (
         <FlexibleDialog
@@ -166,16 +174,20 @@ const DrawerDialog = React.forwardRef(function DrawerDialog(
             ref={ref}
             styles={{
                 root: [
-                    componentStyles.root,
-                    alignmentStyles,
-                    styles?.root,
+                    componentStyles.root, // Aphrodite class
+                    componentStyles[alignment], // Aphrodite class
+                    animationStyle, // plain object
+                    styles?.root, // consumer-provided override
                 ].filter(Boolean),
-                dialog: [componentStyles.dialog, styles?.dialog].filter(
-                    Boolean,
-                ),
-                panel: styles?.panel,
-                content: styles?.content,
-                closeButton: styles?.closeButton,
+                dialog: [
+                    alignment === "blockEnd"
+                        ? componentStyles.dialogBlockEnd // Aphrodite class
+                        : componentStyles.dialogDefault, // Aphrodite class
+                    styles?.dialog, // consumer-provided override
+                ].filter(Boolean),
+                panel: styles?.panel, // consumer-provided override
+                content: styles?.content, // consumer-provided override
+                closeButton: styles?.closeButton, // consumer-provided override
             }}
         />
     );
@@ -236,123 +248,109 @@ const createKeyframes = (isRtl: boolean, alignment: DrawerAlignment) => ({
 });
 
 /**
- * The animation properties shared by every alignment. `timingDuration` overrides
- * the duration of both phases; `easing` overrides either phase's curve.
+ * The default animation style for one phase: which keyframes to run, the
+ * default duration and curve, and which end state to hold outside the
+ * animation. Returns a plain object — never passed to StyleSheet.create.
  */
-const getAnimationStyles = ({
-    animated,
-    isExiting,
-    timingDuration,
-    easing,
-    alignmentKeyframes,
-}: {
-    animated: boolean;
-    isExiting: boolean;
-    timingDuration: number | undefined;
-    easing: DrawerEasing | undefined;
-    alignmentKeyframes: ReturnType<typeof createKeyframes> | null;
-}) => {
-    const phaseDuration = isExiting
-        ? DRAWER_EXIT_DURATION_MS
-        : DRAWER_ENTER_DURATION_MS;
-    const phaseEasing = isExiting
-        ? (easing?.exit ?? DRAWER_EXIT_EASING)
-        : (easing?.enter ?? DRAWER_ENTER_EASING);
-
+const buildDefaultStyle = (
+    isExiting: boolean,
+    alignmentKeyframes: ReturnType<typeof createKeyframes>,
+): React.CSSProperties => ({
     // Aphrodite accepts a keyframes object for `animationName`, but the
     // CSSProperties type only permits a string. [FEI-5019]
-    const animationName = (animated && alignmentKeyframes
-        ? isExiting
-            ? alignmentKeyframes.slideOut
-            : alignmentKeyframes.slideIn
-        : undefined) as unknown as React.CSSProperties["animationName"];
+    animationName: (isExiting
+        ? alignmentKeyframes.slideOut
+        : alignmentKeyframes.slideIn) as unknown as React.CSSProperties["animationName"],
+    animationDuration: `${isExiting ? DRAWER_EXIT_DURATION_MS : DRAWER_ENTER_DURATION_MS}ms`,
+    animationTimingFunction: isExiting
+        ? DRAWER_EXIT_EASING
+        : DRAWER_ENTER_EASING,
+    // `backwards` holds the off-screen `from` before the entrance starts;
+    // `forwards` holds the off-screen `to` after the exit completes.
+    animationFillMode: isExiting ? "forwards" : "backwards",
+});
+
+const buildDirectionStyles = (alignment: DrawerAlignment) => {
+    const ltrKeyframes = createKeyframes(false, alignment);
+    // blockEnd never mirrors, so its RTL entry reuses the same keyframes.
+    const rtlKeyframes =
+        alignment === "blockEnd"
+            ? ltrKeyframes
+            : createKeyframes(true, alignment);
 
     return {
-        animationName,
-        animationDuration: `${timingDuration ?? phaseDuration}ms`,
-        animationTimingFunction: phaseEasing,
-        // `backwards` holds the off-screen `from` before the entrance starts;
-        // `forwards` holds the off-screen `to` after the exit completes.
-        animationFillMode: isExiting ? "forwards" : "backwards",
+        ltr: {
+            enter: buildDefaultStyle(false, ltrKeyframes),
+            exit: buildDefaultStyle(true, ltrKeyframes),
+        },
+        rtl: {
+            enter: buildDefaultStyle(false, rtlKeyframes),
+            exit: buildDefaultStyle(true, rtlKeyframes),
+        },
     };
 };
 
-const getComponentStyles = ({
-    alignment,
-    isRtl,
-    animated,
-    isExiting = false,
-    timingDuration,
-    easing,
-}: {
-    alignment: DrawerAlignment | undefined;
-    isRtl: boolean;
-    animated: boolean;
-    timingDuration: number | undefined;
-    easing: DrawerEasing | undefined;
-    isExiting?: boolean;
-}) => {
-    // Generate keyframes for the current alignment and RTL state
-    const alignmentKeyframes = alignment
-        ? createKeyframes(isRtl, alignment)
-        : null;
-
-    const animationStyles = getAnimationStyles({
-        animated,
-        isExiting,
-        timingDuration,
-        easing,
-        alignmentKeyframes,
-    });
-
-    return StyleSheet.create({
-        root: {
-            boxShadow: theme.dialog.shadow.default,
-            // Allows propagating the text color to all the children.
-            color: semanticColor.core.foreground.neutral.strong,
-            overflow: "auto", // Prevent dialog from scrolling with background
-            position: "relative",
-            willChange: "transform, opacity",
-
-            // Override FlexibleDialog defaults for drawer usage
-            height: "100%",
-            minBlockSize: "100vh",
-
-            // Use common widths for mininum/maximum
-            minInlineSize: breakpoint.width.xsMax,
-            maxInlineSize: breakpoint.width.smMax,
-            width: "100%",
-
-            // Unset minimums on smaller screens
-            [breakpoint.mediaQuery.smOrSmaller]: {
-                minInlineSize: "unset",
-                maxInlineSize: "unset",
-            },
-        },
-        dialog: {
-            // Override the minBlockSize and minInlineSize on View
-            // And allow BlockEnd content to provide its own height
-            minBlockSize: alignment === "blockEnd" ? "unset" : "100vh",
-            minInlineSize: "unset",
-        },
-        inlineStart: {
-            ...animationStyles,
-        },
-        inlineEnd: {
-            ...animationStyles,
-        },
-        blockEnd: {
-            ...animationStyles,
-            height: "auto",
-            minBlockSize: "unset",
-            maxInlineSize: "unset",
-
-            [breakpoint.mediaQuery.smOrSmaller]: {
-                height: "auto",
-            },
-        },
-    });
+// The default animation style for every alignment × direction × phase
+// combination, computed once. Plain objects — never passed to
+// StyleSheet.create.
+const DEFAULT_ANIMATION_STYLES: Record<
+    DrawerAlignment,
+    ReturnType<typeof buildDirectionStyles>
+> = {
+    inlineStart: buildDirectionStyles("inlineStart"),
+    inlineEnd: buildDirectionStyles("inlineEnd"),
+    blockEnd: buildDirectionStyles("blockEnd"),
 };
+
+// Positioning only — independent of animation state, so this is computed once
+// rather than per render. Aphrodite classes (StyleSheet.create), unlike the
+// animation styles above.
+const componentStyles = StyleSheet.create({
+    root: {
+        boxShadow: theme.dialog.shadow.default,
+        // Allows propagating the text color to all the children.
+        color: semanticColor.core.foreground.neutral.strong,
+        overflow: "auto", // Prevent dialog from scrolling with background
+        position: "relative",
+        willChange: "transform, opacity",
+
+        // Override FlexibleDialog defaults for drawer usage
+        height: "100%",
+        minBlockSize: "100vh",
+
+        // Use common widths for mininum/maximum
+        minInlineSize: breakpoint.width.xsMax,
+        maxInlineSize: breakpoint.width.smMax,
+        width: "100%",
+
+        // Unset minimums on smaller screens
+        [breakpoint.mediaQuery.smOrSmaller]: {
+            minInlineSize: "unset",
+            maxInlineSize: "unset",
+        },
+    },
+    // Override the minBlockSize and minInlineSize on View, and allow blockEnd
+    // content to provide its own height.
+    dialogDefault: {
+        minBlockSize: "100vh",
+        minInlineSize: "unset",
+    },
+    dialogBlockEnd: {
+        minBlockSize: "unset",
+        minInlineSize: "unset",
+    },
+    inlineStart: {},
+    inlineEnd: {},
+    blockEnd: {
+        height: "auto",
+        minBlockSize: "unset",
+        maxInlineSize: "unset",
+
+        [breakpoint.mediaQuery.smOrSmaller]: {
+            height: "auto",
+        },
+    },
+});
 
 DrawerDialog.displayName = "DrawerDialog";
 

--- a/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-dialog.tsx
@@ -2,13 +2,19 @@ import * as React from "react";
 import {StyleSheet} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import {breakpoint, semanticColor} from "@khanacademy/wonder-blocks-tokens";
-import type {DrawerAlignment} from "../util/types";
+import type {DrawerAlignment, DrawerEasing} from "../util/types";
 import {
     useDrawerContext,
     DEFAULT_DRAWER_ANIMATED,
     DEFAULT_DRAWER_IS_EXITING,
-    DEFAULT_DRAWER_TIMING_DURATION_MS,
 } from "../util/drawer-context";
+import {
+    DRAWER_ENTER_DURATION_MS,
+    DRAWER_ENTER_EASING,
+    DRAWER_EXIT_DURATION_MS,
+    DRAWER_EXIT_EASING,
+    DRAWER_SLIDE_OFFSET,
+} from "../util/drawer-animation";
 import FlexibleDialog from "./flexible-dialog";
 import theme from "../theme";
 import {useDirectionDetection} from "../hooks/use-direction-detection";
@@ -133,8 +139,8 @@ const DrawerDialog = React.forwardRef(function DrawerDialog(
     const alignment = contextProps.alignment;
     const animated = contextProps.animated ?? DEFAULT_DRAWER_ANIMATED;
     const isExiting = contextProps.isExiting ?? DEFAULT_DRAWER_IS_EXITING;
-    const timingDuration =
-        contextProps.timingDuration ?? DEFAULT_DRAWER_TIMING_DURATION_MS;
+    const timingDuration = contextProps.timingDuration;
+    const easing = contextProps.easing;
 
     const {styles} = props;
 
@@ -148,6 +154,7 @@ const DrawerDialog = React.forwardRef(function DrawerDialog(
         animated,
         isExiting,
         timingDuration,
+        easing,
     });
 
     const alignmentStyles =
@@ -174,67 +181,122 @@ const DrawerDialog = React.forwardRef(function DrawerDialog(
     );
 });
 
+/** The resting transform, shared by all alignments. */
+const REST_TRANSFORM = "translate3d(0, 0, 0)";
+
+/**
+ * The transform that displaces the panel from its resting position by `offset`,
+ * a CSS length or percentage, along the axis its alignment docks to.
+ */
 const getTransformValue = (
     isRtl: boolean,
     alignment: DrawerAlignment,
-    percentage: number,
+    offset: string,
 ): string => {
     if (alignment === "blockEnd") {
-        return `translate3d(0, ${percentage}%, 0)`;
+        // Positive Y is downward, off the bottom edge.
+        return `translate3d(0, ${offset}, 0)`;
     }
 
-    // For inlineEnd, we need to reverse the direction compared to inlineStart
-    const directionMultiplier = isRtl
+    const isNegative = isRtl
         ? alignment === "inlineEnd"
-            ? -1
-            : 1
-        : alignment === "inlineEnd"
-          ? 1
-          : -1;
+        : alignment === "inlineStart";
 
-    return `translate3d(${directionMultiplier * percentage}%, 0, 0)`;
+    // calc() rather than a "-" prefix, since `offset` is a string.
+    const signedOffset = isNegative ? `calc(-1 * ${offset})` : offset;
+
+    return `translate3d(${signedOffset}, 0, 0)`;
 };
 
+/** The panel slides only; opacity is left alone. */
 const createKeyframes = (isRtl: boolean, alignment: DrawerAlignment) => ({
     slideIn: {
         "0%": {
-            transform: getTransformValue(isRtl, alignment, 100),
-            opacity: 0,
+            transform: getTransformValue(isRtl, alignment, DRAWER_SLIDE_OFFSET),
         },
         "100%": {
-            transform: getTransformValue(isRtl, alignment, 0),
-            opacity: 1,
+            transform: REST_TRANSFORM,
         },
     },
     slideOut: {
         "0%": {
-            transform: getTransformValue(isRtl, alignment, 0),
-            opacity: 1,
+            transform: REST_TRANSFORM,
         },
         "100%": {
-            transform: getTransformValue(isRtl, alignment, 100),
-            opacity: 0,
+            transform: getTransformValue(isRtl, alignment, DRAWER_SLIDE_OFFSET),
         },
     },
 });
+
+/**
+ * The animation properties shared by every alignment. `timingDuration` overrides
+ * the duration of both phases; `easing` overrides either phase's curve.
+ */
+const getAnimationStyles = ({
+    animated,
+    isExiting,
+    timingDuration,
+    easing,
+    alignmentKeyframes,
+}: {
+    animated: boolean;
+    isExiting: boolean;
+    timingDuration: number | undefined;
+    easing: DrawerEasing | undefined;
+    alignmentKeyframes: ReturnType<typeof createKeyframes> | null;
+}) => {
+    const phaseDuration = isExiting
+        ? DRAWER_EXIT_DURATION_MS
+        : DRAWER_ENTER_DURATION_MS;
+    const phaseEasing = isExiting
+        ? (easing?.exit ?? DRAWER_EXIT_EASING)
+        : (easing?.enter ?? DRAWER_ENTER_EASING);
+
+    // Aphrodite accepts a keyframes object for `animationName`, but the
+    // CSSProperties type only permits a string. [FEI-5019]
+    const animationName = (animated && alignmentKeyframes
+        ? isExiting
+            ? alignmentKeyframes.slideOut
+            : alignmentKeyframes.slideIn
+        : undefined) as unknown as React.CSSProperties["animationName"];
+
+    return {
+        animationName,
+        animationDuration: `${timingDuration ?? phaseDuration}ms`,
+        animationTimingFunction: phaseEasing,
+        // `backwards` holds the off-screen `from` before the entrance starts;
+        // `forwards` holds the off-screen `to` after the exit completes.
+        animationFillMode: isExiting ? "forwards" : "backwards",
+    };
+};
 
 const getComponentStyles = ({
     alignment,
     isRtl,
     animated,
-    isExiting,
+    isExiting = false,
     timingDuration,
+    easing,
 }: {
     alignment: DrawerAlignment | undefined;
     isRtl: boolean;
     animated: boolean;
-    timingDuration: number;
+    timingDuration: number | undefined;
+    easing: DrawerEasing | undefined;
     isExiting?: boolean;
 }) => {
     // Generate keyframes for the current alignment and RTL state
     const alignmentKeyframes = alignment
         ? createKeyframes(isRtl, alignment)
         : null;
+
+    const animationStyles = getAnimationStyles({
+        animated,
+        isExiting,
+        timingDuration,
+        easing,
+        alignmentKeyframes,
+    });
 
     return StyleSheet.create({
         root: {
@@ -243,7 +305,7 @@ const getComponentStyles = ({
             color: semanticColor.core.foreground.neutral.strong,
             overflow: "auto", // Prevent dialog from scrolling with background
             position: "relative",
-            willChange: "transform, opacity",
+            willChange: "transform",
 
             // Override FlexibleDialog defaults for drawer usage
             height: "100%",
@@ -267,40 +329,13 @@ const getComponentStyles = ({
             minInlineSize: "unset",
         },
         inlineStart: {
-            // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
-            animationName:
-                animated &&
-                alignmentKeyframes &&
-                (isExiting
-                    ? alignmentKeyframes.slideOut
-                    : alignmentKeyframes.slideIn),
-            animationDuration: `${timingDuration}ms`,
-            animationTimingFunction: "linear",
-            animationFillMode: "forwards",
+            ...animationStyles,
         },
         inlineEnd: {
-            // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
-            animationName:
-                animated &&
-                alignmentKeyframes &&
-                (isExiting
-                    ? alignmentKeyframes.slideOut
-                    : alignmentKeyframes.slideIn),
-            animationDuration: `${timingDuration}ms`,
-            animationTimingFunction: "linear",
-            animationFillMode: "forwards",
+            ...animationStyles,
         },
         blockEnd: {
-            // @ts-expect-error [FEI-5019] - `animationName` expects a string not an object
-            animationName:
-                animated &&
-                alignmentKeyframes &&
-                (isExiting
-                    ? alignmentKeyframes.slideOut
-                    : alignmentKeyframes.slideIn),
-            animationDuration: `${timingDuration}ms`,
-            animationTimingFunction: "linear",
-            animationFillMode: "forwards",
+            ...animationStyles,
             height: "auto",
             minBlockSize: "unset",
             maxInlineSize: "unset",

--- a/packages/wonder-blocks-modal/src/components/drawer-launcher.tsx
+++ b/packages/wonder-blocks-modal/src/components/drawer-launcher.tsx
@@ -8,7 +8,7 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 import FocusTrap from "./focus-trap";
 import DrawerBackdrop from "./drawer-backdrop";
 import ScrollDisabler from "./scroll-disabler";
-import type {DrawerAlignment, ModalElement} from "../util/types";
+import type {DrawerAlignment, DrawerEasing, ModalElement} from "../util/types";
 import {
     DrawerContext,
     DEFAULT_DRAWER_TIMING_DURATION_MS,
@@ -16,6 +16,7 @@ import {
     DEFAULT_DRAWER_BACKDROP_DISMISS_ENABLED,
     DEFAULT_DRAWER_IS_EXITING,
 } from "../util/drawer-context";
+import {DRAWER_EXIT_DURATION_MS} from "../util/drawer-animation";
 import ModalContext from "./modal-context";
 import type {DrawerDialogStyles} from "./drawer-dialog";
 
@@ -81,19 +82,40 @@ type BaseProps = Readonly<{
     /**
      * Optional styles for the DrawerLauncher.
      *
-     * This can be used to style the container that holds the focus trap, modal
-     * dialog, and scrollable region.
+     * - `container` styles the container that holds the focus trap, modal dialog,
+     *   and scrollable region.
+     * - `backdrop` styles the backdrop overlaying the page behind the drawer,
+     *   applied last so it overrides the backdrop's own styles. This is also the
+     *   only way to reach the backdrop's opacity animation. Prefer
+     *   `timingDuration` over setting `animationDuration` here, which desyncs the
+     *   backdrop from the panel; `animationName: "none"` drops the animation in
+     *   both directions, leaving the overlay to appear and disappear in a single
+     *   frame each way.
      */
     styles?: {
         container?: StyleType;
+        backdrop?: StyleType;
     };
     /**
-     * Optional number of milliseconds for slide-in animation. Defaults to 400ms.
-     * Used to ensure timing of focused elements after modals are opened.
+     * Optional number of milliseconds for the slide animations, overriding the
+     * duration of *both* phases. Also used to ensure timing of focused elements
+     * after modals are opened.
+     *
+     * When unset, the enter runs at 300ms and the exit at 150ms. Easing is
+     * unaffected either way.
      *
      * Turned off when `animated` option is `false` for reduced-motion preferences.
      */
     timingDuration?: number;
+    /**
+     * Optional per-phase easing overrides for the slide animation, e.g.
+     * `{enter: "ease-out", exit: "ease-in"}`. Each value is any CSS
+     * `animation-timing-function`, and either phase may be omitted to keep its
+     * default curve.
+     *
+     * Applies to the sliding panel only; the backdrop's fade stays linear.
+     */
+    easing?: DrawerEasing;
     /**
      * Whether to include animation in the `DrawerLauncher` and child components.
      * This should be false if the user has `prefers-reduced-motion` opted in.
@@ -166,7 +188,6 @@ type Props = ControlledProps | UncontrolledProps;
 
 const defaultProps = {
     backdropDismissEnabled: DEFAULT_DRAWER_BACKDROP_DISMISS_ENABLED,
-    defaultTimingDuration: DEFAULT_DRAWER_TIMING_DURATION_MS,
 } as const;
 
 const DrawerLauncher = (props: Props) => {
@@ -183,8 +204,14 @@ const DrawerLauncher = (props: Props) => {
         alignment,
         styles,
         animated = DEFAULT_DRAWER_ANIMATED,
-        timingDuration = defaultProps.defaultTimingDuration,
+        // Undefined by default, so the drawer components fall back to their
+        // per-phase durations and easing curves.
+        timingDuration,
+        easing,
     } = props;
+
+    const easingEnter = easing?.enter;
+    const easingExit = easing?.exit;
 
     // State for uncontrolled mode
     const [uncontrolledOpened, setUncontrolledOpened] = React.useState(false);
@@ -235,7 +262,7 @@ const DrawerLauncher = (props: Props) => {
 
     const handleCloseModal = React.useCallback(() => {
         if (animated) {
-            // If component is animated, allow time for exit animations
+            // If component is animated, allow time for the exit animation.
             setIsExiting(true);
             setTimeout(() => {
                 setIsExiting(false);
@@ -246,7 +273,7 @@ const DrawerLauncher = (props: Props) => {
                     onClose?.();
                 }
                 returnFocus();
-            }, timingDuration);
+            }, timingDuration ?? DRAWER_EXIT_DURATION_MS);
         } else {
             // For non-animated case, cleanup immediately
             if (typeof controlledOpened === "boolean") {
@@ -271,8 +298,18 @@ const DrawerLauncher = (props: Props) => {
             animated,
             isExiting,
             timingDuration,
+            easing: {enter: easingEnter, exit: easingExit},
         }),
-        [alignment, animated, isExiting, timingDuration],
+        // Depends on the easing phases individually rather than the object, so an
+        // inline `easing={{enter: "..."}}` literal doesn't invalidate the memo.
+        [
+            alignment,
+            animated,
+            isExiting,
+            timingDuration,
+            easingEnter,
+            easingExit,
+        ],
     );
 
     const renderModal = React.useCallback(() => {
@@ -318,6 +355,7 @@ const DrawerLauncher = (props: Props) => {
                               <DrawerBackdrop
                                   initialFocusId={initialFocusId}
                                   testId={testId}
+                                  style={styles?.backdrop}
                                   onCloseModal={
                                       backdropDismissEnabled
                                           ? handleCloseModal
@@ -371,9 +409,11 @@ function DrawerLauncherKeypressListener({onClose}: {onClose: () => unknown}) {
  * modal components may result in incorrect animations, positioning, and styling.
  *
  * - Slide animations can be turned off with the `animated` prop.
- * - Timing of animations can be fine-tuned with the `timingDuration` prop, used on
- * enter and exit animations. It is also used to coordinate timing of focus management
- * on open and close.
+ * - The drawer slides in over 300ms easing out, and leaves over 150ms easing in.
+ * - `timingDuration` overrides the duration of both phases. It is also used to
+ * coordinate timing of focus management on open and close.
+ * - `easing` overrides the curves per phase, e.g.
+ * `easing={{enter: "ease-out", exit: "ease-in"}}`.
  *
  * For conditionally rendering modals, ensure there is only one `DrawerLauncher` in
  * your component tree. A launcher needs to stay mounted on the current page to

--- a/packages/wonder-blocks-modal/src/util/drawer-animation.ts
+++ b/packages/wonder-blocks-modal/src/util/drawer-animation.ts
@@ -1,0 +1,27 @@
+/**
+ * Animation values for the drawer system, shared by `drawer-dialog` (the sliding
+ * panel) and `drawer-backdrop` (the fade).
+ *
+ * Enter and exit run on an asymmetric clock: the entrance is longer and eases
+ * out, the exit is quicker and eases in. Both layers use the same durations, so
+ * they finish together.
+ */
+
+/** Duration in milliseconds of the enter (slide-in) animation. */
+export const DRAWER_ENTER_DURATION_MS = 300;
+
+/** Duration in milliseconds of the exit (slide-out) animation. */
+export const DRAWER_EXIT_DURATION_MS = 150;
+
+/** Easing for the entrance: a decisive arrival that settles gently. */
+export const DRAWER_ENTER_EASING = "cubic-bezier(0.05, 0.7, 0.1, 1)";
+
+/** Easing for the exit: eases in so the panel accelerates away. */
+export const DRAWER_EXIT_EASING = "cubic-bezier(0.3, 0, 0.8, 0.15)";
+
+/**
+ * How far the panel sits from its resting position at the far end of the slide,
+ * as a percentage of its own size, so it is fully clear of the edge it is docked
+ * to. The panel slides without fading, so this has to cover it completely.
+ */
+export const DRAWER_SLIDE_OFFSET = "100%";

--- a/packages/wonder-blocks-modal/src/util/drawer-animation.ts
+++ b/packages/wonder-blocks-modal/src/util/drawer-animation.ts
@@ -1,6 +1,6 @@
 /**
- * Animation values for the drawer system, shared by `drawer-dialog` (the sliding
- * panel) and `drawer-backdrop` (the fade).
+ * Animation values for the drawer system, shared by `drawer-dialog` (the panel,
+ * which slides and fades) and `drawer-backdrop` (which fades).
  *
  * Enter and exit run on an asymmetric clock: the entrance is longer and eases
  * out, the exit is quicker and eases in. Both layers use the same durations, so
@@ -21,7 +21,8 @@ export const DRAWER_EXIT_EASING = "cubic-bezier(0.3, 0, 0.8, 0.15)";
 
 /**
  * How far the panel sits from its resting position at the far end of the slide,
- * as a percentage of its own size, so it is fully clear of the edge it is docked
- * to. The panel slides without fading, so this has to cover it completely.
+ * as a percentage of its own size. A partial distance, so the movement is
+ * suggested rather than a full traverse of the panel's width; the panel's fade
+ * covers the rest.
  */
-export const DRAWER_SLIDE_OFFSET = "100%";
+export const DRAWER_SLIDE_OFFSET = "42%";

--- a/packages/wonder-blocks-modal/src/util/drawer-context.ts
+++ b/packages/wonder-blocks-modal/src/util/drawer-context.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
-import type {DrawerAlignment} from "./types";
+import {DRAWER_ENTER_DURATION_MS} from "./drawer-animation";
+import type {DrawerAlignment, DrawerEasing} from "./types";
 
 /**
  * Centralized default values for the drawer system.
@@ -8,8 +9,12 @@ import type {DrawerAlignment} from "./types";
  * and can be imported by consumers who need to reference or override defaults.
  */
 
-/** Default duration in milliseconds for drawer slide animations and focus timing. */
-export const DEFAULT_DRAWER_TIMING_DURATION_MS = 400;
+/**
+ * The drawer's enter duration in milliseconds. Each phase has its own duration —
+ * see `DRAWER_ENTER_DURATION_MS` and `DRAWER_EXIT_DURATION_MS` in
+ * `./drawer-animation`.
+ */
+export const DEFAULT_DRAWER_TIMING_DURATION_MS = DRAWER_ENTER_DURATION_MS;
 
 /** Default setting for whether drawer animations are enabled. */
 export const DEFAULT_DRAWER_ANIMATED = true;
@@ -24,14 +29,17 @@ export interface DrawerContextProps {
     alignment?: DrawerAlignment;
     animated?: boolean;
     isExiting?: boolean;
+    /** Overrides the duration of both the enter and exit animations. */
     timingDuration?: number;
+    /** Per-phase overrides for the slide easing. */
+    easing?: DrawerEasing;
 }
 
-// Default values for the drawer context - using centralized defaults from DrawerLauncher
+// `timingDuration` and `easing` are omitted so that, when unset, the drawer
+// components fall back to the per-phase values in `./drawer-animation`.
 const defaultDrawerContextValue: DrawerContextProps = {
     animated: DEFAULT_DRAWER_ANIMATED,
     isExiting: DEFAULT_DRAWER_IS_EXITING,
-    timingDuration: DEFAULT_DRAWER_TIMING_DURATION_MS,
 };
 
 export const DrawerContext = React.createContext<DrawerContextProps>(

--- a/packages/wonder-blocks-modal/src/util/types.ts
+++ b/packages/wonder-blocks-modal/src/util/types.ts
@@ -19,3 +19,15 @@ export type ModalElement = React.ReactElement | null;
  * `blockEnd` is bottom-aligned.
  */
 export type DrawerAlignment = "inlineStart" | "inlineEnd" | "blockEnd";
+
+/**
+ * Easing curves for the drawer's slide animation, one per phase. Each value is
+ * any CSS `animation-timing-function`; omitting a phase leaves it on its default
+ * curve.
+ */
+export type DrawerEasing = {
+    /** The curve used while the drawer slides into place. */
+    enter?: string;
+    /** The curve used while the drawer slides away. */
+    exit?: string;
+};


### PR DESCRIPTION
## Summary:

Updates `DrawerLauncher`'s default animation to match the design team's motion spec (WB-2191), and adds two customization points. Previously both phases shared one 400ms linear animation and the panel faded as it slid.

- **Enter:** 300ms, `cubic-bezier(0.05, 0.7, 0.1, 1)`
- **Exit:** 150ms, `cubic-bezier(0.3, 0, 0.8, 0.15)`
- Panel slides without fading, travelling its full width/height. The backdrop keeps its fade and shares the panel's durations.
- Closing unmounts the drawer after the exit duration rather than the enter duration.

New API:

- `easing={{enter, exit}}` — per-phase curve overrides, applied to the panel; the backdrop's fade stays linear.
- `styles.backdrop` — styles the backdrop overlay, applied last. Also the only way to reach its opacity animation.

Also fixes a pre-existing bug: `timingDuration` applied only to the panel, so an override left the panel and backdrop finishing at different times.

Issue: WB-2191

## Test plan:
- `pnpm jest`, `pnpm lint`, `pnpm typecheck` all pass
- Verify computed animation values in Storybook across all three alignments, including RTL sign flipping, and for default vs. overridden timing/easing