### PR TITLE
DatePicker: Change interaction pattern to manual activation

### DIFF
--- a/.changeset/date-picker-calendar-toggle-button.md
+++ b/.changeset/date-picker-calendar-toggle-button.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-date-picker": minor
+---
+
+DatePicker: the calendar overlay now only opens on explicit activation (clicking the calendar icon button, or ArrowDown/Enter on the text input), matching native browser date/time inputs. Focusing or clicking the text input alone no longer opens the overlay. The previously decorative calendar icon is now a focusable, keyboard-operable toggle button (default aria-label "Show calendar"), and a new `calendarButtonAriaLabel` prop lets consumers customize it.
+
+DatePicker's focused day button in the calendar grid now also uses the standard Wonder Blocks focus style (`focusStyles` from `@khanacademy/wonder-blocks-styles`) instead of react-day-picker's default focus ring.

--- a/.changeset/date-picker-calendar-toggle-button.md
+++ b/.changeset/date-picker-calendar-toggle-button.md
@@ -2,6 +2,6 @@
 "@khanacademy/wonder-blocks-date-picker": minor
 ---
 
-DatePicker: the calendar overlay now only opens on explicit activation (clicking the calendar icon button, or ArrowDown/Enter on the text input), matching native browser date/time inputs. Focusing or clicking the text input alone no longer opens the overlay. The previously decorative calendar icon is now a focusable, keyboard-operable toggle button (default aria-label "Show calendar"), and a new `calendarButtonAriaLabel` prop lets consumers customize it.
+DatePicker: the calendar overlay now only opens by clicking the calendar toggle button (or activating it via keyboard), matching native browser date/time inputs.
 
 DatePicker's focused day button in the calendar grid now also uses the standard Wonder Blocks focus style (`focusStyles` from `@khanacademy/wonder-blocks-styles`) instead of react-day-picker's default focus ring.

--- a/.changeset/icon-button-on-keydown.md
+++ b/.changeset/icon-button-on-keydown.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-icon-button": minor
+---
+
+Add `onKeyDown` prop to `IconButton`, composed with (not replacing) internal Space/Enter handling. Fixes `IconButtonUnstyled` bug where a caller `onKeyDown` silently overrode internal key handling.

--- a/__docs__/catalog/components-config.tsx
+++ b/__docs__/catalog/components-config.tsx
@@ -1139,8 +1139,8 @@ export const floatingComponents = [
             React.useEffect(() => {
                 // Wait for the DatePicker to render, then dispatch a click
                 const timeout = setTimeout(() => {
-                    // Click the input to open the calendar
-                    const el = ref.current?.querySelector("input");
+                    // Click the calendar toggle button to open the calendar
+                    const el = ref.current?.querySelector("button");
                     if (el) {
                         el.click();
                     }

--- a/__docs__/wonder-blocks-date-picker/date-picker-testing-snapshots.stories.tsx
+++ b/__docs__/wonder-blocks-date-picker/date-picker-testing-snapshots.stories.tsx
@@ -103,10 +103,12 @@ const DatePickerScenario = ({
         if (!opened) {
             return;
         }
-        // Wait for the component to render, then click the input to open the
-        // calendar.
+        // Wait for the component to render, then click the calendar toggle
+        // button to open the calendar.
         const timer = setTimeout(() => {
-            containerRef.current?.querySelector("input")?.click();
+            containerRef.current
+                ?.querySelector<HTMLButtonElement>("button")
+                ?.click();
         }, 100);
 
         return () => clearTimeout(timer);

--- a/__docs__/wonder-blocks-date-picker/date-picker.argtypes.tsx
+++ b/__docs__/wonder-blocks-date-picker/date-picker.argtypes.tsx
@@ -80,6 +80,12 @@ export default {
             category: "Accessibility",
         },
     },
+    calendarButtonAriaLabel: {
+        control: {type: "text"},
+        table: {
+            category: "Accessibility",
+        },
+    },
     style: {
         control: {type: "object"},
         table: {

--- a/__docs__/wonder-blocks-date-picker/date-picker.argtypes.tsx
+++ b/__docs__/wonder-blocks-date-picker/date-picker.argtypes.tsx
@@ -86,6 +86,12 @@ export default {
             category: "Accessibility",
         },
     },
+    calendarGridRegionAriaLabel: {
+        control: {type: "text"},
+        table: {
+            category: "Accessibility",
+        },
+    },
     style: {
         control: {type: "object"},
         table: {

--- a/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
+++ b/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
@@ -476,7 +476,7 @@ export const InsideModal: Story = {
         const textboxes = await within(dialog).findAllByRole("textbox");
         const dateInput = textboxes[0];
         const calendarButtons = await within(dialog).findAllByRole("button", {
-            name: "Show calendar",
+            name: "Toggle calendar",
         });
         await userEvent.click(calendarButtons[0]);
 

--- a/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
+++ b/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
@@ -473,18 +473,18 @@ export const InsideModal: Story = {
         const dialog = await canvas.findByRole("dialog", {
             name: "Date Picker in Modal",
         });
-        const textboxes = await within(dialog).findAllByRole("textbox");
-        const dateInput = textboxes[0];
         const calendarButtons = await within(dialog).findAllByRole("button", {
             name: "Toggle calendar",
         });
         await userEvent.click(calendarButtons[0]);
 
         await canvas.findByRole("grid");
-        expect(dateInput).toHaveFocus();
+        // Clicking the toggle button opens the overlay without moving focus
+        // off the button (matching native date/time inputs).
+        expect(calendarButtons[0]).toHaveFocus();
 
         // fire keydown to trigger handledEscapeRef in DatePicker
-        dateInput.dispatchEvent(
+        calendarButtons[0].dispatchEvent(
             new KeyboardEvent("keydown", {
                 key: "Escape",
                 bubbles: true,
@@ -492,7 +492,7 @@ export const InsideModal: Story = {
         );
 
         // fire keyup to stop propagation to modal based on handledEscapeRef
-        dateInput.dispatchEvent(
+        calendarButtons[0].dispatchEvent(
             new KeyboardEvent("keyup", {
                 key: "Escape",
                 bubbles: true,

--- a/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
+++ b/__docs__/wonder-blocks-date-picker/date-picker.stories.tsx
@@ -1,12 +1,13 @@
 import type {Meta, StoryObj} from "@storybook/react-vite";
+import {StyleSheet} from "aphrodite";
 import {Temporal} from "temporal-polyfill";
 import * as React from "react";
 import {expect, userEvent, waitFor, within} from "storybook/test";
 
 import {fr, es} from "date-fns/locale";
 import Button from "@khanacademy/wonder-blocks-button";
-import {View, type PropsFor} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {addStyle, View, type PropsFor} from "@khanacademy/wonder-blocks-core";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {ModalLauncher, OnePaneDialog} from "@khanacademy/wonder-blocks-modal";
@@ -15,8 +16,11 @@ import {DatePicker} from "@khanacademy/wonder-blocks-date-picker";
 import ComponentInfo from "../components/component-info";
 import packageConfig from "../../packages/wonder-blocks-date-picker/package.json";
 import DatePickerArgTypes from "./date-picker.argtypes";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 
 type Props = PropsFor<typeof DatePicker>;
+
+const StyledInput = addStyle("input");
 
 const DatePickerWrapper = (props: Props) => {
     const [selectedDate, setSelectedDate] = React.useState<
@@ -304,11 +308,15 @@ const DatePickerWithOpenOverlay = (props: Props) => {
     const containerRef = React.useRef<HTMLDivElement>(null);
 
     React.useEffect(() => {
-        // Wait for the component to render, then click the input to open the calendar
+        // Wait for the component to render, then click the calendar toggle
+        // button to open the calendar (matches real user activation).
         const timer = setTimeout(() => {
-            const input = containerRef.current?.querySelector("input");
-            if (input) {
-                input.click();
+            const button =
+                containerRef.current?.querySelector<HTMLButtonElement>(
+                    "button",
+                );
+            if (button) {
+                button.click();
             }
         }, 100);
 
@@ -459,14 +467,18 @@ export const InsideModal: Story = {
     play: async ({canvasElement}) => {
         const canvas = within(canvasElement.ownerDocument.body);
 
-        // Open modal and focus the first date picker input so the overlay opens
+        // Open modal, then click the first date picker's calendar button to
+        // open its overlay (explicit activation, not just focus/click).
         await userEvent.click(canvas.getByRole("button", {name: "Open Modal"}));
         const dialog = await canvas.findByRole("dialog", {
             name: "Date Picker in Modal",
         });
         const textboxes = await within(dialog).findAllByRole("textbox");
         const dateInput = textboxes[0];
-        await userEvent.click(dateInput);
+        const calendarButtons = await within(dialog).findAllByRole("button", {
+            name: "Show calendar",
+        });
+        await userEvent.click(calendarButtons[0]);
 
         await canvas.findByRole("grid");
         expect(dateInput).toHaveFocus();
@@ -568,3 +580,88 @@ export const WithCustomStyles: Story = {
         updateDate: () => {},
     },
 };
+
+const ActivationComparisonExample = () => {
+    const [selectedDate, setSelectedDate] = React.useState<
+        Temporal.PlainDate | null | undefined
+    >(Temporal.Now.plainDateISO());
+    const [time, setTime] = React.useState("13:00");
+
+    return (
+        <View
+            style={{
+                flexDirection: "row",
+                alignItems: "flex-start",
+                gap: sizing.size_320,
+                padding: sizing.size_320,
+            }}
+        >
+            <View style={{gap: sizing.size_080, inlineSize: 240}}>
+                <LabeledField
+                    label="Wonder Blocks DatePicker"
+                    description="Try focusing/clicking the field vs. clicking the calendar icon button to see when the overlay opens."
+                    field={
+                        <DatePicker
+                            selectedDate={selectedDate}
+                            updateDate={setSelectedDate}
+                            inputAriaLabel="Choose or enter a date"
+                        />
+                    }
+                />
+            </View>
+
+            <View style={{gap: sizing.size_080, inlineSize: 240}}>
+                <LabeledField
+                    label="Native time input"
+                    description="For comparison: try focusing/clicking/typing to see when the
+                    native time picker overlay opens."
+                    field={
+                        <StyledInput
+                            type="time"
+                            id="native-time-input"
+                            value={time}
+                            onChange={(e) => {
+                                // Entering 0 causes this to be empty
+                                if (e.target.value === "") {
+                                    return;
+                                }
+                                setTime(e.target.value);
+                            }}
+                            data-testid="time-input"
+                            style={styles.timeInput}
+                        />
+                    }
+                />
+            </View>
+        </View>
+    );
+};
+
+/**
+ * Renders the Wonder Blocks DatePicker next to a native `<input type="time">`
+ * so we can manually compare when each control's overlay activates.
+ *
+ * Both controls now only show their picker overlay on **explicit
+ * activation**: for the native time input, clicking its clock icon (or
+ * pressing a key like Space/Enter/Down while focused); for the DatePicker,
+ * clicking its calendar icon button (or pressing Enter/Space while it's
+ * focused, or ArrowDown/Enter while the text input is focused). Plain focus
+ * (e.g. tabbing into either field) no longer opens either overlay. Use this
+ * story to manually verify the two controls feel consistent.
+ */
+export const DateAndTimeComparison: Story = {
+    render: () => <ActivationComparisonExample />,
+};
+
+const styles = StyleSheet.create({
+    timeInput: {
+        height: "4rem",
+        padding: `0 ${sizing.size_160}`,
+        font: "inherit",
+        border: `${border.width.thin} solid ${semanticColor.input.default.border}`,
+        borderRadius: border.radius.radius_080,
+        backgroundColor: semanticColor.input.default.background,
+        color: semanticColor.input.default.foreground,
+        ...focusStyles.focus,
+    },
+});

--- a/packages/wonder-blocks-date-picker/package.json
+++ b/packages/wonder-blocks-date-picker/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@khanacademy/wonder-blocks-core": "workspace:*",
     "@khanacademy/wonder-blocks-form": "workspace:*",
-    "@khanacademy/wonder-blocks-icon": "workspace:*",
+    "@khanacademy/wonder-blocks-icon-button": "workspace:*",
     "@khanacademy/wonder-blocks-modal": "workspace:*",
     "@khanacademy/wonder-blocks-styles": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",

--- a/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker-input.test.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker-input.test.tsx
@@ -12,7 +12,13 @@ describe("DatePickerInput", () => {
         const validDate = "2021-05-13";
 
         // Act
-        render(<DatePickerInput value={validDate} />);
+        render(
+            <DatePickerInput
+                value={validDate}
+                expanded={false}
+                onToggleOverlay={() => {}}
+            />,
+        );
 
         // Assert
         expect(await screen.findByRole("textbox")).toHaveValue(validDate);
@@ -31,6 +37,8 @@ describe("DatePickerInput", () => {
                 value={validDate}
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 modifiers={{
                     selected: TemporalLocaleUtils.temporalDateToJsDate(
                         Temporal.PlainDate.from(validDate),
@@ -74,6 +82,8 @@ describe("DatePickerInput", () => {
                 value=""
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 modifiers={{
                     // We want to disable past dates and dates after 10 days from now
                     disabled: (date) => {
@@ -111,6 +121,8 @@ describe("DatePickerInput", () => {
                 value={invalidDate}
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 modifiers={{
                     // We want to disable past dates and dates after 10 days from now
                     disabled: (date) => {
@@ -149,6 +161,8 @@ describe("DatePickerInput", () => {
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 getModifiersForDay={TemporalLocaleUtils.getModifiersForDay}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 modifiers={{
                     // We want to disable past dates and dates after 10 days from now
                     disabled: (date) => {
@@ -184,6 +198,8 @@ describe("DatePickerInput", () => {
                 value={initialDate}
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 modifiers={{
                     selected: TemporalLocaleUtils.temporalDateToJsDate(
                         Temporal.PlainDate.from(initialDate),
@@ -230,6 +246,8 @@ describe("DatePickerInput", () => {
                 value=""
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-picker-input"
             />,
         );
@@ -249,42 +267,64 @@ describe("DatePickerInput", () => {
         );
     });
 
-    it("should allow clicking the input by default", async () => {
-        // Arrange
-        const onClickSpy = jest.fn();
+    it("calls onToggleOverlay when the calendar button is clicked", async () => {
+        const onToggleOverlaySpy = jest.fn();
         render(
             <DatePickerInput
                 value="2021-05-12"
                 disabled={false}
-                onClick={onClickSpy}
+                expanded={false}
+                onToggleOverlay={onToggleOverlaySpy}
                 testId="date-picker-input"
             />,
         );
-
-        // Act
-        await userEvent.click(screen.getByTestId("date-picker-input"));
-
-        // Assert
-        expect(onClickSpy).toHaveBeenCalled();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Show calendar"}),
+        );
+        expect(onToggleOverlaySpy).toHaveBeenCalled();
     });
 
-    it("should not allow clicking the input if it's disabled", async () => {
-        // Arrange
-        const onClickSpy = jest.fn();
+    it("does not call onToggleOverlay when the calendar button is clicked if disabled", async () => {
+        const onToggleOverlaySpy = jest.fn();
         render(
             <DatePickerInput
                 value="2021-05-12"
                 disabled={true}
-                onClick={onClickSpy}
+                expanded={false}
+                onToggleOverlay={onToggleOverlaySpy}
                 testId="date-picker-input"
             />,
         );
+        await userEvent.click(
+            screen.getByRole("button", {name: "Show calendar"}),
+        );
+        expect(onToggleOverlaySpy).not.toHaveBeenCalled();
+    });
 
-        // Act
-        await userEvent.click(screen.getByTestId("date-picker-input"));
+    it("reflects the expanded prop on the calendar button's aria-expanded", () => {
+        const {rerender} = render(
+            <DatePickerInput
+                value="2021-05-12"
+                expanded={false}
+                onToggleOverlay={() => {}}
+                testId="date-picker-input"
+            />,
+        );
+        expect(
+            screen.getByRole("button", {name: "Show calendar"}),
+        ).toHaveAttribute("aria-expanded", "false");
 
-        // Assert
-        expect(onClickSpy).not.toHaveBeenCalled();
+        rerender(
+            <DatePickerInput
+                value="2021-05-12"
+                expanded={true}
+                onToggleOverlay={() => {}}
+                testId="date-picker-input"
+            />,
+        );
+        expect(
+            screen.getByRole("button", {name: "Show calendar"}),
+        ).toHaveAttribute("aria-expanded", "true");
     });
 
     it("onBlur: reverts back to the latest valid input if the current one is invalid", async () => {
@@ -301,6 +341,8 @@ describe("DatePickerInput", () => {
                 value={validDate}
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 modifiers={{
                     // We want to disable past dates and dates after 10 days from now
                     disabled: (date) => {
@@ -339,6 +381,8 @@ describe("DatePickerInput", () => {
                 value=""
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-picker-input"
             />,
         );
@@ -360,6 +404,8 @@ describe("DatePickerInput", () => {
                 dateFormat="YYYY-MM-DD"
                 value="2021-05-15"
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-picker-input"
             />,
         );
@@ -375,6 +421,8 @@ describe("DatePickerInput", () => {
                 dateFormat="YYYY-MM-DD"
                 value="2021-05-15"
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-picker-input"
             />,
         );
@@ -392,6 +440,8 @@ describe("DatePickerInput", () => {
                 onChange={handleChange}
                 dateFormat="M/D/YYYY"
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-input"
             />,
         );
@@ -415,6 +465,8 @@ describe("DatePickerInput", () => {
                 onChange={jest.fn()}
                 dateFormat="M/D/YYYY"
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-input"
             />,
         );
@@ -442,6 +494,8 @@ describe("DatePickerInput", () => {
                     value="1/1/2026"
                     parseDate={TemporalLocaleUtils.parseDateToJsDate}
                     onChange={onChangeSpy}
+                    expanded={false}
+                    onToggleOverlay={() => {}}
                     testId="date-picker-input"
                 />
                 <button>After</button>
@@ -476,6 +530,8 @@ describe("DatePickerInput", () => {
                 value="1/1/2026"
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-picker-input"
             />,
         );
@@ -506,6 +562,8 @@ describe("DatePickerInput", () => {
                 value=""
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-picker-input"
             />,
         );
@@ -530,6 +588,8 @@ describe("DatePickerInput", () => {
                 value=""
                 parseDate={TemporalLocaleUtils.parseDateToJsDate}
                 onChange={onChangeSpy}
+                expanded={false}
+                onToggleOverlay={() => {}}
                 testId="date-picker-input"
             />,
         );

--- a/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker-input.test.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker-input.test.tsx
@@ -279,7 +279,7 @@ describe("DatePickerInput", () => {
             />,
         );
         await userEvent.click(
-            screen.getByRole("button", {name: "Show calendar"}),
+            screen.getByRole("button", {name: "Toggle calendar"}),
         );
         expect(onToggleOverlaySpy).toHaveBeenCalled();
     });
@@ -296,7 +296,7 @@ describe("DatePickerInput", () => {
             />,
         );
         await userEvent.click(
-            screen.getByRole("button", {name: "Show calendar"}),
+            screen.getByRole("button", {name: "Toggle calendar"}),
         );
         expect(onToggleOverlaySpy).not.toHaveBeenCalled();
     });
@@ -311,7 +311,7 @@ describe("DatePickerInput", () => {
             />,
         );
         expect(
-            screen.getByRole("button", {name: "Show calendar"}),
+            screen.getByRole("button", {name: "Toggle calendar"}),
         ).toHaveAttribute("aria-expanded", "false");
 
         rerender(
@@ -323,7 +323,7 @@ describe("DatePickerInput", () => {
             />,
         );
         expect(
-            screen.getByRole("button", {name: "Show calendar"}),
+            screen.getByRole("button", {name: "Toggle calendar"}),
         ).toHaveAttribute("aria-expanded", "true");
     });
 

--- a/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker-overlay.test.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker-overlay.test.tsx
@@ -1,11 +1,19 @@
 import * as React from "react";
-import {describe, it} from "@jest/globals";
+import {afterEach, describe, it} from "@jest/globals";
 import {render, screen} from "@testing-library/react";
 
 import DatePickerOverlay from "../date-picker-overlay";
 
 describe("DatePickerOverlay", () => {
-    it("renders the children if valid props are passed in", () => {
+    afterEach(() => {
+        // The "does not render if we cannot find a host" test below mocks
+        // `document.querySelector` to return null; without restoring it,
+        // that mock leaks into later tests and makes every subsequent
+        // DatePickerOverlay render bail out with `modalHost` missing.
+        jest.restoreAllMocks();
+    });
+
+    it("renders the children if valid props are passed in", async () => {
         // Arrange
         const referenceElement = document.createElement("input");
 
@@ -20,7 +28,11 @@ describe("DatePickerOverlay", () => {
         );
 
         // Assert
-        expect(screen.getByText("overlay container")).toBeInTheDocument();
+        // Popper resolves its position asynchronously; findByText waits for
+        // that pending update to flush (inside act()) before asserting.
+        expect(
+            await screen.findByText("overlay container"),
+        ).toBeInTheDocument();
     });
 
     it("does not render if the referenceElement is invalid", () => {
@@ -60,5 +72,29 @@ describe("DatePickerOverlay", () => {
 
         // Assert
         expect(screen.queryByText("overlay container")).not.toBeInTheDocument();
+    });
+
+    it("renders the overlay with an aria-label for the calendar grid region", async () => {
+        // Arrange
+        const referenceElement = document.createElement("input");
+        const calendarGridRegionAriaLabel = "Custom aria-label";
+
+        // Act
+        render(
+            <DatePickerOverlay
+                referenceElement={referenceElement}
+                onClose={() => {}}
+                calendarGridRegionAriaLabel={calendarGridRegionAriaLabel}
+            >
+                <div>overlay container</div>
+            </DatePickerOverlay>,
+        );
+
+        // Assert
+        const overlayContainer = await screen.findByRole("region");
+        expect(overlayContainer).toHaveAttribute(
+            "aria-label",
+            calendarGridRegionAriaLabel,
+        );
     });
 });

--- a/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker.test.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker.test.tsx
@@ -32,7 +32,9 @@ function expectOverlayHidden() {
 // focus/click on the input no longer opens the overlay.
 async function openOverlay() {
     await userEvent.tab();
-    await userEvent.click(screen.getByRole("button", {name: "Show calendar"}));
+    await userEvent.click(
+        screen.getByRole("button", {name: "Toggle calendar"}),
+    );
 }
 
 describe("DatePicker", () => {
@@ -94,14 +96,14 @@ describe("DatePicker", () => {
         await openOverlay();
         expectOverlayVisible();
         await userEvent.click(
-            screen.getByRole("button", {name: "Show calendar"}),
+            screen.getByRole("button", {name: "Toggle calendar"}),
         );
         expectOverlayHidden();
     });
 
     it("reflects aria-expanded on the calendar button as the overlay opens and closes", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        const button = screen.getByRole("button", {name: "Show calendar"});
+        const button = screen.getByRole("button", {name: "Toggle calendar"});
         expect(button).toHaveAttribute("aria-expanded", "false");
         await openOverlay();
         expect(button).toHaveAttribute("aria-expanded", "true");
@@ -113,7 +115,7 @@ describe("DatePicker", () => {
         render(<DatePicker disabled updateDate={() => {}} />);
         await userEvent.tab();
         await userEvent.click(
-            screen.getByRole("button", {name: "Show calendar"}),
+            screen.getByRole("button", {name: "Toggle calendar"}),
         );
         expectOverlayHidden();
     });
@@ -161,7 +163,7 @@ describe("DatePicker", () => {
     it("keeps focus on the calendar button when it's clicked to open the overlay", async () => {
         render(<DatePicker updateDate={() => {}} />);
         const calendarButton = screen.getByRole("button", {
-            name: "Show calendar",
+            name: "Toggle calendar",
         });
         await userEvent.click(calendarButton);
         expect(calendarButton).toHaveFocus();
@@ -170,7 +172,7 @@ describe("DatePicker", () => {
     it("closes the overlay and returns focus to the calendar button when Escape is pressed", async () => {
         render(<DatePicker updateDate={() => {}} />);
         const calendarButton = screen.getByRole("button", {
-            name: "Show calendar",
+            name: "Toggle calendar",
         });
         await openOverlay();
         expect(calendarButton).toHaveFocus();
@@ -194,18 +196,17 @@ describe("DatePicker", () => {
         await userEvent.keyboard("{Escape}");
         await waitFor(() => expectOverlayHidden());
         expect(
-            screen.getByRole("button", {name: "Show calendar"}),
+            screen.getByRole("button", {name: "Toggle calendar"}),
         ).toHaveFocus();
         await userEvent.keyboard("{ArrowDown}");
         expectOverlayHidden();
     });
 
-    it("opens the date picker if Enter is pressed when closed", async () => {
+    it("does not open the overlay when Enter is pressed on the input while closed", async () => {
         render(<DatePicker updateDate={() => {}} />);
         await userEvent.tab();
-        await userEvent.keyboard("{Escape}");
         await userEvent.keyboard("{Enter}");
-        expectOverlayVisible();
+        expectOverlayHidden();
     });
 
     it("closes the date picker if Enter is pressed when open", async () => {
@@ -215,19 +216,21 @@ describe("DatePicker", () => {
         expectOverlayHidden();
     });
 
-    it("opens the date picker if down arrow is pressed when closed", async () => {
+    it("does not open the overlay when ArrowDown is pressed on the input while closed", async () => {
+        // The calendar button is the only way to open the overlay --
+        // ArrowDown on the input matches native date/time inputs, where
+        // arrow keys adjust the focused value segment instead.
         render(<DatePicker updateDate={() => {}} />);
         await userEvent.tab();
-        await userEvent.keyboard("{Escape}");
         await userEvent.keyboard("{ArrowDown}");
-        expectOverlayVisible();
+        expectOverlayHidden();
     });
 
     it("moves focus into the calendar grid when ArrowDown is pressed on the calendar button while the overlay is already open", async () => {
         render(<DatePicker updateDate={() => {}} />);
         await openOverlay();
         expect(
-            screen.getByRole("button", {name: "Show calendar"}),
+            screen.getByRole("button", {name: "Toggle calendar"}),
         ).toHaveFocus();
         await userEvent.keyboard("{ArrowDown}");
         await waitFor(() => {
@@ -242,8 +245,8 @@ describe("DatePicker", () => {
     it("moves focus into the calendar grid when ArrowDown is pressed on the input while the overlay is already open", async () => {
         render(<DatePicker updateDate={() => {}} />);
         const input = screen.getByRole("textbox");
-        await userEvent.tab();
-        await userEvent.keyboard("{ArrowDown}"); // opens; focus stays on input
+        await openOverlay(); // opens via the calendar button
+        await userEvent.click(input);
         expect(input).toHaveFocus();
         await userEvent.keyboard("{ArrowDown}"); // overlay already open
         await waitFor(() => {
@@ -569,7 +572,7 @@ describe("DatePicker", () => {
             await userEvent.clear(input);
             await userEvent.type(input, "asdf");
             await userEvent.click(
-                screen.getByRole("button", {name: "Show calendar"}),
+                screen.getByRole("button", {name: "Toggle calendar"}),
             );
             await userEvent.click(await screen.findByText("20"));
             await waitFor(() => {
@@ -647,6 +650,26 @@ describe("DatePicker", () => {
         await openOverlay();
         await userEvent.click(screen.getByLabelText(/previous month/i));
         await screen.findByText("April 2021");
+    });
+
+    it("returns focus to the calendar button when Shift+Tab is pressed from the month navigation buttons", async () => {
+        render(<DatePicker updateDate={() => {}} />);
+        const calendarButton = screen.getByRole("button", {
+            name: "Toggle calendar",
+        });
+        await openOverlay();
+        expect(calendarButton).toHaveFocus();
+
+        // Tab from the button enters the overlay, landing on the first
+        // focusable element (the previous-month nav button), not the day
+        // grid.
+        await userEvent.tab();
+        expect(screen.getByLabelText(/previous month/i)).toHaveFocus();
+
+        // Shift+Tab back out should return focus to the calendar button --
+        // not the text input.
+        await userEvent.tab({shift: true});
+        expect(calendarButton).toHaveFocus();
     });
 
     describe("Month navigation (uncontrolled overlay)", () => {

--- a/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker.test.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker.test.tsx
@@ -20,13 +20,6 @@ function renderPicker(props = {}) {
     return render(<DatePicker {...defaultPickerProps} {...props} />);
 }
 
-function expectOverlayVisible() {
-    expect(screen.getByTestId("focus-sentinel-prev")).toBeInTheDocument();
-}
-function expectOverlayHidden() {
-    expect(screen.queryByTestId("focus-sentinel-prev")).not.toBeInTheDocument();
-}
-
 describe("DatePicker", () => {
     beforeEach(() => {
         // Mock getBoundingClientRect to provide realistic dimensions
@@ -50,7 +43,9 @@ describe("DatePicker", () => {
         render(<DatePicker updateDate={() => {}} />);
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("does not show the date picker overlay if the input is clicked", async () => {
@@ -61,7 +56,9 @@ describe("DatePicker", () => {
         await userEvent.click(screen.getByRole("textbox"));
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("does not show the date picker overlay if disabled", async () => {
@@ -72,7 +69,9 @@ describe("DatePicker", () => {
         await userEvent.click(screen.getByRole("textbox"));
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("does not show the date picker overlay if the input is focused", async () => {
@@ -83,7 +82,9 @@ describe("DatePicker", () => {
         await userEvent.tab();
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("shows the date picker overlay when the calendar button is clicked", async () => {
@@ -97,7 +98,7 @@ describe("DatePicker", () => {
         );
 
         // Assert
-        expectOverlayVisible();
+        expect(screen.getByTestId("focus-sentinel-prev")).toBeInTheDocument();
     });
 
     it("shows the calendar grid when the calendar button is clicked", async () => {
@@ -128,7 +129,9 @@ describe("DatePicker", () => {
         );
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("sets aria-expanded to false on the calendar button by default", () => {
@@ -180,7 +183,9 @@ describe("DatePicker", () => {
         );
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("includes a footer if set", async () => {
@@ -244,7 +249,9 @@ describe("DatePicker", () => {
         await userEvent.type(screen.getByRole("textbox"), "{Esc}");
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("keeps focus on the calendar button when it's clicked to open the overlay", async () => {
@@ -273,7 +280,11 @@ describe("DatePicker", () => {
         await userEvent.keyboard("{Escape}");
 
         // Assert
-        await waitFor(() => expectOverlayHidden());
+        await waitFor(() =>
+            expect(
+                screen.queryByTestId("focus-sentinel-prev"),
+            ).not.toBeInTheDocument(),
+        );
     });
 
     it("returns focus to the calendar button when Escape is pressed", async () => {
@@ -300,13 +311,19 @@ describe("DatePicker", () => {
             screen.getByRole("button", {name: "Toggle calendar"}),
         );
         await userEvent.keyboard("{Escape}");
-        await waitFor(() => expectOverlayHidden());
+        await waitFor(() =>
+            expect(
+                screen.queryByTestId("focus-sentinel-prev"),
+            ).not.toBeInTheDocument(),
+        );
 
         // Act
         await userEvent.keyboard("{Escape}");
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("does not reopen the overlay with ArrowDown when the calendar button is focused", async () => {
@@ -317,13 +334,19 @@ describe("DatePicker", () => {
             screen.getByRole("button", {name: "Toggle calendar"}),
         );
         await userEvent.keyboard("{Escape}");
-        await waitFor(() => expectOverlayHidden());
+        await waitFor(() =>
+            expect(
+                screen.queryByTestId("focus-sentinel-prev"),
+            ).not.toBeInTheDocument(),
+        );
 
         // Act
         await userEvent.keyboard("{ArrowDown}");
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("does not open the overlay when Enter is pressed on the input while closed", async () => {
@@ -335,7 +358,9 @@ describe("DatePicker", () => {
         await userEvent.keyboard("{Enter}");
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("closes the date picker if Enter is pressed when open", async () => {
@@ -350,7 +375,9 @@ describe("DatePicker", () => {
         await userEvent.keyboard("{Enter}");
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     // The calendar button is the only way to open the overlay -- ArrowDown
@@ -365,7 +392,9 @@ describe("DatePicker", () => {
         await userEvent.keyboard("{ArrowDown}");
 
         // Assert
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("moves focus into the calendar grid when ArrowDown is pressed on the calendar button while the overlay is already open", async () => {
@@ -435,7 +464,7 @@ describe("DatePicker", () => {
             screen.getByRole("button", {name: "Toggle calendar"}),
         );
         await userEvent.type(screen.getByRole("textbox"), "{Enter}");
-        expectOverlayVisible();
+        expect(screen.getByTestId("focus-sentinel-prev")).toBeInTheDocument();
     });
 
     it("allows keyboard users to select a date using Tab and Enter", async () => {
@@ -467,7 +496,9 @@ describe("DatePicker", () => {
             screen.getByRole("button", {name: "Toggle calendar"}),
         );
         await userEvent.click(document.body);
-        expectOverlayHidden();
+        expect(
+            screen.queryByTestId("focus-sentinel-prev"),
+        ).not.toBeInTheDocument();
     });
 
     it("closes the date picker if we click outside the container", async () => {
@@ -477,7 +508,11 @@ describe("DatePicker", () => {
             screen.getByRole("button", {name: "Toggle calendar"}),
         );
         await userEvent.click(document.body);
-        await waitFor(() => expectOverlayHidden());
+        await waitFor(() =>
+            expect(
+                screen.queryByTestId("focus-sentinel-prev"),
+            ).not.toBeInTheDocument(),
+        );
     });
     it("closes the date picker if a date is selected", async () => {
         DateMock.advanceTo(new Date("2023-05-10T09:30:00"));

--- a/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker.test.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker.test.tsx
@@ -27,16 +27,6 @@ function expectOverlayHidden() {
     expect(screen.queryByTestId("focus-sentinel-prev")).not.toBeInTheDocument();
 }
 
-// Opens the calendar overlay via the explicit toggle mechanism: focus the
-// input (matching real usage), then click the calendar toggle button. Plain
-// focus/click on the input no longer opens the overlay.
-async function openOverlay() {
-    await userEvent.tab();
-    await userEvent.click(
-        screen.getByRole("button", {name: "Toggle calendar"}),
-    );
-}
-
 describe("DatePicker", () => {
     beforeEach(() => {
         // Mock getBoundingClientRect to provide realistic dimensions
@@ -58,69 +48,143 @@ describe("DatePicker", () => {
         // Arrange
         // Act
         render(<DatePicker updateDate={() => {}} />);
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("does not show the date picker overlay if the input is clicked", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
+
+        // Act
         await userEvent.click(screen.getByRole("textbox"));
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("does not show the date picker overlay if disabled", async () => {
+        // Arrange
         render(<DatePicker disabled updateDate={() => {}} />);
+
+        // Act
         await userEvent.click(screen.getByRole("textbox"));
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("does not show the date picker overlay if the input is focused", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
+
+        // Act
         await userEvent.tab();
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("shows the date picker overlay when the calendar button is clicked", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
-        expectOverlayVisible();
-    });
 
-    it("shows the calendar grid when the calendar button is clicked", async () => {
-        render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
-        await expect(screen.getByRole("grid")).toBeVisible();
-    });
-
-    it("closes the date picker overlay when the calendar button is clicked again", async () => {
-        render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
-        expectOverlayVisible();
-        await userEvent.click(
-            screen.getByRole("button", {name: "Toggle calendar"}),
-        );
-        expectOverlayHidden();
-    });
-
-    it("reflects aria-expanded on the calendar button as the overlay opens and closes", async () => {
-        render(<DatePicker updateDate={() => {}} />);
-        const button = screen.getByRole("button", {name: "Toggle calendar"});
-        expect(button).toHaveAttribute("aria-expanded", "false");
-        await openOverlay();
-        expect(button).toHaveAttribute("aria-expanded", "true");
-        await userEvent.click(button);
-        expect(button).toHaveAttribute("aria-expanded", "false");
-    });
-
-    it("does not open the overlay when the calendar button is clicked if disabled", async () => {
-        render(<DatePicker disabled updateDate={() => {}} />);
+        // Act
         await userEvent.tab();
         await userEvent.click(
             screen.getByRole("button", {name: "Toggle calendar"}),
         );
+
+        // Assert
+        expectOverlayVisible();
+    });
+
+    it("shows the calendar grid when the calendar button is clicked", async () => {
+        // Arrange
+        render(<DatePicker updateDate={() => {}} />);
+
+        // Act
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Assert
+        await expect(screen.getByRole("grid")).toBeVisible();
+    });
+
+    it("closes the date picker overlay when the calendar button is clicked again", async () => {
+        // Arrange
+        render(<DatePicker updateDate={() => {}} />);
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Assert
+        expectOverlayHidden();
+    });
+
+    it("sets aria-expanded to false on the calendar button by default", () => {
+        // Arrange
+        render(<DatePicker updateDate={() => {}} />);
+
+        // Act
+        const button = screen.getByRole("button", {name: "Toggle calendar"});
+
+        // Assert
+        expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("sets aria-expanded to true on the calendar button when the overlay opens", async () => {
+        // Arrange
+        render(<DatePicker updateDate={() => {}} />);
+        const button = screen.getByRole("button", {name: "Toggle calendar"});
+
+        // Act
+        await userEvent.tab();
+        await userEvent.click(button);
+
+        // Assert
+        expect(button).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("sets aria-expanded to false on the calendar button when the overlay closes", async () => {
+        // Arrange
+        render(<DatePicker updateDate={() => {}} />);
+        const button = screen.getByRole("button", {name: "Toggle calendar"});
+        await userEvent.tab();
+        await userEvent.click(button);
+
+        // Act
+        await userEvent.click(button);
+
+        // Assert
+        expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("does not open the overlay when the calendar button is clicked if disabled", async () => {
+        // Arrange
+        render(<DatePicker disabled updateDate={() => {}} />);
+
+        // Act
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("includes a footer if set", async () => {
+        // Arrange
         render(
             <DatePicker
                 updateDate={() => {}}
@@ -129,13 +193,21 @@ describe("DatePicker", () => {
                 )}
             />,
         );
-        await openOverlay();
+
+        // Act
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Assert
         expect(
             screen.getByRole("button", {name: /footer button/i}),
         ).toBeInTheDocument();
     });
 
     it("allows closing the date picker from within the footer", async () => {
+        // Arrange
         render(
             <DatePicker
                 updateDate={() => {}}
@@ -144,95 +216,170 @@ describe("DatePicker", () => {
                 )}
             />,
         );
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Act
         await userEvent.click(
             screen.getByRole("button", {name: /footer button/i}),
         );
+
+        // Assert
         await waitFor(() =>
             expect(screen.queryByRole("grid")).not.toBeInTheDocument(),
         );
     });
 
     it("closes the date picker if ESC is pressed", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Act
         await userEvent.type(screen.getByRole("textbox"), "{Esc}");
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("keeps focus on the calendar button when it's clicked to open the overlay", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
         const calendarButton = screen.getByRole("button", {
             name: "Toggle calendar",
         });
+
+        // Act
         await userEvent.click(calendarButton);
+
+        // Assert
         expect(calendarButton).toHaveFocus();
     });
 
-    it("closes the overlay and returns focus to the calendar button when Escape is pressed", async () => {
+    it("closes the overlay when Escape is pressed", async () => {
+        // Arrange
+        render(<DatePicker updateDate={() => {}} />);
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Act
+        await userEvent.keyboard("{Escape}");
+
+        // Assert
+        await waitFor(() => expectOverlayHidden());
+    });
+
+    it("returns focus to the calendar button when Escape is pressed", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
         const calendarButton = screen.getByRole("button", {
             name: "Toggle calendar",
         });
-        await openOverlay();
-        expect(calendarButton).toHaveFocus();
+        await userEvent.tab();
+        await userEvent.click(calendarButton);
+
+        // Act
         await userEvent.keyboard("{Escape}");
-        await waitFor(() => expectOverlayHidden());
-        expect(calendarButton).toHaveFocus();
+
+        // Assert
+        await waitFor(() => expect(calendarButton).toHaveFocus());
     });
 
     it("does not reopen overlay when pressing Escape while closed", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.keyboard("{Escape}");
         await waitFor(() => expectOverlayHidden());
+
+        // Act
         await userEvent.keyboard("{Escape}");
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("does not reopen the overlay with ArrowDown when the calendar button is focused", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.keyboard("{Escape}");
         await waitFor(() => expectOverlayHidden());
-        expect(
-            screen.getByRole("button", {name: "Toggle calendar"}),
-        ).toHaveFocus();
+
+        // Act
         await userEvent.keyboard("{ArrowDown}");
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("does not open the overlay when Enter is pressed on the input while closed", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
         await userEvent.tab();
+
+        // Act
         await userEvent.keyboard("{Enter}");
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("closes the date picker if Enter is pressed when open", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Act
         await userEvent.keyboard("{Enter}");
+
+        // Assert
         expectOverlayHidden();
     });
 
+    // The calendar button is the only way to open the overlay -- ArrowDown
+    // on the input matches native date/time inputs, where arrow keys adjust
+    // the focused value segment instead.
     it("does not open the overlay when ArrowDown is pressed on the input while closed", async () => {
-        // The calendar button is the only way to open the overlay --
-        // ArrowDown on the input matches native date/time inputs, where
-        // arrow keys adjust the focused value segment instead.
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
         await userEvent.tab();
+
+        // Act
         await userEvent.keyboard("{ArrowDown}");
+
+        // Assert
         expectOverlayHidden();
     });
 
     it("moves focus into the calendar grid when ArrowDown is pressed on the calendar button while the overlay is already open", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
-        expect(
+        await userEvent.tab();
+        await userEvent.click(
             screen.getByRole("button", {name: "Toggle calendar"}),
-        ).toHaveFocus();
+        );
+
+        // Act
         await userEvent.keyboard("{ArrowDown}");
+
+        // Assert
         await waitFor(() => {
             const grid = screen.getByRole("grid");
             const focusedElement = document.activeElement; // eslint-disable-line testing-library/no-node-access -- no Testing Library helper exposes "the currently focused element"
@@ -242,13 +389,36 @@ describe("DatePicker", () => {
         });
     });
 
-    it("moves focus into the calendar grid when ArrowDown is pressed on the input while the overlay is already open", async () => {
+    it("allows focusing the input directly while the overlay is already open", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
         const input = screen.getByRole("textbox");
-        await openOverlay(); // opens via the calendar button
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Act
         await userEvent.click(input);
+
+        // Assert
         expect(input).toHaveFocus();
-        await userEvent.keyboard("{ArrowDown}"); // overlay already open
+    });
+
+    it("moves focus into the calendar grid when ArrowDown is pressed on the input while the overlay is already open", async () => {
+        // Arrange
+        render(<DatePicker updateDate={() => {}} />);
+        const input = screen.getByRole("textbox");
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+        await userEvent.click(input);
+
+        // Act
+        await userEvent.keyboard("{ArrowDown}");
+
+        // Assert
         await waitFor(() => {
             const grid = screen.getByRole("grid");
             const focusedElement = document.activeElement; // eslint-disable-line testing-library/no-node-access -- no Testing Library helper exposes "the currently focused element"
@@ -260,7 +430,10 @@ describe("DatePicker", () => {
 
     it("does not close overlay on Enter if closeOnSelect is false", async () => {
         render(<DatePicker updateDate={() => {}} closeOnSelect={false} />);
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.type(screen.getByRole("textbox"), "{Enter}");
         expectOverlayVisible();
     });
@@ -272,7 +445,10 @@ describe("DatePicker", () => {
             updateDate: updateDateMock,
             dateFormat: "YYYY-MM-DD",
         });
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         // Tab order inside the overlay: calendar toggle button, then the
         // previous/next month nav buttons, then into the day grid (only the
         // selected day is tabbable via roving tabindex).
@@ -286,14 +462,20 @@ describe("DatePicker", () => {
 
     it("closes the date picker if the input is blurred", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.click(document.body);
         expectOverlayHidden();
     });
 
     it("closes the date picker if we click outside the container", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.click(document.body);
         await waitFor(() => expectOverlayHidden());
     });
@@ -306,7 +488,10 @@ describe("DatePicker", () => {
                 updateDate={jest.fn()}
             />,
         );
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.click(screen.getByText("15"));
         await waitFor(() =>
             expect(screen.queryByRole("grid")).not.toBeInTheDocument(),
@@ -323,7 +508,10 @@ describe("DatePicker", () => {
                 updateDate={jest.fn()}
             />,
         );
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.click(screen.getByText("15"));
         await expect(screen.getByRole("grid")).toBeInTheDocument();
     });
@@ -333,7 +521,10 @@ describe("DatePicker", () => {
             updateDate: jest.fn(),
             dateFormat: "YYYY-MM-DD",
         });
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.click(screen.getByText("15"));
         await waitFor(() => {
             expect(within(container).getByRole("textbox")).toHaveValue(
@@ -349,7 +540,10 @@ describe("DatePicker", () => {
             minDate: Temporal.PlainDate.from("2021-05-05"),
             maxDate: Temporal.PlainDate.from("2021-05-12"),
         });
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         const input = screen.getByRole("textbox");
         await userEvent.clear(input);
         await userEvent.type(input, "2021-05-10");
@@ -587,7 +781,10 @@ describe("DatePicker", () => {
             minDate: Temporal.PlainDate.from("2021-05-05"),
             maxDate: Temporal.PlainDate.from("2021-05-12"),
         });
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.clear(screen.getByRole("textbox"));
         await userEvent.type(screen.getByRole("textbox"), "2021-55-55");
         const gridcell = screen.getByRole("gridcell", {selected: true});
@@ -629,7 +826,10 @@ describe("DatePicker", () => {
                 <DatePicker updateDate={() => {}} />
             </div>,
         );
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         const wrapper = screen.getByTestId("date-picker-overlay");
         expect(
             within(wrapper)
@@ -640,35 +840,57 @@ describe("DatePicker", () => {
 
     it("navigates to next month when next button is clicked", async () => {
         renderPicker();
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.click(screen.getByLabelText(/next month/i));
         await screen.findByText("June 2021");
     });
 
     it("navigates to previous month when previous button is clicked", async () => {
         renderPicker();
-        await openOverlay();
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
         await userEvent.click(screen.getByLabelText(/previous month/i));
         await screen.findByText("April 2021");
     });
 
+    // Tab from the button enters the overlay, landing on the first
+    // focusable element (the previous-month nav button), not the day grid.
+    it("moves focus to the previous-month button when Tab is pressed from the calendar button", async () => {
+        // Arrange
+        render(<DatePicker updateDate={() => {}} />);
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Toggle calendar"}),
+        );
+
+        // Act
+        await userEvent.tab();
+
+        // Assert
+        expect(screen.getByLabelText(/previous month/i)).toHaveFocus();
+    });
+
+    // Shift+Tab back out should return focus to the calendar button -- not
+    // the text input.
     it("returns focus to the calendar button when Shift+Tab is pressed from the month navigation buttons", async () => {
+        // Arrange
         render(<DatePicker updateDate={() => {}} />);
         const calendarButton = screen.getByRole("button", {
             name: "Toggle calendar",
         });
-        await openOverlay();
-        expect(calendarButton).toHaveFocus();
-
-        // Tab from the button enters the overlay, landing on the first
-        // focusable element (the previous-month nav button), not the day
-        // grid.
         await userEvent.tab();
-        expect(screen.getByLabelText(/previous month/i)).toHaveFocus();
+        await userEvent.click(calendarButton);
+        await userEvent.tab();
 
-        // Shift+Tab back out should return focus to the calendar button --
-        // not the text input.
+        // Act
         await userEvent.tab({shift: true});
+
+        // Assert
         expect(calendarButton).toHaveFocus();
     });
 
@@ -677,7 +899,10 @@ describe("DatePicker", () => {
             renderPicker({
                 selectedDate: Temporal.PlainDate.from("2021-03-15"),
             });
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             expect(screen.getByText("March 2021")).toBeInTheDocument();
         });
         it.each([
@@ -687,10 +912,16 @@ describe("DatePicker", () => {
             "reopening after %s month and close shows selected date month",
             async (_, label) => {
                 renderPicker();
-                await openOverlay();
+                await userEvent.tab();
+                await userEvent.click(
+                    screen.getByRole("button", {name: "Toggle calendar"}),
+                );
                 await userEvent.click(screen.getByLabelText(label));
                 await userEvent.keyboard("{Escape}");
-                await openOverlay();
+                await userEvent.tab();
+                await userEvent.click(
+                    screen.getByRole("button", {name: "Toggle calendar"}),
+                );
                 expect(screen.getByText("May 2021")).toBeInTheDocument();
             },
         );
@@ -699,7 +930,10 @@ describe("DatePicker", () => {
     describe("Typing vs next/previous focus", () => {
         it("typing a month name updates the overlay to that month", async () => {
             renderPicker();
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.type(screen.getByRole("textbox"), "March 15, 2021");
             await screen.findByText("March 2021");
@@ -715,7 +949,10 @@ describe("DatePicker", () => {
 
         it("clicking next month keeps focus on the next button", async () => {
             renderPicker();
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             await userEvent.click(screen.getByLabelText(/next month/i));
             await waitFor(() =>
                 expect(screen.getByLabelText(/next month/i)).toHaveFocus(),
@@ -724,7 +961,10 @@ describe("DatePicker", () => {
 
         it("clicking previous month keeps focus on the previous button", async () => {
             renderPicker();
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             await userEvent.click(screen.getByLabelText(/previous month/i));
             await waitFor(() =>
                 expect(screen.getByLabelText(/previous month/i)).toHaveFocus(),
@@ -733,7 +973,10 @@ describe("DatePicker", () => {
 
         it("second click on next month keeps focus on next button", async () => {
             renderPicker();
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             await userEvent.click(screen.getByLabelText(/next month/i));
             await userEvent.click(screen.getByLabelText(/next month/i));
             await waitFor(() =>
@@ -743,7 +986,10 @@ describe("DatePicker", () => {
 
         it("after typing then clicking next, overlay shows next month", async () => {
             renderPicker();
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.type(screen.getByRole("textbox"), "March 15, 2021");
             await userEvent.click(screen.getByLabelText(/next month/i));
@@ -752,7 +998,10 @@ describe("DatePicker", () => {
 
         it("after clicking next then typing in input, focus stays in input", async () => {
             renderPicker();
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             await userEvent.click(screen.getByLabelText(/next month/i));
             const input = screen.getByRole("textbox");
             await userEvent.click(input);
@@ -762,7 +1011,10 @@ describe("DatePicker", () => {
 
         it("after typing full date, next button still navigates months", async () => {
             renderPicker();
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.type(screen.getByRole("textbox"), "March 15, 2021");
             await screen.findByText("March 2021");
@@ -773,7 +1025,10 @@ describe("DatePicker", () => {
 
         it("after clicking a day, next button still navigates months", async () => {
             renderPicker({closeOnSelect: false});
-            await openOverlay();
+            await userEvent.tab();
+            await userEvent.click(
+                screen.getByRole("button", {name: "Toggle calendar"}),
+            );
             await userEvent.click(screen.getByText("15"));
             await userEvent.click(screen.getByLabelText(/next month/i));
             expect(await screen.findByText("June 2021")).toBeInTheDocument();
@@ -791,7 +1046,10 @@ describe("DatePicker", () => {
                 render(
                     <DatePicker {...localeProps} selectedDate={undefined} />,
                 );
-                await openOverlay();
+                await userEvent.tab();
+                await userEvent.click(
+                    screen.getByRole("button", {name: "Toggle calendar"}),
+                );
                 expect(await screen.findByRole("grid")).toBeInTheDocument();
             });
 
@@ -799,7 +1057,10 @@ describe("DatePicker", () => {
                 render(
                     <DatePicker {...localeProps} selectedDate={undefined} />,
                 );
-                await openOverlay();
+                await userEvent.tab();
+                await userEvent.click(
+                    screen.getByRole("button", {name: "Toggle calendar"}),
+                );
                 await userEvent.type(
                     screen.getByRole("textbox"),
                     "January 15, 2021",
@@ -814,7 +1075,10 @@ describe("DatePicker", () => {
                         selectedDate={Temporal.PlainDate.from("2026-01-15")}
                     />,
                 );
-                await openOverlay();
+                await userEvent.tab();
+                await userEvent.click(
+                    screen.getByRole("button", {name: "Toggle calendar"}),
+                );
                 rerender(
                     <DatePicker
                         {...localeProps}
@@ -831,7 +1095,10 @@ describe("DatePicker", () => {
                         selectedDate={Temporal.PlainDate.from("2021-12-25")}
                     />,
                 );
-                await openOverlay();
+                await userEvent.tab();
+                await userEvent.click(
+                    screen.getByRole("button", {name: "Toggle calendar"}),
+                );
                 expect(
                     await screen.findByText("December 2021"),
                 ).toBeInTheDocument();
@@ -912,7 +1179,10 @@ describe("DatePicker", () => {
                     locale: es,
                 });
                 const input = screen.getByRole("textbox");
-                await openOverlay();
+                await userEvent.tab();
+                await userEvent.click(
+                    screen.getByRole("button", {name: "Toggle calendar"}),
+                );
                 await userEvent.click(screen.getByText("15"));
                 await waitFor(() =>
                     expect(input).toHaveValue("enero 15, 2026"),
@@ -942,7 +1212,10 @@ describe("DatePicker", () => {
                         locale={es}
                     />,
                 );
-                await openOverlay();
+                await userEvent.tab();
+                await userEvent.click(
+                    screen.getByRole("button", {name: "Toggle calendar"}),
+                );
                 await userEvent.click(screen.getByText("15"));
                 expect(
                     screen.getByDisplayValue("01/15/2026"),

--- a/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker.test.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/__tests__/date-picker.test.tsx
@@ -27,6 +27,14 @@ function expectOverlayHidden() {
     expect(screen.queryByTestId("focus-sentinel-prev")).not.toBeInTheDocument();
 }
 
+// Opens the calendar overlay via the explicit toggle mechanism: focus the
+// input (matching real usage), then click the calendar toggle button. Plain
+// focus/click on the input no longer opens the overlay.
+async function openOverlay() {
+    await userEvent.tab();
+    await userEvent.click(screen.getByRole("button", {name: "Show calendar"}));
+}
+
 describe("DatePicker", () => {
     beforeEach(() => {
         // Mock getBoundingClientRect to provide realistic dimensions
@@ -51,10 +59,10 @@ describe("DatePicker", () => {
         expectOverlayHidden();
     });
 
-    it("shows the date picker overlay if the input is clicked", async () => {
+    it("does not show the date picker overlay if the input is clicked", async () => {
         render(<DatePicker updateDate={() => {}} />);
         await userEvent.click(screen.getByRole("textbox"));
-        expectOverlayVisible();
+        expectOverlayHidden();
     });
 
     it("does not show the date picker overlay if disabled", async () => {
@@ -63,16 +71,51 @@ describe("DatePicker", () => {
         expectOverlayHidden();
     });
 
-    it("shows the date picker overlay if the input is focused", async () => {
+    it("does not show the date picker overlay if the input is focused", async () => {
         render(<DatePicker updateDate={() => {}} />);
         await userEvent.tab();
+        expectOverlayHidden();
+    });
+
+    it("shows the date picker overlay when the calendar button is clicked", async () => {
+        render(<DatePicker updateDate={() => {}} />);
+        await openOverlay();
         expectOverlayVisible();
     });
 
-    it("shows the calendar grid when input is focused", async () => {
+    it("shows the calendar grid when the calendar button is clicked", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await userEvent.tab();
+        await openOverlay();
         await expect(screen.getByRole("grid")).toBeVisible();
+    });
+
+    it("closes the date picker overlay when the calendar button is clicked again", async () => {
+        render(<DatePicker updateDate={() => {}} />);
+        await openOverlay();
+        expectOverlayVisible();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Show calendar"}),
+        );
+        expectOverlayHidden();
+    });
+
+    it("reflects aria-expanded on the calendar button as the overlay opens and closes", async () => {
+        render(<DatePicker updateDate={() => {}} />);
+        const button = screen.getByRole("button", {name: "Show calendar"});
+        expect(button).toHaveAttribute("aria-expanded", "false");
+        await openOverlay();
+        expect(button).toHaveAttribute("aria-expanded", "true");
+        await userEvent.click(button);
+        expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("does not open the overlay when the calendar button is clicked if disabled", async () => {
+        render(<DatePicker disabled updateDate={() => {}} />);
+        await userEvent.tab();
+        await userEvent.click(
+            screen.getByRole("button", {name: "Show calendar"}),
+        );
+        expectOverlayHidden();
     });
 
     it("includes a footer if set", async () => {
@@ -84,7 +127,7 @@ describe("DatePicker", () => {
                 )}
             />,
         );
-        await userEvent.tab();
+        await openOverlay();
         expect(
             screen.getByRole("button", {name: /footer button/i}),
         ).toBeInTheDocument();
@@ -99,7 +142,7 @@ describe("DatePicker", () => {
                 )}
             />,
         );
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.click(
             screen.getByRole("button", {name: /footer button/i}),
         );
@@ -110,35 +153,51 @@ describe("DatePicker", () => {
 
     it("closes the date picker if ESC is pressed", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.type(screen.getByRole("textbox"), "{Esc}");
         expectOverlayHidden();
     });
 
-    it("returns focus to input after closing overlay with Escape", async () => {
+    it("keeps focus on the calendar button when it's clicked to open the overlay", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        const input = screen.getByRole("textbox");
-        await userEvent.tab();
+        const calendarButton = screen.getByRole("button", {
+            name: "Show calendar",
+        });
+        await userEvent.click(calendarButton);
+        expect(calendarButton).toHaveFocus();
+    });
+
+    it("closes the overlay and returns focus to the calendar button when Escape is pressed", async () => {
+        render(<DatePicker updateDate={() => {}} />);
+        const calendarButton = screen.getByRole("button", {
+            name: "Show calendar",
+        });
+        await openOverlay();
+        expect(calendarButton).toHaveFocus();
         await userEvent.keyboard("{Escape}");
-        await waitFor(() => expect(input).toHaveFocus());
+        await waitFor(() => expectOverlayHidden());
+        expect(calendarButton).toHaveFocus();
     });
 
     it("does not reopen overlay when pressing Escape while closed", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.keyboard("{Escape}");
         await waitFor(() => expectOverlayHidden());
         await userEvent.keyboard("{Escape}");
         expectOverlayHidden();
     });
 
-    it("allows reopening overlay with ArrowDown after Escape", async () => {
+    it("does not reopen the overlay with ArrowDown when the calendar button is focused", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.keyboard("{Escape}");
         await waitFor(() => expectOverlayHidden());
+        expect(
+            screen.getByRole("button", {name: "Show calendar"}),
+        ).toHaveFocus();
         await userEvent.keyboard("{ArrowDown}");
-        expectOverlayVisible();
+        expectOverlayHidden();
     });
 
     it("opens the date picker if Enter is pressed when closed", async () => {
@@ -151,7 +210,7 @@ describe("DatePicker", () => {
 
     it("closes the date picker if Enter is pressed when open", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.keyboard("{Enter}");
         expectOverlayHidden();
     });
@@ -164,9 +223,41 @@ describe("DatePicker", () => {
         expectOverlayVisible();
     });
 
+    it("moves focus into the calendar grid when ArrowDown is pressed on the calendar button while the overlay is already open", async () => {
+        render(<DatePicker updateDate={() => {}} />);
+        await openOverlay();
+        expect(
+            screen.getByRole("button", {name: "Show calendar"}),
+        ).toHaveFocus();
+        await userEvent.keyboard("{ArrowDown}");
+        await waitFor(() => {
+            const grid = screen.getByRole("grid");
+            const focusedElement = document.activeElement; // eslint-disable-line testing-library/no-node-access -- no Testing Library helper exposes "the currently focused element"
+            expect(within(grid).getAllByRole("button")).toContain(
+                focusedElement,
+            );
+        });
+    });
+
+    it("moves focus into the calendar grid when ArrowDown is pressed on the input while the overlay is already open", async () => {
+        render(<DatePicker updateDate={() => {}} />);
+        const input = screen.getByRole("textbox");
+        await userEvent.tab();
+        await userEvent.keyboard("{ArrowDown}"); // opens; focus stays on input
+        expect(input).toHaveFocus();
+        await userEvent.keyboard("{ArrowDown}"); // overlay already open
+        await waitFor(() => {
+            const grid = screen.getByRole("grid");
+            const focusedElement = document.activeElement; // eslint-disable-line testing-library/no-node-access -- no Testing Library helper exposes "the currently focused element"
+            expect(within(grid).getAllByRole("button")).toContain(
+                focusedElement,
+            );
+        });
+    });
+
     it("does not close overlay on Enter if closeOnSelect is false", async () => {
         render(<DatePicker updateDate={() => {}} closeOnSelect={false} />);
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.type(screen.getByRole("textbox"), "{Enter}");
         expectOverlayVisible();
     });
@@ -178,6 +269,10 @@ describe("DatePicker", () => {
             updateDate: updateDateMock,
             dateFormat: "YYYY-MM-DD",
         });
+        await openOverlay();
+        // Tab order inside the overlay: calendar toggle button, then the
+        // previous/next month nav buttons, then into the day grid (only the
+        // selected day is tabbable via roving tabindex).
         await userEvent.tab();
         await userEvent.tab();
         await userEvent.tab();
@@ -188,14 +283,14 @@ describe("DatePicker", () => {
 
     it("closes the date picker if the input is blurred", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await userEvent.click(screen.getByRole("textbox"));
+        await openOverlay();
         await userEvent.click(document.body);
         expectOverlayHidden();
     });
 
     it("closes the date picker if we click outside the container", async () => {
         render(<DatePicker updateDate={() => {}} />);
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.click(document.body);
         await waitFor(() => expectOverlayHidden());
     });
@@ -208,7 +303,7 @@ describe("DatePicker", () => {
                 updateDate={jest.fn()}
             />,
         );
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.click(screen.getByText("15"));
         await waitFor(() =>
             expect(screen.queryByRole("grid")).not.toBeInTheDocument(),
@@ -225,7 +320,7 @@ describe("DatePicker", () => {
                 updateDate={jest.fn()}
             />,
         );
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.click(screen.getByText("15"));
         await expect(screen.getByRole("grid")).toBeInTheDocument();
     });
@@ -235,7 +330,7 @@ describe("DatePicker", () => {
             updateDate: jest.fn(),
             dateFormat: "YYYY-MM-DD",
         });
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.click(screen.getByText("15"));
         await waitFor(() => {
             expect(within(container).getByRole("textbox")).toHaveValue(
@@ -251,7 +346,7 @@ describe("DatePicker", () => {
             minDate: Temporal.PlainDate.from("2021-05-05"),
             maxDate: Temporal.PlainDate.from("2021-05-12"),
         });
-        await userEvent.tab();
+        await openOverlay();
         const input = screen.getByRole("textbox");
         await userEvent.clear(input);
         await userEvent.type(input, "2021-05-10");
@@ -473,7 +568,9 @@ describe("DatePicker", () => {
             const input = screen.getByRole("textbox");
             await userEvent.clear(input);
             await userEvent.type(input, "asdf");
-            await userEvent.click(input);
+            await userEvent.click(
+                screen.getByRole("button", {name: "Show calendar"}),
+            );
             await userEvent.click(await screen.findByText("20"));
             await waitFor(() => {
                 expect(input).toHaveValue("1/20/2026");
@@ -487,7 +584,7 @@ describe("DatePicker", () => {
             minDate: Temporal.PlainDate.from("2021-05-05"),
             maxDate: Temporal.PlainDate.from("2021-05-12"),
         });
-        await userEvent.tab();
+        await openOverlay();
         await userEvent.clear(screen.getByRole("textbox"));
         await userEvent.type(screen.getByRole("textbox"), "2021-55-55");
         const gridcell = screen.getByRole("gridcell", {selected: true});
@@ -529,7 +626,7 @@ describe("DatePicker", () => {
                 <DatePicker updateDate={() => {}} />
             </div>,
         );
-        await userEvent.click(screen.getByRole("textbox"));
+        await openOverlay();
         const wrapper = screen.getByTestId("date-picker-overlay");
         expect(
             within(wrapper)
@@ -540,14 +637,14 @@ describe("DatePicker", () => {
 
     it("navigates to next month when next button is clicked", async () => {
         renderPicker();
-        await userEvent.click(screen.getByRole("textbox"));
+        await openOverlay();
         await userEvent.click(screen.getByLabelText(/next month/i));
         await screen.findByText("June 2021");
     });
 
     it("navigates to previous month when previous button is clicked", async () => {
         renderPicker();
-        await userEvent.click(screen.getByRole("textbox"));
+        await openOverlay();
         await userEvent.click(screen.getByLabelText(/previous month/i));
         await screen.findByText("April 2021");
     });
@@ -557,7 +654,7 @@ describe("DatePicker", () => {
             renderPicker({
                 selectedDate: Temporal.PlainDate.from("2021-03-15"),
             });
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             expect(screen.getByText("March 2021")).toBeInTheDocument();
         });
         it.each([
@@ -567,10 +664,10 @@ describe("DatePicker", () => {
             "reopening after %s month and close shows selected date month",
             async (_, label) => {
                 renderPicker();
-                await userEvent.click(screen.getByRole("textbox"));
+                await openOverlay();
                 await userEvent.click(screen.getByLabelText(label));
                 await userEvent.keyboard("{Escape}");
-                await userEvent.click(screen.getByRole("textbox"));
+                await openOverlay();
                 expect(screen.getByText("May 2021")).toBeInTheDocument();
             },
         );
@@ -579,7 +676,7 @@ describe("DatePicker", () => {
     describe("Typing vs next/previous focus", () => {
         it("typing a month name updates the overlay to that month", async () => {
             renderPicker();
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.type(screen.getByRole("textbox"), "March 15, 2021");
             await screen.findByText("March 2021");
@@ -595,7 +692,7 @@ describe("DatePicker", () => {
 
         it("clicking next month keeps focus on the next button", async () => {
             renderPicker();
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             await userEvent.click(screen.getByLabelText(/next month/i));
             await waitFor(() =>
                 expect(screen.getByLabelText(/next month/i)).toHaveFocus(),
@@ -604,7 +701,7 @@ describe("DatePicker", () => {
 
         it("clicking previous month keeps focus on the previous button", async () => {
             renderPicker();
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             await userEvent.click(screen.getByLabelText(/previous month/i));
             await waitFor(() =>
                 expect(screen.getByLabelText(/previous month/i)).toHaveFocus(),
@@ -613,7 +710,7 @@ describe("DatePicker", () => {
 
         it("second click on next month keeps focus on next button", async () => {
             renderPicker();
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             await userEvent.click(screen.getByLabelText(/next month/i));
             await userEvent.click(screen.getByLabelText(/next month/i));
             await waitFor(() =>
@@ -623,7 +720,7 @@ describe("DatePicker", () => {
 
         it("after typing then clicking next, overlay shows next month", async () => {
             renderPicker();
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.type(screen.getByRole("textbox"), "March 15, 2021");
             await userEvent.click(screen.getByLabelText(/next month/i));
@@ -632,7 +729,7 @@ describe("DatePicker", () => {
 
         it("after clicking next then typing in input, focus stays in input", async () => {
             renderPicker();
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             await userEvent.click(screen.getByLabelText(/next month/i));
             const input = screen.getByRole("textbox");
             await userEvent.click(input);
@@ -642,7 +739,7 @@ describe("DatePicker", () => {
 
         it("after typing full date, next button still navigates months", async () => {
             renderPicker();
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             await userEvent.clear(screen.getByRole("textbox"));
             await userEvent.type(screen.getByRole("textbox"), "March 15, 2021");
             await screen.findByText("March 2021");
@@ -653,7 +750,7 @@ describe("DatePicker", () => {
 
         it("after clicking a day, next button still navigates months", async () => {
             renderPicker({closeOnSelect: false});
-            await userEvent.click(screen.getByRole("textbox"));
+            await openOverlay();
             await userEvent.click(screen.getByText("15"));
             await userEvent.click(screen.getByLabelText(/next month/i));
             expect(await screen.findByText("June 2021")).toBeInTheDocument();
@@ -667,11 +764,11 @@ describe("DatePicker", () => {
             dateFormat: "MMMM D, YYYY",
         };
         describe("locale prop accepts Locale object directly", () => {
-            it("displays calendar when input is clicked", async () => {
+            it("displays calendar when the calendar button is clicked", async () => {
                 render(
                     <DatePicker {...localeProps} selectedDate={undefined} />,
                 );
-                await userEvent.click(screen.getByRole("textbox"));
+                await openOverlay();
                 expect(await screen.findByRole("grid")).toBeInTheDocument();
             });
 
@@ -679,7 +776,7 @@ describe("DatePicker", () => {
                 render(
                     <DatePicker {...localeProps} selectedDate={undefined} />,
                 );
-                await userEvent.click(screen.getByRole("textbox"));
+                await openOverlay();
                 await userEvent.type(
                     screen.getByRole("textbox"),
                     "January 15, 2021",
@@ -694,9 +791,7 @@ describe("DatePicker", () => {
                         selectedDate={Temporal.PlainDate.from("2026-01-15")}
                     />,
                 );
-                await userEvent.click(
-                    screen.getByDisplayValue("January 15, 2026"),
-                );
+                await openOverlay();
                 rerender(
                     <DatePicker
                         {...localeProps}
@@ -713,9 +808,7 @@ describe("DatePicker", () => {
                         selectedDate={Temporal.PlainDate.from("2021-12-25")}
                     />,
                 );
-                await userEvent.click(
-                    screen.getByDisplayValue("December 25, 2021"),
-                );
+                await openOverlay();
                 expect(
                     await screen.findByText("December 2021"),
                 ).toBeInTheDocument();
@@ -796,7 +889,7 @@ describe("DatePicker", () => {
                     locale: es,
                 });
                 const input = screen.getByRole("textbox");
-                await userEvent.click(input);
+                await openOverlay();
                 await userEvent.click(screen.getByText("15"));
                 await waitFor(() =>
                     expect(input).toHaveValue("enero 15, 2026"),
@@ -826,7 +919,7 @@ describe("DatePicker", () => {
                         locale={es}
                     />,
                 );
-                await userEvent.tab();
+                await openOverlay();
                 await userEvent.click(screen.getByText("15"));
                 expect(
                     screen.getByDisplayValue("01/15/2026"),

--- a/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
@@ -12,7 +12,7 @@ import {
 } from "../util/temporal-locale-utils";
 import type {CustomModifiers} from "../util/types";
 
-const DEFAULT_CALENDAR_BUTTON_ARIA_LABEL = "Show calendar";
+const DEFAULT_CALENDAR_BUTTON_ARIA_LABEL = "Toggle calendar";
 
 interface Props {
     /**

--- a/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
@@ -54,7 +54,7 @@ interface Props {
      * move focus into the calendar overlay on ArrowDown when it's already
      * open, and to close it on Escape.
      */
-    onCalendarButtonKeyDown?: (e: KeyboardEvent) => unknown;
+    onCalendarButtonKeyDown?: (e: React.KeyboardEvent) => unknown;
     /**
      * The aria-label for the calendar toggle button.
      */
@@ -401,19 +401,6 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
         const innerRef = React.useRef<HTMLInputElement>(null);
         const buttonRef = React.useRef<HTMLButtonElement>(null);
 
-        // IconButton doesn't expose an onKeyDown prop, so we listen directly
-        // on the underlying button element.
-        React.useEffect(() => {
-            const button = buttonRef.current;
-            if (!button || !onCalendarButtonKeyDown) {
-                return;
-            }
-            button.addEventListener("keydown", onCalendarButtonKeyDown);
-            return () => {
-                button.removeEventListener("keydown", onCalendarButtonKeyDown);
-            };
-        }, [onCalendarButtonKeyDown]);
-
         const handleChange = (newValue: string) => {
             setValue(newValue);
 
@@ -498,6 +485,7 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
                     aria-expanded={expanded}
                     aria-haspopup="grid"
                     onClick={() => onToggleOverlay()}
+                    onKeyDown={onCalendarButtonKeyDown}
                     style={styles.icon}
                 />
             </View>

--- a/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
@@ -60,6 +60,12 @@ interface Props {
      */
     calendarButtonAriaLabel?: string;
     /**
+     * Ref to the calendar toggle button's DOM node. Lets the parent
+     * (DatePicker) focus the button directly (e.g. after Escape closes the
+     * overlay) and use it as the overlay's focus-trap anchor.
+     */
+    calendarButtonRef?: React.Ref<HTMLButtonElement>;
+    /**
      * Called if the user press a key inside the input element.
      */
     onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => unknown;
@@ -168,6 +174,7 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
             onToggleOverlay,
             onCalendarButtonKeyDown,
             calendarButtonAriaLabel = DEFAULT_CALENDAR_BUTTON_ARIA_LABEL,
+            calendarButtonRef,
             ...restProps
         } = props;
 
@@ -399,7 +406,6 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
         };
 
         const innerRef = React.useRef<HTMLInputElement>(null);
-        const buttonRef = React.useRef<HTMLButtonElement>(null);
 
         const handleChange = (newValue: string) => {
             setValue(newValue);
@@ -448,17 +454,6 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
                 pendingValidationRef.current = false;
                 validateInput();
             };
-            // Lets the parent (DatePicker) return focus to the calendar
-            // toggle button, e.g. after Escape closes the overlay.
-            (inputElement as any).focusCalendarButton = () => {
-                buttonRef.current?.focus();
-            };
-            // Lets the parent (DatePicker) use the calendar toggle button --
-            // not the input -- as the overlay's focus-trap anchor, so
-            // Shift+Tab out of the overlay's first element (a nav button)
-            // returns focus to the button that opened it.
-            (inputElement as any).getCalendarButtonElement = () =>
-                buttonRef.current;
             return inputElement;
         });
 
@@ -481,7 +476,7 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
                     style={styles.textField}
                 />
                 <IconButton
-                    ref={buttonRef}
+                    ref={calendarButtonRef}
                     icon={calendarIcon}
                     size="small"
                     kind="tertiary"

--- a/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
@@ -453,6 +453,12 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
             (inputElement as any).focusCalendarButton = () => {
                 buttonRef.current?.focus();
             };
+            // Lets the parent (DatePicker) use the calendar toggle button --
+            // not the input -- as the overlay's focus-trap anchor, so
+            // Shift+Tab out of the overlay's first element (a nav button)
+            // returns focus to the button that opened it.
+            (inputElement as any).getCalendarButtonElement = () =>
+                buttonRef.current;
             return inputElement;
         });
 

--- a/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker-input.tsx
@@ -3,14 +3,16 @@ import * as React from "react";
 
 import {useOnMountEffect, View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
-import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import calendarIcon from "@phosphor-icons/core/bold/calendar-blank-bold.svg";
 import {
     enUSLocaleCode,
     TemporalLocaleUtils,
 } from "../util/temporal-locale-utils";
 import type {CustomModifiers} from "../util/types";
+
+const DEFAULT_CALENDAR_BUTTON_ARIA_LABEL = "Show calendar";
 
 interface Props {
     /**
@@ -34,13 +36,29 @@ interface Props {
      */
     onBlur?: (e: React.FocusEvent<HTMLInputElement>) => unknown;
     /**
-     * Called when the input element is clicked.
-     */
-    onClick?: (arg1: React.MouseEvent<Element>) => unknown;
-    /**
      * Called when the input element gains focus.
      */
     onFocus?: (e: React.FocusEvent<HTMLInputElement>) => unknown;
+    /**
+     * Whether the calendar overlay is currently open. Reflected on the
+     * calendar toggle button via `aria-expanded`.
+     */
+    expanded: boolean;
+    /**
+     * Called when the calendar toggle button is clicked (or activated via
+     * keyboard) to open/close the calendar overlay.
+     */
+    onToggleOverlay: () => unknown;
+    /**
+     * Called on keydown while the calendar toggle button is focused. Used to
+     * move focus into the calendar overlay on ArrowDown when it's already
+     * open, and to close it on Escape.
+     */
+    onCalendarButtonKeyDown?: (e: KeyboardEvent) => unknown;
+    /**
+     * The aria-label for the calendar toggle button.
+     */
+    calendarButtonAriaLabel?: string;
     /**
      * Called if the user press a key inside the input element.
      */
@@ -134,7 +152,6 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
         const {
             value: propValue,
             onBlur,
-            onClick,
             onFocus,
             onKeyDown,
             onChange,
@@ -147,6 +164,10 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
             testId,
             resetInvalidValueOnBlur = true,
             ["aria-label"]: ariaLabel,
+            expanded,
+            onToggleOverlay,
+            onCalendarButtonKeyDown,
+            calendarButtonAriaLabel = DEFAULT_CALENDAR_BUTTON_ARIA_LABEL,
             ...restProps
         } = props;
 
@@ -378,6 +399,20 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
         };
 
         const innerRef = React.useRef<HTMLInputElement>(null);
+        const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+        // IconButton doesn't expose an onKeyDown prop, so we listen directly
+        // on the underlying button element.
+        React.useEffect(() => {
+            const button = buttonRef.current;
+            if (!button || !onCalendarButtonKeyDown) {
+                return;
+            }
+            button.addEventListener("keydown", onCalendarButtonKeyDown);
+            return () => {
+                button.removeEventListener("keydown", onCalendarButtonKeyDown);
+            };
+        }, [onCalendarButtonKeyDown]);
 
         const handleChange = (newValue: string) => {
             setValue(newValue);
@@ -426,18 +461,16 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
                 pendingValidationRef.current = false;
                 validateInput();
             };
+            // Lets the parent (DatePicker) return focus to the calendar
+            // toggle button, e.g. after Escape closes the overlay.
+            (inputElement as any).focusCalendarButton = () => {
+                buttonRef.current?.focus();
+            };
             return inputElement;
         });
 
         return (
-            <View
-                style={styles.container}
-                onClick={(e) => {
-                    if (!restProps.disabled && onClick) {
-                        onClick(e);
-                    }
-                }}
-            >
+            <View style={styles.container}>
                 <TextField
                     ref={innerRef}
                     {...restProps}
@@ -454,14 +487,17 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
                     type="text"
                     style={styles.textField}
                 />
-                <PhosphorIcon
+                <IconButton
+                    ref={buttonRef}
                     icon={calendarIcon}
-                    color={
-                        restProps.disabled
-                            ? semanticColor.core.foreground.disabled.default
-                            : semanticColor.core.foreground.instructive.default
-                    }
                     size="small"
+                    kind="tertiary"
+                    actionType="neutral"
+                    disabled={restProps.disabled}
+                    aria-label={calendarButtonAriaLabel}
+                    aria-expanded={expanded}
+                    aria-haspopup="grid"
+                    onClick={() => onToggleOverlay()}
                     style={styles.icon}
                 />
             </View>
@@ -469,12 +505,16 @@ const DatePickerInput = React.forwardRef<HTMLInputElement, Props>(
     },
 );
 
-// Match form field left padding; right side uses the same edge spacing so
-// the icon sits 16px from the right edge (symmetric with 16px left padding).
+// Match form field left padding. Inset the button's own hit target (not
+// just its icon glyph) by this amount, so the button's edges -- which
+// become visible on hover/focus/press -- line up with the text field's
+// left inline padding at every interaction state.
 const fieldPaddingInline = sizing.size_160; // match TextField theme
-const iconSize = sizing.size_160; // PhosphorIcon size="small"
-const fieldPaddingInlineEnd =
-    fieldPaddingInline + iconSize + fieldPaddingInline; // gap + icon + gap
+const calendarButtonSize = sizing.size_320; // IconButton size="small"
+
+// Reserve enough end padding on the text field that typed text never runs
+// under the calendar button.
+const fieldPaddingInlineEnd = `calc(${fieldPaddingInline} + ${calendarButtonSize} + ${fieldPaddingInline} / 2)`;
 
 const styles = StyleSheet.create({
     container: {
@@ -483,7 +523,7 @@ const styles = StyleSheet.create({
         justifyContent: "stretch",
     },
     icon: {
-        pointerEvents: "none",
+        margin: 0,
         position: "absolute",
         insetInlineEnd: fieldPaddingInline,
     },

--- a/packages/wonder-blocks-date-picker/src/components/date-picker-overlay.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker-overlay.tsx
@@ -49,6 +49,17 @@ interface Props {
      */
     referenceElement: HTMLElement | null | undefined;
     /**
+     * The element used as the focus-trap's anchor: Tab from this element
+     * enters the overlay, and Shift+Tab out of the overlay's first element
+     * returns focus to it. Defaults to `referenceElement` if not given.
+     *
+     * This is separate from `referenceElement` because the popper should
+     * stay positioned relative to the input field, even when a different
+     * element (e.g. a toggle button) is what keyboard focus should treat as
+     * the overlay's anchor.
+     */
+    focusReferenceElement?: HTMLElement | null | undefined;
+    /**
      * Text direction: when "rtl", the overlay is positioned at the end (e.g. bottom-end)
      * so it aligns with the input in RTL layout. Defaults to "ltr" (bottom-start).
      */
@@ -74,6 +85,7 @@ interface Props {
 const DatePickerOverlay = ({
     children,
     referenceElement,
+    focusReferenceElement,
     onClose,
     dir = "ltr",
     style = DEFAULT_STYLE,
@@ -93,7 +105,7 @@ const DatePickerOverlay = ({
 
     return createPortal(
         <FocusManager
-            referenceElement={referenceElement}
+            referenceElement={focusReferenceElement ?? referenceElement}
             onEndFocused={onClose}
         >
             <Popper

--- a/packages/wonder-blocks-date-picker/src/components/date-picker-overlay.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker-overlay.tsx
@@ -14,6 +14,8 @@ import {
 
 import FocusManager from "./focus-manager";
 
+const DEFAULT_CALENDAR_GRID_REGION_ARIA_LABEL = "Date picker calendar";
+
 // Custom styles to display the calendar popup correctly.
 const DEFAULT_STYLE = {
     background: semanticColor.core.background.base.default,
@@ -55,6 +57,10 @@ interface Props {
      * Styles that will be applied to the children.
      */
     style?: StyleType;
+    /**
+     * The aria-label for the calendar grid region. Defaults to "Date picker calendar".
+     */
+    calendarGridRegionAriaLabel?: string;
 }
 
 /**
@@ -71,6 +77,7 @@ const DatePickerOverlay = ({
     onClose,
     dir = "ltr",
     style = DEFAULT_STYLE,
+    calendarGridRegionAriaLabel = DEFAULT_CALENDAR_GRID_REGION_ARIA_LABEL,
 }: Props): React.ReactElement | null => {
     if (!referenceElement) {
         return null;
@@ -130,7 +137,9 @@ const DatePickerOverlay = ({
 
                     return (
                         <div
+                            aria-label={calendarGridRegionAriaLabel}
                             ref={ref}
+                            role="region"
                             style={combinedStyles}
                             data-placement={placement}
                         >

--- a/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
@@ -1,11 +1,16 @@
-import {StyleSheet} from "aphrodite";
+import {css, StyleSheet} from "aphrodite";
 import {Temporal} from "temporal-polyfill";
 import * as React from "react";
-import {DayPicker} from "react-day-picker";
+import {DayPicker, getDefaultClassNames, UI} from "react-day-picker";
 import {enUS, type Locale} from "react-day-picker/locale";
 
-import {View, type StyleType} from "@khanacademy/wonder-blocks-core";
+import {
+    findFocusableNodes,
+    View,
+    type StyleType,
+} from "@khanacademy/wonder-blocks-core";
 import {font, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import {useCloseOnOutsideClick} from "../hooks/use-close-on-outside-click";
 import {useDatePickerModifiers} from "../hooks/use-date-picker-modifiers";
 import {useDisplayMonth} from "../hooks/use-display-month";
@@ -88,6 +93,11 @@ interface Props {
      */
     inputAriaLabel?: string;
     /**
+     * The aria-label for the calendar toggle button that opens/closes the
+     * calendar overlay. Defaults to "Show calendar".
+     */
+    calendarButtonAriaLabel?: string;
+    /**
      * The placeholder assigned to the date field
      */
     placeholder?: string;
@@ -137,6 +147,18 @@ const customRootStyle = {
     "--rdp-today-color": semanticColor.core.foreground.instructive.default,
 } as React.CSSProperties & Record<string, string>;
 
+// React Day Picker's own day buttons don't use the Wonder Blocks focus
+// style, so we add it as an extra class alongside the default one (classNames
+// entries replace, rather than merge with, the default per UI element).
+const dayButtonFocusStyles = StyleSheet.create({
+    focus: focusStyles.focus,
+});
+const dayPickerClassNames = {
+    [UI.DayButton]: `${getDefaultClassNames()[UI.DayButton]} ${css(
+        dayButtonFocusStyles.focus,
+    )}`,
+};
+
 /**
  * A UI component that allows the user to pick a date by using an input element
  * or the calendar popup exposed by `react-day-picker`.
@@ -151,6 +173,7 @@ const DatePicker = (props: Props) => {
         maxDate,
         minDate,
         inputAriaLabel,
+        calendarButtonAriaLabel,
         placeholder,
         selectedDate,
         style,
@@ -168,6 +191,12 @@ const DatePicker = (props: Props) => {
     const datePickerRef = React.useRef<HTMLElement | null>(null);
     const refWrapper = React.useRef<HTMLDivElement>(null);
     const skipNextOpenRef = React.useRef(false);
+    // True right before we programmatically move focus into the overlay
+    // (ArrowDown). A blur fired by that focus move may not reliably report
+    // `relatedTarget` (the destination), so isLeavingDropdown can't always
+    // detect that focus stayed within the widget; this flag lets
+    // handleInputBlur skip the close in that one case.
+    const movingFocusIntoOverlayRef = React.useRef(false);
 
     const {handleEscapeKeyDown} = useEscapeKeyupCapture();
     const {
@@ -240,6 +269,55 @@ const DatePicker = (props: Props) => {
         datePickerInputRef,
     ]);
 
+    // Toggle handler for the calendar button: opens/closes the overlay on
+    // explicit activation (click, or Enter/Space via keyboard), matching
+    // native date/time inputs which never open their picker on plain focus.
+    const handleToggleOverlay = React.useCallback(() => {
+        if (disabled) {
+            return;
+        }
+        if (showOverlay) {
+            close();
+        } else {
+            skipNextOpenRef.current = false; // user explicitly opening
+            open();
+        }
+    }, [disabled, showOverlay, close, open, skipNextOpenRef]);
+
+    // Moves focus back to the calendar toggle button, e.g. after Escape
+    // closes the overlay.
+    const focusCalendarButton = React.useCallback(() => {
+        (
+            datePickerInputRef.current as HTMLInputElement & {
+                focusCalendarButton?: () => void;
+            }
+        )?.focusCalendarButton?.();
+    }, [datePickerInputRef]);
+
+    // Moves focus into the calendar grid (to the selected/today day cell,
+    // via DayPicker's roving tabindex) when the overlay is already open.
+    // Prefers the grid itself over nav buttons so ArrowDown always lands on
+    // a day, not the prev/next month controls.
+    const focusIntoOverlay = React.useCallback(() => {
+        const overlayRoot = datePickerRef.current;
+        if (!overlayRoot) {
+            return;
+        }
+        const grid = overlayRoot.querySelector<HTMLElement>('[role="grid"]');
+        // DayPicker uses a roving tabindex: exactly one day (the
+        // selected/today cell) has tabindex="0" and is guaranteed enabled.
+        // findFocusableNodes would otherwise return every day button
+        // (including tabindex="-1" and disabled out-of-range ones) in DOM
+        // order, which could be a disabled day at the start of the grid.
+        const rovingTarget = grid?.querySelector<HTMLElement>('[tabindex="0"]');
+        const target =
+            rovingTarget ?? findFocusableNodes(grid ?? overlayRoot)[0];
+        if (target) {
+            movingFocusIntoOverlayRef.current = true;
+            target.focus();
+        }
+    }, [datePickerRef]);
+
     useCloseOnOutsideClick({
         refWrapper,
         datePickerRef,
@@ -295,29 +373,37 @@ const DatePicker = (props: Props) => {
     };
 
     const handleInputBlur = (e: React.FocusEvent) => {
+        if (movingFocusIntoOverlayRef.current) {
+            movingFocusIntoOverlayRef.current = false;
+            return;
+        }
         if (isLeavingDropdown(e)) {
             close();
         }
     };
 
-    // What to do when Escape closes the overlay: prevent reopen on focus, close, return focus to input.
+    // What to do when Escape closes the overlay: prevent reopen on focus, close, return focus to the calendar button.
     const onEscapeCloseOverlay = React.useCallback(() => {
-        skipNextOpenRef.current = true; // focus restored to input; don't reopen on focus
+        skipNextOpenRef.current = true; // focus restored to the button; don't reopen on focus
         close();
-        datePickerInputRef.current?.focus();
-    }, [close, skipNextOpenRef, datePickerInputRef]);
+        focusCalendarButton();
+    }, [close, skipNextOpenRef, focusCalendarButton]);
 
-    // Input keyboard: Escape closes overlay (via hook's handleEscapeKeyDown); ArrowDown opens overlay; Enter toggles overlay.
+    // Input keyboard: Escape closes overlay (via hook's handleEscapeKeyDown); ArrowDown opens overlay (or moves focus into it if already open); Enter toggles overlay.
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if (e.key === "Escape") {
             if (showOverlay) {
                 handleEscapeKeyDown(e, onEscapeCloseOverlay);
             }
         }
-        if (e.key === "ArrowDown" && !showOverlay) {
+        if (e.key === "ArrowDown") {
             e.preventDefault();
-            skipNextOpenRef.current = false; // user explicitly opening
-            open();
+            if (showOverlay) {
+                focusIntoOverlay();
+            } else {
+                skipNextOpenRef.current = false; // user explicitly opening
+                open();
+            }
         }
         if (e.key === "Enter") {
             e.preventDefault();
@@ -332,6 +418,27 @@ const DatePicker = (props: Props) => {
             }
         }
     };
+
+    // Calendar button keyboard: only a click toggles the overlay open; from
+    // the button, ArrowDown never opens it. ArrowDown only moves focus into
+    // the overlay once it's already open (via a click); Escape closes it
+    // (focus already on the button).
+    const handleCalendarButtonKeyDown = React.useCallback(
+        (e: KeyboardEvent) => {
+            if (e.key === "ArrowDown" && showOverlay) {
+                e.preventDefault();
+                focusIntoOverlay();
+            } else if (e.key === "Escape" && showOverlay) {
+                handleEscapeKeyDown(e, onEscapeCloseOverlay);
+            }
+        },
+        [
+            showOverlay,
+            focusIntoOverlay,
+            handleEscapeKeyDown,
+            onEscapeCloseOverlay,
+        ],
+    );
 
     // Wrapper for DayPicker's root so we can handle Escape when focus is inside the calendar (e.g. on nav buttons). Same Escape handler as the input.
     const RootWithEsc = React.useCallback(
@@ -392,8 +499,6 @@ const DatePicker = (props: Props) => {
         return (
             <DatePickerInput
                 onBlur={handleInputBlur}
-                onFocus={open}
-                onClick={open}
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
                 aria-label={inputAriaLabel}
@@ -409,6 +514,10 @@ const DatePicker = (props: Props) => {
                 modifiers={inputModifiers}
                 resetInvalidValueOnBlur={resetInvalidValueOnBlur}
                 testId={id && `${id}-input`}
+                expanded={showOverlay}
+                onToggleOverlay={handleToggleOverlay}
+                onCalendarButtonKeyDown={handleCalendarButtonKeyDown}
+                calendarButtonAriaLabel={calendarButtonAriaLabel}
             />
         );
     };
@@ -538,6 +647,7 @@ const DatePicker = (props: Props) => {
                             dir={dir}
                             styles={dayPickerStyles}
                             modifiersStyles={dayPickerModifiersStyles}
+                            classNames={dayPickerClassNames}
                         />
                         {maybeRenderFooter()}
                     </View>

--- a/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
@@ -299,6 +299,20 @@ const DatePicker = (props: Props) => {
         )?.focusCalendarButton?.();
     }, [datePickerInputRef]);
 
+    // The calendar toggle button's DOM node, used both so focus moving
+    // to/from it isn't treated as "leaving" the widget, and as the
+    // overlay's focus-trap anchor (see calendarButtonElement below).
+    const getCalendarButtonElement = React.useCallback(():
+        | HTMLButtonElement
+        | null
+        | undefined => {
+        return (
+            datePickerInputRef.current as HTMLInputElement & {
+                getCalendarButtonElement?: () => HTMLButtonElement | null;
+            }
+        )?.getCalendarButtonElement?.();
+    }, [datePickerInputRef]);
+
     // Moves focus into the calendar grid (to the selected/today day cell,
     // via DayPicker's roving tabindex) when the overlay is already open.
     // Prefers the grid itself over nav buttons so ArrowDown always lands on
@@ -368,11 +382,18 @@ const DatePicker = (props: Props) => {
     // True when focus is leaving the calendar overlay (e.g. tabbing out or clicking outside). Used to close on blur when focus leaves the dropdown.
     const isLeavingDropdown = (e: React.FocusEvent): boolean => {
         const dayPickerCalendar = datePickerRef.current;
-        if (!dayPickerCalendar) {
+        if (!(e.relatedTarget instanceof Node)) {
             return true;
         }
-        if (e.relatedTarget instanceof Node) {
-            return !dayPickerCalendar.contains(e.relatedTarget);
+        // Not leaving if focus moved into the calendar, or to the toggle
+        // button -- both are still part of this widget while the overlay
+        // is open (e.g. Tab from the input to the button).
+        if (dayPickerCalendar?.contains(e.relatedTarget)) {
+            return false;
+        }
+        const calendarButton = getCalendarButtonElement();
+        if (calendarButton?.contains(e.relatedTarget)) {
+            return false;
         }
         return true;
     };
@@ -394,32 +415,26 @@ const DatePicker = (props: Props) => {
         focusCalendarButton();
     }, [close, skipNextOpenRef, focusCalendarButton]);
 
-    // Input keyboard: Escape closes overlay (via hook's handleEscapeKeyDown); ArrowDown opens overlay (or moves focus into it if already open); Enter toggles overlay.
+    // Input keyboard: the calendar button is the only way to open the
+    // overlay (matching native date/time inputs, where arrow keys adjust
+    // the focused value segment rather than opening a picker). Escape and
+    // ArrowDown/Enter here only act when the overlay is already open (e.g.
+    // opened via the button while the input still has focus).
     const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (!showOverlay) {
+            return;
+        }
         if (e.key === "Escape") {
-            if (showOverlay) {
-                handleEscapeKeyDown(e, onEscapeCloseOverlay);
-            }
+            handleEscapeKeyDown(e, onEscapeCloseOverlay);
         }
         if (e.key === "ArrowDown") {
             e.preventDefault();
-            if (showOverlay) {
-                focusIntoOverlay();
-            } else {
-                skipNextOpenRef.current = false; // user explicitly opening
-                open();
-            }
+            focusIntoOverlay();
         }
         if (e.key === "Enter") {
             e.preventDefault();
-            // Toggle overlay: open if closed, close if open (respecting closeOnSelect)
-            if (showOverlay) {
-                if (closeOnSelect) {
-                    close();
-                }
-            } else {
-                skipNextOpenRef.current = false; // user explicitly opening
-                open();
+            if (closeOnSelect) {
+                close();
             }
         }
     };
@@ -628,12 +643,19 @@ const DatePicker = (props: Props) => {
         handleMonthChange,
     ]);
 
+    // The overlay is positioned relative to the input, but the calendar
+    // toggle button -- not the input -- is the focus-trap anchor: Tab from
+    // the button enters the overlay, and Shift+Tab out of its first element
+    // returns focus to the button.
+    const calendarButtonElement = getCalendarButtonElement() ?? undefined;
+
     return (
         <View style={style} ref={refWrapper}>
             {renderInput(modifiers)}
             {showOverlay && (
                 <DatePickerOverlay
                     referenceElement={datePickerInputRef.current}
+                    focusReferenceElement={calendarButtonElement}
                     onClose={close}
                     dir={dir === "rtl" ? "rtl" : "ltr"}
                     calendarGridRegionAriaLabel={calendarGridRegionAriaLabel}

--- a/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
@@ -424,7 +424,7 @@ const DatePicker = (props: Props) => {
     // the overlay once it's already open (via a click); Escape closes it
     // (focus already on the button).
     const handleCalendarButtonKeyDown = React.useCallback(
-        (e: KeyboardEvent) => {
+        (e: React.KeyboardEvent) => {
             if (e.key === "ArrowDown" && showOverlay) {
                 e.preventDefault();
                 focusIntoOverlay();

--- a/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
@@ -94,9 +94,13 @@ interface Props {
     inputAriaLabel?: string;
     /**
      * The aria-label for the calendar toggle button that opens/closes the
-     * calendar overlay. Defaults to "Show calendar".
+     * calendar overlay. Defaults to "Toggle calendar".
      */
     calendarButtonAriaLabel?: string;
+    /**
+     * The aria-label for the calendar grid region. Defaults to "Date picker calendar".
+     */
+    calendarGridRegionAriaLabel?: string;
     /**
      * The placeholder assigned to the date field
      */
@@ -174,6 +178,7 @@ const DatePicker = (props: Props) => {
         minDate,
         inputAriaLabel,
         calendarButtonAriaLabel,
+        calendarGridRegionAriaLabel,
         placeholder,
         selectedDate,
         style,
@@ -631,6 +636,7 @@ const DatePicker = (props: Props) => {
                     referenceElement={datePickerInputRef.current}
                     onClose={close}
                     dir={dir === "rtl" ? "rtl" : "ltr"}
+                    calendarGridRegionAriaLabel={calendarGridRegionAriaLabel}
                 >
                     <View ref={datePickerRef}>
                         <DayPicker

--- a/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
+++ b/packages/wonder-blocks-date-picker/src/components/date-picker.tsx
@@ -193,6 +193,7 @@ const DatePicker = (props: Props) => {
     >(selectedDate);
 
     const datePickerInputRef = React.useRef<HTMLInputElement | null>(null);
+    const calendarButtonRef = React.useRef<HTMLButtonElement | null>(null);
     const datePickerRef = React.useRef<HTMLElement | null>(null);
     const refWrapper = React.useRef<HTMLDivElement>(null);
     const skipNextOpenRef = React.useRef(false);
@@ -289,30 +290,6 @@ const DatePicker = (props: Props) => {
         }
     }, [disabled, showOverlay, close, open, skipNextOpenRef]);
 
-    // Moves focus back to the calendar toggle button, e.g. after Escape
-    // closes the overlay.
-    const focusCalendarButton = React.useCallback(() => {
-        (
-            datePickerInputRef.current as HTMLInputElement & {
-                focusCalendarButton?: () => void;
-            }
-        )?.focusCalendarButton?.();
-    }, [datePickerInputRef]);
-
-    // The calendar toggle button's DOM node, used both so focus moving
-    // to/from it isn't treated as "leaving" the widget, and as the
-    // overlay's focus-trap anchor (see calendarButtonElement below).
-    const getCalendarButtonElement = React.useCallback(():
-        | HTMLButtonElement
-        | null
-        | undefined => {
-        return (
-            datePickerInputRef.current as HTMLInputElement & {
-                getCalendarButtonElement?: () => HTMLButtonElement | null;
-            }
-        )?.getCalendarButtonElement?.();
-    }, [datePickerInputRef]);
-
     // Moves focus into the calendar grid (to the selected/today day cell,
     // via DayPicker's roving tabindex) when the overlay is already open.
     // Prefers the grid itself over nav buttons so ArrowDown always lands on
@@ -391,7 +368,7 @@ const DatePicker = (props: Props) => {
         if (dayPickerCalendar?.contains(e.relatedTarget)) {
             return false;
         }
-        const calendarButton = getCalendarButtonElement();
+        const calendarButton = calendarButtonRef.current;
         if (calendarButton?.contains(e.relatedTarget)) {
             return false;
         }
@@ -412,8 +389,8 @@ const DatePicker = (props: Props) => {
     const onEscapeCloseOverlay = React.useCallback(() => {
         skipNextOpenRef.current = true; // focus restored to the button; don't reopen on focus
         close();
-        focusCalendarButton();
-    }, [close, skipNextOpenRef, focusCalendarButton]);
+        calendarButtonRef.current?.focus();
+    }, [close, skipNextOpenRef]);
 
     // Input keyboard: the calendar button is the only way to open the
     // overlay (matching native date/time inputs, where arrow keys adjust
@@ -538,6 +515,7 @@ const DatePicker = (props: Props) => {
                 onToggleOverlay={handleToggleOverlay}
                 onCalendarButtonKeyDown={handleCalendarButtonKeyDown}
                 calendarButtonAriaLabel={calendarButtonAriaLabel}
+                calendarButtonRef={calendarButtonRef}
             />
         );
     };
@@ -643,19 +621,20 @@ const DatePicker = (props: Props) => {
         handleMonthChange,
     ]);
 
-    // The overlay is positioned relative to the input, but the calendar
-    // toggle button -- not the input -- is the focus-trap anchor: Tab from
-    // the button enters the overlay, and Shift+Tab out of its first element
-    // returns focus to the button.
-    const calendarButtonElement = getCalendarButtonElement() ?? undefined;
-
     return (
         <View style={style} ref={refWrapper}>
             {renderInput(modifiers)}
             {showOverlay && (
                 <DatePickerOverlay
                     referenceElement={datePickerInputRef.current}
-                    focusReferenceElement={calendarButtonElement}
+                    // The overlay is positioned relative to the input, but
+                    // the calendar toggle button -- not the input -- is the
+                    // focus-trap anchor: Tab from the button enters the
+                    // overlay, and Shift+Tab out of its first element
+                    // returns focus to the button.
+                    focusReferenceElement={
+                        calendarButtonRef.current ?? undefined
+                    }
                     onClose={close}
                     dir={dir === "rtl" ? "rtl" : "ltr"}
                     calendarGridRegionAriaLabel={calendarGridRegionAriaLabel}

--- a/packages/wonder-blocks-date-picker/tsconfig-build.json
+++ b/packages/wonder-blocks-date-picker/tsconfig-build.json
@@ -8,7 +8,7 @@
     "references": [
         {"path": "../wonder-blocks-core/tsconfig-build.json"},
         {"path": "../wonder-blocks-form/tsconfig-build.json"},
-        {"path": "../wonder-blocks-icon/tsconfig-build.json"},
+        {"path": "../wonder-blocks-icon-button/tsconfig-build.json"},
         {"path": "../wonder-blocks-modal/tsconfig-build.json"},
         {"path": "../wonder-blocks-styles/tsconfig-build.json"},
         {"path": "../wonder-blocks-tokens/tsconfig-build.json"},

--- a/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-unstyled.test.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/__tests__/icon-button-unstyled.test.tsx
@@ -369,6 +369,135 @@ describe("IconButtonUnstyled", () => {
             });
         });
 
+        it("calls a consumer-provided onKeyDown for keys other than Enter/Space", () => {
+            // Arrange
+            const onKeyDownMock = jest.fn();
+
+            render(
+                <IconButtonUnstyled
+                    aria-label="search"
+                    onClick={() => {}}
+                    onKeyDown={onKeyDownMock}
+                    testId="icon-button"
+                >
+                    <PhosphorIcon icon={magnifyingGlassIcon} />
+                </IconButtonUnstyled>,
+            );
+
+            // Act
+            const button = screen.getByRole("button");
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyDown(button, {key: "ArrowDown"});
+
+            // Assert
+            expect(onKeyDownMock).toHaveBeenCalledWith(
+                expect.objectContaining({key: "ArrowDown"}),
+            );
+        });
+
+        it("calls a consumer-provided onKeyUp for keys other than Enter/Space", () => {
+            // Arrange
+            const onKeyUpMock = jest.fn();
+
+            render(
+                <IconButtonUnstyled
+                    aria-label="search"
+                    onClick={() => {}}
+                    onKeyUp={onKeyUpMock}
+                    testId="icon-button"
+                >
+                    <PhosphorIcon icon={magnifyingGlassIcon} />
+                </IconButtonUnstyled>,
+            );
+
+            // Act
+            const button = screen.getByRole("button");
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyUp(button, {key: "ArrowDown"});
+
+            // Assert
+            expect(onKeyUpMock).toHaveBeenCalledWith(
+                expect.objectContaining({key: "ArrowDown"}),
+            );
+        });
+
+        it("calls a consumer-provided onKeyUp on Enter", () => {
+            // Arrange
+            const onKeyUpMock = jest.fn();
+
+            render(
+                <IconButtonUnstyled
+                    aria-label="search"
+                    onClick={() => {}}
+                    onKeyUp={onKeyUpMock}
+                    testId="icon-button"
+                >
+                    <PhosphorIcon icon={magnifyingGlassIcon} />
+                </IconButtonUnstyled>,
+            );
+
+            // Act
+            const button = screen.getByRole("button");
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyUp(button, {key: "Enter"});
+
+            // Assert
+            expect(onKeyUpMock).toHaveBeenCalledWith(
+                expect.objectContaining({key: "Enter"}),
+            );
+        });
+
+        it("still triggers onPress(true) on Enter when a consumer onKeyDown is also provided", () => {
+            // Arrange
+            const onPressMock = jest.fn();
+
+            render(
+                <IconButtonUnstyled
+                    aria-label="search"
+                    onKeyDown={() => {}}
+                    onPress={onPressMock}
+                    testId="icon-button"
+                >
+                    <PhosphorIcon icon={magnifyingGlassIcon} />
+                </IconButtonUnstyled>,
+            );
+
+            // Act
+            const button = screen.getByRole("button");
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyDown(button, {key: "Enter"});
+
+            // Assert: the consumer's handler and the button's own internal
+            // press-state handling both run -- neither clobbers the other.
+            expect(onPressMock).toHaveBeenCalledWith(true);
+        });
+
+        it("still triggers onClick via keyup on Enter when a consumer onKeyUp is also provided", () => {
+            // Arrange
+            const onClickMock = jest.fn();
+
+            render(
+                <IconButtonUnstyled
+                    aria-label="search"
+                    onClick={onClickMock}
+                    onKeyUp={() => {}}
+                    testId="icon-button"
+                >
+                    <PhosphorIcon icon={magnifyingGlassIcon} />
+                </IconButtonUnstyled>,
+            );
+
+            // Act
+            const button = screen.getByRole("button");
+            // eslint-disable-next-line testing-library/prefer-user-event
+            fireEvent.keyUp(button, {key: "Enter"});
+
+            // Assert: the consumer's handler and the button's own internal
+            // click-on-activation handling both run -- neither clobbers the
+            // other.
+            expect(onClickMock).toHaveBeenCalledTimes(1);
+        });
+
         describe("when disabled", () => {
             describe.each([
                 {key: "Enter", label: "Enter"},

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-unstyled.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-unstyled.tsx
@@ -56,6 +56,7 @@ export const IconButtonUnstyled: React.ForwardRefExoticComponent<
 
     const handleKeyDown = React.useCallback(
         (e: React.KeyboardEvent) => {
+            onKeyDownProp?.(e);
             const key = e.key;
             // Prevent default behavior for space and enter keys on
             // buttons. We let the browser handle the default behavior
@@ -66,13 +67,13 @@ export const IconButtonUnstyled: React.ForwardRefExoticComponent<
                     onPress?.(true);
                 }
             }
-            onKeyDownProp?.(e);
         },
         [disabled, href, onPress, onKeyDownProp],
     );
 
     const handleKeyUp = React.useCallback(
         (e: React.KeyboardEvent) => {
+            onKeyUpProp?.(e);
             const key = e.key;
             if (!href && (key === keys.enter || key === keys.space)) {
                 if (!disabled && restProps.onClick) {
@@ -80,7 +81,6 @@ export const IconButtonUnstyled: React.ForwardRefExoticComponent<
                 }
                 onPress?.(false);
             }
-            onKeyUpProp?.(e);
         },
         [disabled, href, onPress, restProps, onKeyUpProp],
     );

--- a/packages/wonder-blocks-icon-button/src/components/icon-button-unstyled.tsx
+++ b/packages/wonder-blocks-icon-button/src/components/icon-button-unstyled.tsx
@@ -26,16 +26,6 @@ type Props = Omit<IconButtonProps, "icon"> & {
      */
     href?: string;
     /**
-     * Listens for keydown events on the button. This is useful for preventing
-     * default behavior when the user presses the spacebar or enter key.
-     */
-    onKeyDown?: (e: React.KeyboardEvent) => unknown;
-    /**
-     * Listens for keyup events on the button. This is useful for triggering
-     * actions when the user presses the spacebar or enter key.
-     */
-    onKeyUp?: (e: React.KeyboardEvent) => unknown;
-    /**
      * When the button is in a pressing state. This is useful for keyboard
      * interactions, so we can provide visual feedback to the user.
      */
@@ -53,6 +43,8 @@ export const IconButtonUnstyled: React.ForwardRefExoticComponent<
         disabled,
         href,
         kind,
+        onKeyDown: onKeyDownProp,
+        onKeyUp: onKeyUpProp,
         onPress,
         skipClientNav,
         style,
@@ -74,8 +66,9 @@ export const IconButtonUnstyled: React.ForwardRefExoticComponent<
                     onPress?.(true);
                 }
             }
+            onKeyDownProp?.(e);
         },
-        [disabled, href, onPress],
+        [disabled, href, onPress, onKeyDownProp],
     );
 
     const handleKeyUp = React.useCallback(
@@ -87,8 +80,9 @@ export const IconButtonUnstyled: React.ForwardRefExoticComponent<
                 }
                 onPress?.(false);
             }
+            onKeyUpProp?.(e);
         },
-        [disabled, href, onPress, restProps],
+        [disabled, href, onPress, restProps, onKeyUpProp],
     );
 
     const commonProps = {

--- a/packages/wonder-blocks-icon-button/src/util/icon-button.types.ts
+++ b/packages/wonder-blocks-icon-button/src/util/icon-button.types.ts
@@ -125,6 +125,18 @@ export type BaseIconButtonProps = Partial<Omit<AriaProps, "aria-disabled">> & {
      * Function to call when the mouse down event is triggered.
      */
     onMouseDown?: (e: React.MouseEvent) => void;
+
+    /**
+     * Function to call when a key is pressed down while the button is
+     * focused. Composed with, not replacing, internal Space/Enter handling.
+     */
+    onKeyDown?: (e: React.KeyboardEvent) => unknown;
+
+    /**
+     * Function to call when a key is released while the button is focused.
+     * Composed with, not replacing, internal Space/Enter handling.
+     */
+    onKeyUp?: (e: React.KeyboardEvent) => unknown;
 };
 
 export type IconButtonProps = BaseIconButtonProps & {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -898,9 +898,9 @@ importers:
       '@khanacademy/wonder-blocks-form':
         specifier: workspace:*
         version: link:../wonder-blocks-form
-      '@khanacademy/wonder-blocks-icon':
+      '@khanacademy/wonder-blocks-icon-button':
         specifier: workspace:*
-        version: link:../wonder-blocks-icon
+        version: link:../wonder-blocks-icon-button
       '@khanacademy/wonder-blocks-modal':
         specifier: workspace:*
         version: link:../wonder-blocks-modal


### PR DESCRIPTION
## Summary:
When a `DatePicker` sits side-by-side with a native time input, the activation patterns aren't consistent with one another. This PR changes the WB `DatePicker` to use manual activation on a calendar icon button overlaying the `DatePickerInput`. It also includes a change to `IconButton` to add an `onKeyDown` prop, which was unsupported before.

Expected interaction flow:
- Tab onto DatePicker input, and tab again to reach icon button
- Enter/space toggles the date picker overlay
- When date picker overlay is open, arrow down to move focus into the date picker grid (note: except in NVDA or JAWS, where Browse Mode is the default and the virtual cursor will move to the next element outside the date picker)
- Escape or shift tab will return to the icon button
- Tab will continue past the icon button when the overlay is closed

Issue: WB-2425

## Test plan:
1. Review new comparison story: `/?path=/story/packages-datepicker-datepicker--date-and-time-comparison&globals=theme:thunderblocks`
2. Ensure date validation and locales still work (@beaesguerra's [testing doc](https://khanacademy.atlassian.net/wiki/spaces/~712020fa1796fb383b47c5a0cb43a4c0a5ca5f/pages/4571201829/Test+cases+for+date-picker+integration) may help!)
3. Ensure tests pass