### PR TITLE
Dropdown: Add label to internal listbox

### DIFF
--- a/.changeset/shaggy-pandas-listen.md
+++ b/.changeset/shaggy-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-dropdown": patch
+---
+
+SingleSelect / MultiSelect: label the listbox with the same name as the opener so the options have context in a screen reader. The name comes from the opener's associated `<label>` element (e.g. from `LabeledField`), the select's `aria-labelledby`, or its `aria-label`.

--- a/__docs__/wonder-blocks-dropdown/multi-select.accessibility.mdx
+++ b/__docs__/wonder-blocks-dropdown/multi-select.accessibility.mdx
@@ -45,6 +45,25 @@ that would need to be omitted from the visible label.
 
 <Canvas of={MultiSelectAccessibilityStories.UsingOpenerAriaLabel} />
 
+## Naming the listbox
+
+The listbox that contains the options is rendered in a portal, so it is
+disconnected in the DOM from the opener that labels it. To give the options
+context when a screen reader user navigates into the listbox, `MultiSelect`
+labels the listbox with the same name as the opener, using whichever of these
+labels the opener has:
+
+1. The `<label>` element associated with the opener, such as the one rendered by
+`LabeledField`. The listbox refers to the same label element, which is the
+labelling recommended for the
+[combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).
+2. The element referenced by `aria-labelledby` on the `MultiSelect`.
+3. The `aria-label` on the `MultiSelect`.
+
+So, a `MultiSelect` labelled "Students" has a listbox named "Students". If the
+`MultiSelect` has no label at all, neither does its listbox, which is another
+reason to always give it one.
+
 ## Automatic screen reader announcements in `MultiSelect`
 
 `MultiSelect` uses the [Wonder Blocks Announcer](/?path=/docs/packages-announcer--docs)

--- a/__docs__/wonder-blocks-dropdown/single-select.accessibility.mdx
+++ b/__docs__/wonder-blocks-dropdown/single-select.accessibility.mdx
@@ -50,6 +50,25 @@ that would need to be omitted from the visible label.
 
 <Canvas of={SingleSelectAccessibilityStories.UsingOpenerAriaLabel} />
 
+## Naming the listbox
+
+The listbox that contains the options is rendered in a portal, so it is
+disconnected in the DOM from the opener that labels it. To give the options
+context when a screen reader user navigates into the listbox, `SingleSelect`
+labels the listbox with the same name as the opener, using whichever of these
+labels the opener has:
+
+1. The `<label>` element associated with the opener, such as the one rendered by
+`LabeledField`. The listbox refers to the same label element, which is the
+labelling recommended for the
+[combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).
+2. The element referenced by `aria-labelledby` on the `SingleSelect`.
+3. The `aria-label` on the `SingleSelect`.
+
+So, a `SingleSelect` labelled "Fruit" has a listbox named "Fruit". If the
+`SingleSelect` has no label at all, neither does its listbox, which is another
+reason to always give it one.
+
 ## Automatic screen reader announcements in `SingleSelect`
 
 `SingleSelect` uses the [Wonder Blocks Announcer](/?path=/docs/packages-announcer--docs)

--- a/packages/wonder-blocks-dropdown/package.json
+++ b/packages/wonder-blocks-dropdown/package.json
@@ -61,6 +61,7 @@
     "react-window": "catalog:"
   },
   "devDependencies": {
-    "@khanacademy/wb-dev-build-settings": "workspace:*"
+    "@khanacademy/wb-dev-build-settings": "workspace:*",
+    "@khanacademy/wonder-blocks-labeled-field": "workspace:*"
   }
 }

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/multi-select.test.tsx
@@ -14,6 +14,8 @@ import {
 } from "@testing-library/user-event";
 
 import {PropsFor} from "@khanacademy/wonder-blocks-core";
+import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
+
 import OptionItem from "../option-item";
 import MultiSelect from "../multi-select";
 import {defaultLabels as builtinLabels} from "../../util/constants";
@@ -2563,6 +2565,96 @@ describe("MultiSelect", () => {
             // Assert
             expect(opener).toHaveAttribute("aria-controls", dropdown.id);
             expect(opener).toHaveAttribute("aria-controls", expect.any(String));
+        });
+    });
+
+    describe("a11y > listbox label", () => {
+        it("should label the listbox with the label from LabeledField", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <LabeledField
+                    label="Students"
+                    field={
+                        <MultiSelect onChange={jest.fn()}>
+                            <OptionItem label="item 1" value="1" />
+                            <OptionItem label="item 2" value="2" />
+                        </MultiSelect>
+                    }
+                />,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(
+                await screen.findByRole("listbox", {hidden: true}),
+            ).toHaveAccessibleName("Students");
+        });
+
+        it("should label the listbox with the label element associated with the opener", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <div>
+                    <label id="select-label" htmlFor="select">
+                        Students
+                    </label>
+                    <MultiSelect id="select" onChange={jest.fn()}>
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                    </MultiSelect>
+                </div>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(
+                await screen.findByRole("listbox", {hidden: true}),
+            ).toHaveAccessibleName("Students");
+        });
+
+        it("should use the aria-label from the select as the accessible name for the listbox", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <MultiSelect onChange={jest.fn()} aria-label="Students">
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </MultiSelect>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(
+                await screen.findByRole("listbox", {hidden: true}),
+            ).toHaveAccessibleName("Students");
+        });
+
+        it("should label the listbox with the same element as the opener when aria-labelledby is set", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <div>
+                    <span id="external-label">Students</span>
+                    <MultiSelect
+                        onChange={jest.fn()}
+                        aria-labelledby="external-label"
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                    </MultiSelect>
+                </div>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(
+                await screen.findByRole("listbox", {hidden: true}),
+            ).toHaveAccessibleName("Students");
         });
     });
 

--- a/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/__tests__/single-select.test.tsx
@@ -13,6 +13,8 @@ import {
 
 import {PropsFor} from "@khanacademy/wonder-blocks-core";
 
+import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
+
 import OptionItem from "../option-item";
 import SingleSelect from "../single-select";
 import type {SingleSelectLabelsValues} from "../single-select";
@@ -1875,6 +1877,105 @@ describe("SingleSelect", () => {
             // Assert
             expect(opener).toHaveAttribute("aria-controls", dropdown.id);
             expect(opener).toHaveAttribute("aria-controls", expect.any(String));
+        });
+    });
+
+    describe("a11y > listbox label", () => {
+        it("should label the listbox with the label from LabeledField", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <LabeledField
+                    label="Students"
+                    field={
+                        <SingleSelect placeholder="Choose" onChange={jest.fn()}>
+                            <OptionItem label="item 1" value="1" />
+                            <OptionItem label="item 2" value="2" />
+                        </SingleSelect>
+                    }
+                />,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(
+                await screen.findByRole("listbox", {hidden: true}),
+            ).toHaveAccessibleName("Students");
+        });
+
+        it("should label the listbox with the label element associated with the opener", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <div>
+                    <label id="select-label" htmlFor="select">
+                        Students
+                    </label>
+                    <SingleSelect
+                        id="select"
+                        placeholder="Choose"
+                        onChange={jest.fn()}
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                    </SingleSelect>
+                </div>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(
+                await screen.findByRole("listbox", {hidden: true}),
+            ).toHaveAccessibleName("Students");
+        });
+
+        it("should use the aria-label from the select as the accessible name for the listbox", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <SingleSelect
+                    placeholder="Choose"
+                    onChange={jest.fn()}
+                    aria-label="Students"
+                >
+                    <OptionItem label="item 1" value="1" />
+                    <OptionItem label="item 2" value="2" />
+                </SingleSelect>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(
+                await screen.findByRole("listbox", {hidden: true}),
+            ).toHaveAccessibleName("Students");
+        });
+
+        it("should label the listbox with the same element as the opener when aria-labelledby is set", async () => {
+            // Arrange
+            const {userEvent} = doRender(
+                <div>
+                    <span id="external-label">Students</span>
+                    <SingleSelect
+                        placeholder="Choose"
+                        onChange={jest.fn()}
+                        aria-labelledby="external-label"
+                    >
+                        <OptionItem label="item 1" value="1" />
+                        <OptionItem label="item 2" value="2" />
+                    </SingleSelect>
+                </div>,
+            );
+
+            // Act
+            await userEvent.click(await screen.findByRole("combobox"));
+
+            // Assert
+            expect(
+                await screen.findByRole("listbox", {hidden: true}),
+            ).toHaveAccessibleName("Students");
         });
     });
 

--- a/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/dropdown-core.tsx
@@ -104,7 +104,7 @@ type DropdownAriaRole = "listbox" | "menu";
 type ItemAriaRole = "option" | "menuitem";
 type DropdownAriaProps = Pick<
     AriaProps,
-    "aria-invalid" | "aria-required" | "aria-labelledby"
+    "aria-invalid" | "aria-required" | "aria-label" | "aria-labelledby"
 >;
 
 type ExportProps = Readonly<{
@@ -981,6 +981,7 @@ class DropdownCore extends React.Component<Props, State> {
     ): React.ReactNode {
         const {
             "aria-invalid": ariaInvalid,
+            "aria-label": ariaLabel,
             "aria-labelledby": ariaLabelledby,
             "aria-required": ariaRequired,
             dropdownStyle,
@@ -1014,6 +1015,7 @@ class DropdownCore extends React.Component<Props, State> {
                 <View
                     id={id}
                     role={role}
+                    aria-label={ariaLabel}
                     aria-labelledby={ariaLabelledby}
                     style={[
                         styles.listboxOrMenu,

--- a/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/multi-select.tsx
@@ -26,7 +26,11 @@ import type {
     OptionItemComponent,
     OptionItemComponentArray,
 } from "../util/types";
-import {getLabel, getSelectOpenerLabel} from "../util/helpers";
+import {
+    getLabel,
+    getListboxLabelProps,
+    getSelectOpenerLabel,
+} from "../util/helpers";
 import {useSelectValidation} from "../hooks/use-select-validation";
 
 export type LabelsValues = {
@@ -262,6 +266,7 @@ const MultiSelect = (props: Props) => {
         style,
         className,
         "aria-label": ariaLabel,
+        "aria-labelledby": ariaLabelledBy,
         "aria-invalid": ariaInvalid,
         "aria-required": ariaRequired,
         disabled = false,
@@ -681,6 +686,7 @@ const MultiSelect = (props: Props) => {
                             disabled={isDisabled}
                             id={uniqueOpenerId}
                             aria-label={ariaLabel}
+                            aria-labelledby={ariaLabelledBy}
                             aria-controls={dropdownId}
                             aria-required={computedRequired}
                             isPlaceholder={openerContent === noneSelected}
@@ -702,6 +708,13 @@ const MultiSelect = (props: Props) => {
     };
 
     const {clearSearch, filter, noResults, someSelected} = labels;
+
+    // Label the listbox with the same name as the opener.
+    const listboxLabelProps = getListboxLabelProps({
+        ariaLabel,
+        ariaLabelledBy,
+        openerElement,
+    });
 
     // Use refs so the effects below only re-fire when their relevant values
     // change, not on every render caused by label prop object identity churn.
@@ -764,6 +777,7 @@ const MultiSelect = (props: Props) => {
                         noResults,
                         someResults: someSelected,
                     }}
+                    {...listboxLabelProps}
                     aria-invalid={ariaInvalid}
                     aria-required={computedRequired}
                     // If readOnly is true, DropdownCore should be disabled to

--- a/packages/wonder-blocks-dropdown/src/components/single-select.tsx
+++ b/packages/wonder-blocks-dropdown/src/components/single-select.tsx
@@ -23,7 +23,11 @@ import type {
     OpenerProps,
     OptionItemComponentArray,
 } from "../util/types";
-import {getLabel, getSelectOpenerLabel} from "../util/helpers";
+import {
+    getLabel,
+    getListboxLabelProps,
+    getSelectOpenerLabel,
+} from "../util/helpers";
 import {useSelectValidation} from "../hooks/use-select-validation";
 
 export type SingleSelectLabelsValues = {
@@ -292,6 +296,7 @@ const SingleSelect = (props: Props) => {
         style,
         className,
         "aria-label": ariaLabel,
+        "aria-labelledby": ariaLabelledBy,
         "aria-invalid": ariaInvalid,
         "aria-required": ariaRequired,
         disabled = false,
@@ -526,6 +531,7 @@ const SingleSelect = (props: Props) => {
                         <SelectOpener
                             {...sharedProps}
                             aria-label={ariaLabel}
+                            aria-labelledby={ariaLabelledBy}
                             aria-controls={dropdownId}
                             aria-required={computedRequired}
                             disabled={isDisabled}
@@ -560,6 +566,13 @@ const SingleSelect = (props: Props) => {
     const items = getMenuItems(allChildren);
     const isDisabled = numEnabledOptions === 0 || disabled;
     const disableInteraction = isDisabled || readOnly;
+
+    // Label the listbox with the same name as the opener.
+    const listboxLabelProps = getListboxLabelProps({
+        ariaLabel,
+        ariaLabelledBy,
+        openerElement,
+    });
 
     const {someResults} = labels;
     const someResultsRef = React.useRef(someResults);
@@ -603,6 +616,7 @@ const SingleSelect = (props: Props) => {
                     }
                     searchText={isFilterable ? searchText : ""}
                     labels={labels}
+                    {...listboxLabelProps}
                     aria-invalid={ariaInvalid}
                     aria-required={ariaRequired}
                     // If readOnly is true, DropdownCore should be disabled to

--- a/packages/wonder-blocks-dropdown/src/util/helpers.ts
+++ b/packages/wonder-blocks-dropdown/src/util/helpers.ts
@@ -84,3 +84,48 @@ export function getSelectOpenerLabel(
     }
     return props.label;
 }
+
+/**
+ * Returns the aria attributes that label a listbox with the same name as its
+ * opener. The listbox is rendered in a portal, so it needs its own name to give
+ * the options context.
+ */
+export function getListboxLabelProps({
+    ariaLabel,
+    ariaLabelledBy,
+    openerElement,
+}: {
+    ariaLabel?: string | null;
+    ariaLabelledBy?: string | null;
+    openerElement?: HTMLElement;
+}): {
+    "aria-label"?: string;
+    "aria-labelledby"?: string;
+} {
+    // The opener is labelable, so it may be named by a `<label for="">`
+    // element, e.g. the one rendered by LabeledField.
+    const openerLabel = getOpenerLabel(openerElement);
+    const labelId = ariaLabelledBy || openerLabel?.id;
+
+    if (labelId) {
+        return {"aria-labelledby": labelId};
+    }
+
+    // Fall back to the label's text for a `<label>` without an id.
+    const label = openerLabel?.textContent || ariaLabel;
+
+    return label ? {"aria-label": label} : {};
+}
+
+/**
+ * Returns the `<label>` element associated with the opener, if there is one.
+ */
+function getOpenerLabel(
+    openerElement?: HTMLElement,
+): HTMLLabelElement | undefined {
+    if (!openerElement || !("labels" in openerElement)) {
+        return undefined;
+    }
+
+    return (openerElement as HTMLButtonElement).labels?.[0];
+}

--- a/packages/wonder-blocks-dropdown/tsconfig-build.json
+++ b/packages/wonder-blocks-dropdown/tsconfig-build.json
@@ -12,6 +12,7 @@
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-form/tsconfig-build.json"},
         {"path": "../wonder-blocks-icon/tsconfig-build.json"},
+        {"path": "../wonder-blocks-labeled-field/tsconfig-build.json"},
         {"path": "../wonder-blocks-modal/tsconfig-build.json"},
         {"path": "../wonder-blocks-pill/tsconfig-build.json"},
         {"path": "../wonder-blocks-search-field/tsconfig-build.json"},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,6 +1026,9 @@ importers:
       '@khanacademy/wb-dev-build-settings':
         specifier: workspace:*
         version: link:../../build-settings
+      '@khanacademy/wonder-blocks-labeled-field':
+        specifier: workspace:*
+        version: link:../wonder-blocks-labeled-field
 
   packages/wonder-blocks-form:
     dependencies:


### PR DESCRIPTION
## Summary:

The listbox rendered by `SingleSelect` and `MultiSelect` lives in a portal, disconnected from its combobox opener, so it had no accessible name — screen reader users navigating into it got no context for the options. Fixes [CLASS-13348](https://khanacademy.atlassian.net/browse/CLASS-13348) (a11y audit finding).

The listbox is now labelled with the same name as the opener, verbatim. `getListboxLabelProps()` picks, in order:

1. `aria-labelledby` on the select → the listbox references the same element
2. the `<label>` associated with the opener (e.g. from `LabeledField`) → the listbox references that label's `id`
3. that label's text, when the label has no `id`
4. the select's `aria-label`

If the select has no label, neither does its listbox — no generic fallback text is invented, so there's nothing new to translate.

Issue: CLASS-13348

## Test plan:
- `pnpm jest`, `pnpm typecheck`, `pnpm lint` all pass
- Verify in Storybook: with `LabeledField`, both components render `<div role="listbox" aria-labelledby="…-labeled-field-label">` pointing at the visible label
- Review MultiSelect and SingleSelect Accessibility docs in Storybook

[CLASS-13348]: https://khanacademy.atlassian.net/browse/CLASS-13348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ