### PR TITLE
Accordion: animate the first time a section is opened

### DIFF
--- a/.changeset/accordion-first-open-animation.md
+++ b/.changeset/accordion-first-open-animation.md
@@ -4,4 +4,6 @@
 
 Fix `AccordionSection` not animating the first time a section is opened when `animated` is true. The expand/collapse row sizing now lives on a single stable Aphrodite class, selected off a `data-expanded` attribute, instead of swapping between two classes. Aphrodite injects a merged class's rule lazily, so the old approach pointed the first expand at a rule that did not exist yet — `grid-template-rows` computed to `none`, which cannot interpolate, and the section snapped open. Every subsequent toggle animated correctly, which is why this only ever showed up on first open.
 
-`AccordionSection`'s wrapper element now renders a `data-expanded="true" | "false"` attribute, and its generated class name changed. Snapshot tests that render an `AccordionSection` will need regenerating. Prefer asserting expanded state via `aria-expanded` on the header rather than via the wrapper's styles.
+`AccordionSection`'s wrapper element now renders a `data-expanded="true" | "false"` attribute, so snapshot tests that render an `AccordionSection` will need regenerating.
+
+If your Jest setup inlines Aphrodite styles (`SNAPSHOT_INLINE_APHRODITE`, as Wonder Blocks' own config does), note that nested selectors are not applied on that path: a **collapsed** wrapper now reports `grid-template-rows: min-content 1fr` rather than `0fr`, so it reads as expanded in a snapshot even when it isn't. Assert expanded state via `aria-expanded` on the header, or the new `data-expanded` attribute, rather than via the wrapper's styles.

--- a/.changeset/accordion-first-open-animation.md
+++ b/.changeset/accordion-first-open-animation.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Fix `AccordionSection` not animating the first time a section is opened when `animated` is true. The expand/collapse row sizing now lives on a single stable Aphrodite class, selected off a `data-expanded` attribute, instead of swapping between two classes. Aphrodite injects a merged class's rule lazily, so the old approach pointed the first expand at a rule that did not exist yet — `grid-template-rows` computed to `none`, which cannot interpolate, and the section snapped open. Every subsequent toggle animated correctly, which is why this only ever showed up on first open.
+
+`AccordionSection`'s wrapper element now renders a `data-expanded="true" | "false"` attribute, and its generated class name changed. Snapshot tests that render an `AccordionSection` will need regenerating. Prefer asserting expanded state via `aria-expanded` on the header rather than via the wrapper's styles.

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
@@ -292,4 +292,48 @@ describe("AccordionSection", () => {
             transition: "border-radius 300ms",
         });
     });
+
+    describe("data-expanded", () => {
+        // The expanded/collapsed row sizing is selected off this attribute
+        // rather than by swapping classes, so it has to track the state.
+        test("reflects the expanded state when it changes", async () => {
+            // Arrange
+            render(
+                <AccordionSection header="Title" testId="accordion-section">
+                    Section content
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+            const wrapper = screen.getByTestId("accordion-section");
+            expect(wrapper).toHaveAttribute("data-expanded", "false");
+
+            // Act
+            await userEvent.click(screen.getByRole("button"));
+
+            // Assert
+            expect(wrapper).toHaveAttribute("data-expanded", "true");
+        });
+
+        test("is true when the section is not collapsible", () => {
+            // Arrange
+
+            // Act
+            render(
+                <AccordionSection
+                    header="Title"
+                    collapsible={false}
+                    testId="accordion-section"
+                >
+                    Section content
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(screen.getByTestId("accordion-section")).toHaveAttribute(
+                "data-expanded",
+                "true",
+            );
+        });
+    });
 });

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -312,6 +312,7 @@ const styles = StyleSheet.create({
         // injects its rule lazily, so swapping classes points the first expand
         // at a rule that doesn't exist yet: `grid-template-rows` computes to
         // `none`, which can't interpolate, and the first open snaps.
+        // Note: while collapsed this outranks a consumer `style` override.
         [':not([data-expanded="true"])' as any]: {
             gridTemplateRows: "min-content 0fr",
         },

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -249,13 +249,12 @@ const AccordionSection = React.forwardRef(function AccordionSection(
     return (
         <View
             id={sectionId}
+            // Drives the expanded/collapsed row sizing in `styles.wrapper`.
+            data-expanded={expandedState ? "true" : "false"}
             style={[
                 styles.wrapper,
                 animated && styles.wrapperWithAnimation,
                 sectionStyles.wrapper,
-                expandedState
-                    ? styles.wrapperExpanded
-                    : styles.wrapperCollapsed,
                 style,
             ]}
             testId={testId}
@@ -307,6 +306,15 @@ const styles = StyleSheet.create({
     wrapper: {
         // Use grid layout for clean animations.
         display: "grid",
+        gridTemplateRows: "min-content 1fr",
+        // The collapsed size is a selector on this same class rather than a
+        // separate one. Aphrodite merges each style list into one class and
+        // injects its rule lazily, so swapping classes points the first expand
+        // at a rule that doesn't exist yet: `grid-template-rows` computes to
+        // `none`, which can't interpolate, and the first open snaps.
+        [':not([data-expanded="true"])' as any]: {
+            gridTemplateRows: "min-content 0fr",
+        },
         // Remove the View's default relative position because it creates
         // overlap issues with the outline. In this case, it's safe to
         // remove the stacking context beacuse accordion sections are always
@@ -317,12 +325,6 @@ const styles = StyleSheet.create({
     },
     wrapperWithAnimation: {
         transition: "grid-template-rows 300ms",
-    },
-    wrapperCollapsed: {
-        gridTemplateRows: "min-content 0fr",
-    },
-    wrapperExpanded: {
-        gridTemplateRows: "min-content 1fr",
     },
     contentWrapper: {
         overflow: "hidden",


### PR DESCRIPTION
https://github.com/user-attachments/assets/1f81a4c6-f76c-49c8-8775-27596122d7d9

## Summary

The `AccordionSection` component doesn't animate the **first** time it's opened was opened — it snapped open . Every toggle after that animates smoothly as intended

## Root cause

Aphrodite merges each style list into a single generated class and injects that class's rule lazily. Swapping between `wrapperCollapsed` and `wrapperExpanded` pointed the first expand at a rule that hadn't been injected yet, so `grid-template-rows` computed to `none` — which **cannot interpolate** — and the section snapped open.

The caret icons rotation works because but `none → rotate(180deg)` *is* interpolable.

## Fix

Now there's one stable class on the wrapper. Collapsing keys off the `data-expanded` attribute. 

Both rules are injected together on first render, so no toggle ever meets a missing rule. 

Precedent: attribute selectors in `StyleSheet.create` are established WB practice (`action-styles.ts`, `cell-core.tsx`, `tab.tsx`).

## Verification

Claude took screengrabs and measured `grid-template-rows` frame by frame in the browser across the first open:

| | before | after |
|---|---|---|
| first open | `0 → 52px` in one frame | `0 → 0.65 → 3.9 → 11.3 → … → 52px` over ~300ms |

Confirmed the diagnosis before fixing: in a `rounded-per-section` accordion all sections share one merged class, so opening section 1 (snap) injected the rule that let section 2's *first* open animate. Same component, same props — which ruled out a layout-measurement cause.

Checked for all three `cornerKind`s, the collapse direction, `animated={false}` (still instant), mount-expanded (no transition on mount), and `collapsible={false}`. Collapsed content stays `visibility: hidden`; zero frames where the panel's `overflow` left `hidden`.

Jest (4/4 accordion suites, existing transition tests unchanged), typecheck, and lint all pass.

## Reviewer notes

- **The `frontend` blast radius is zero**. There are 40 render sites, but 0 snapshots render an accordion, 0 style-based assertions, 0 `data-expanded` collisions, 0 Cypress selectors. Every accordion test there asserts via `aria-expanded`. Yay!
- The collapsed value now sits behind `:not([data-expanded="true"])`, which is more specific than the base class. A consumer overriding `gridTemplateRows` via `style` would still win when expanded but be ignored when collapsed. 