### PR TITLE
WB-2185 Date Picker Contrast/Weight Styles

### DIFF
--- a/.changeset/wise-walls-perform.md
+++ b/.changeset/wise-walls-perform.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-date-picker": patch
+---
+
+Update date picker styling for accessibility

--- a/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
+++ b/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
@@ -342,9 +342,9 @@ const DatePickerWithOpenOverlay = (props: Props) => {
 export const OpenCalendarOverlay: Story = {
     render: (args) => <DatePickerWithOpenOverlay {...args} />,
     args: {
-        selectedDate: Temporal.PlainDate.from("2025-11-01"),
-        minDate: Temporal.PlainDate.from("2025-11-01"),
-        maxDate: Temporal.PlainDate.from("2026-12-31"),
+        selectedDate: Temporal.PlainDate.from("2026-08-25"),
+        minDate: Temporal.PlainDate.from("2026-08-01"),
+        maxDate: Temporal.PlainDate.from("2027-06-11"),
         updateDate: () => {},
     },
 };

--- a/packages/wonder-blocks-date-picker/src/components/date-picker-overlay.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker-overlay.tsx
@@ -84,13 +84,6 @@ const DatePickerOverlay = ({
         return null;
     }
 
-    // 1. Portal: Used to append the child element to the document (or a modal
-    //    if exists). This way we prevent having issues with any stacking
-    //    context generated in DOM tree associated to the parent component.
-    // 2. FocusManager: Used to steal focus, then return focus to the next
-    //    element after the overlay.
-    // 3. Popper: Automatically calculates the position based on the
-    //    referenceElement and applies the required styles to the child element.
     return createPortal(
         <FocusManager
             referenceElement={referenceElement}

--- a/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
@@ -5,7 +5,7 @@ import {DayPicker} from "react-day-picker";
 import {enUS, type Locale} from "react-day-picker/locale";
 
 import {View, type StyleType} from "@khanacademy/wonder-blocks-core";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {font, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {useCloseOnOutsideClick} from "../hooks/use-close-on-outside-click";
 import {useDatePickerModifiers} from "../hooks/use-date-picker-modifiers";
 import {useDisplayMonth} from "../hooks/use-display-month";
@@ -131,9 +131,10 @@ type RootWithEscProps = React.HTMLAttributes<Element> & {
     onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
 };
 
-// Override the React Day Picker accent color.
+// Override the React Day Picker colors.
 const customRootStyle = {
     "--rdp-accent-color": semanticColor.core.border.instructive.default,
+    "--rdp-today-color": semanticColor.core.foreground.instructive.default,
 } as React.CSSProperties & Record<string, string>;
 
 /**
@@ -452,6 +453,17 @@ const DatePicker = (props: Props) => {
         [],
     );
 
+    // `styles` only reads the `day` key per-day; modifier styles like
+    // `selected` must go through `modifiersStyles` instead, since
+    // react-day-picker merges them from a separate prop.
+    const dayPickerModifiersStyles = React.useMemo(
+        () => ({
+            selected: {fontWeight: font.weight.medium},
+            today: {fontWeight: font.weight.bold},
+        }),
+        [],
+    );
+
     // inputDriven: the displayed month in what the user is typing
     const inputDrivenMonth = inputDrivenMonthRef.current;
     const isInputDriven = inputDrivenMonth != null;
@@ -525,6 +537,7 @@ const DatePicker = (props: Props) => {
                             locale={computedLocale}
                             dir={dir}
                             styles={dayPickerStyles}
+                            modifiersStyles={dayPickerModifiersStyles}
                         />
                         {maybeRenderFooter()}
                     </View>


### PR DESCRIPTION
## Summary:
This PR updates the styles for the Date Picker calendar to use color and font weight more intentionally.

- The current day is bolded and blue, no longer relying on color alone
- The selected day is no longer bolded, since it has a circle outline

Issue: WB-2185

## Test plan:
1. Open the date picker stories and measure contrast: `/?path=/story/packages-datepicker-datepicker--open-calendar-overlay&globals=theme:thunderblocks`
2. Note the days fall under text contrast (1.4.3) and should meet 4.5:1, while the previous/next arrow buttons fall under non-text-contrast (1.4.11), only requiring 3:1 ratio

## Screenshots

Before:
<img width="381" height="437" alt="Date picker overlay with bolded selected day, and blue regular weight current day" src="https://github.com/user-attachments/assets/e8d7cf9a-41ef-443d-8bf2-87c6df8a61e9" />

After:
<img width="365" height="420" alt="Date picker overlay with regular weight selected day, and blue bolded current day" src="https://github.com/user-attachments/assets/d10182a4-4fa5-4c0b-9a91-28be943dcc43" />
