### PR TITLE
🚨 [CSS Modules] Migrate Clickable to CSS Modules

### DIFF
--- a/.changeset/css-modules-clickable.md
+++ b/.changeset/css-modules-clickable.md
@@ -1,0 +1,32 @@
+---
+"@khanacademy/wonder-blocks-clickable": minor
+---
+
+Migrate `Clickable` from Aphrodite to CSS Modules (WB-2330, CSS Modules Phase 5).
+The public component API is unchanged — same props, same DOM structure, and the
+same `style` / `className` overrides — so this is an internal styling refactor.
+
+- The four base rules (element reset, `cursor: pointer`, the default focus ring,
+  and the disabled state) now live in `clickable.module.css` and are composed as
+  class-name strings through the existing `style` prop, which
+  `processStyleList` routes to `className`. They reference the same `--wb-*`
+  token variables the Aphrodite version read from, so theming (default /
+  thunderblocks / syl-dark) is unchanged.
+- All four rules are emitted into the nested layer `shared.reset` rather than as
+  unlayered Aphrodite. `Clickable`'s styles are base defaults that consumers
+  (`Cell`, `Pill`, `AccordionSectionHeader`, …) are expected to override, and
+  Aphrodite gave them that precedence by putting the caller's `style` prop last
+  in the array. Because rules directly in a layer outrank that layer's named
+  sub-layers, a consumer's own component styles now win regardless of the order
+  the bundler emits the two stylesheets in.
+- The package now ships its bundled stylesheet at `dist/index.css`, imported
+  automatically as a side-effect of the JS entry. Standard webpack / Vite /
+  Next.js setups pick this up with no changes; SSR consumers that can't process
+  CSS imports may need a CSS loader / mock in their build.
+- Note for consumers who override Clickable styles: Aphrodite emitted these
+  rules unlayered, whereas the CSS Modules build emits them in
+  `@layer shared.reset`. Unlayered consumer CSS now wins over Clickable's own
+  styles regardless of specificity, so overrides that previously needed
+  `!important` may no longer, and stylesheets that were previously losing to
+  Clickable may now start taking effect. Overrides passed through the `style`
+  prop are unaffected — those still route through Aphrodite and continue to win.

--- a/packages/wonder-blocks-clickable/src/components/clickable.module.css
+++ b/packages/wonder-blocks-clickable/src/components/clickable.module.css
@@ -1,0 +1,99 @@
+/**
+ * Clickable styles.
+ *
+ * Source: https://gist.github.com/MoOx/9137295
+ *
+ * Cascade
+ * -------
+ * The build wraps every `*.module.css` in `@layer shared`, so this file becomes
+ * `@layer shared { @layer reset { … } }` — the sub-layer `shared.reset`, shared
+ * with `button-unstyled.module.css`. Rules directly in a layer outrank that
+ * layer's named sub-layers, so *everything* Clickable emits loses to a
+ * consumer's own component styles (which sit directly in `shared`) regardless
+ * of the order the bundler emits the two stylesheets in.
+ *
+ * That is deliberate: all four rules below are base defaults that consumers
+ * (Cell, Pill, AccordionSectionHeader, …) are expected to override. Aphrodite
+ * gave them the same precedence by putting the caller's `style` prop last in
+ * the array; the sub-layer reproduces that without depending on bundle order.
+ * Overrides passed through the `style` prop are unaffected either way — those
+ * still route through Aphrodite, which emits unlayered rules that win over any
+ * `@layer`.
+ *
+ * Within the layer every rule sits at the same specificity, so source order
+ * decides precedence. They are declared reset → link → focused → disabled,
+ * matching the order Aphrodite composed them in `getStyle`.
+ */
+
+@layer reset {
+    .reset {
+        margin: 0;
+        padding: 0;
+        border: none;
+        width: auto;
+        background: var(--wb-semanticColor-core-transparent);
+        box-sizing: border-box;
+        overflow: visible;
+        text-decoration: none;
+
+        /* Inherit font & color from ancestor. `font` is a shorthand that also
+         * resets `line-height`, so the `line-height` normalization below has
+         * to stay after it. */
+        color: inherit;
+        font: inherit;
+
+        /* Normalize `line-height`. Cannot be changed from `normal` in
+         * Firefox 4+. */
+        line-height: normal;
+
+        /* This is usually frowned upon b/c of accessibility. We expect users of
+         * Clickable to define their own focus styles. */
+        outline: none;
+
+        /* This removes the 300ms click delay on mobile browsers by indicating
+         * that "double-tap to zoom" shouldn't be used on this element. */
+        touch-action: manipulation;
+        user-select: none;
+
+        /* Corrects font smoothing for webkit */
+        -webkit-font-smoothing: inherit;
+        -moz-osx-font-smoothing: inherit;
+    }
+
+    .link {
+        cursor: pointer;
+    }
+
+    /**
+     * The default focus ring, applied only when `hideDefaultFocusRing` is unset
+     * and `ClickableBehavior` reports the element as focused. The `:focus`
+     * qualifier is carried over from the Aphrodite version unchanged.
+     */
+    .focused:focus {
+        outline: solid var(--wb-border-width-medium)
+            var(--wb-semanticColor-focus-outer);
+    }
+
+    /**
+     * Disabled. Declared last so it resets the focus ring above (both rules
+     * sit at the same specificity), and so its `color` outranks the
+     * `color: inherit` in `.reset`.
+     *
+     * `:focus-visible` follows `:focus` for the same reason: a disabled
+     * Clickable drops the programmatic focus ring but keeps the keyboard-only
+     * one.
+     */
+    .disabled {
+        cursor: not-allowed;
+        color: var(--wb-semanticColor-action-secondary-disabled-foreground);
+    }
+
+    .disabled:focus {
+        outline: none;
+    }
+
+    .disabled:focus-visible {
+        outline: solid var(--wb-border-width-medium)
+            var(--wb-semanticColor-focus-outer);
+    }
+}

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -2,12 +2,10 @@
 // This file IS the Wonder Blocks Clickable implementation — it intentionally
 // wraps addStyle("button") as its underlying DOM primitive.
 import * as React from "react";
-import {StyleSheet} from "aphrodite";
 import {Link, useInRouterContext} from "react-router-dom-v5-compat";
 
 import {addStyle} from "@khanacademy/wonder-blocks-core";
 import type {AriaProps, StyleType} from "@khanacademy/wonder-blocks-core";
-import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 import getClickableBehavior from "../util/get-clickable-behavior";
 import type {
@@ -16,6 +14,8 @@ import type {
     ExposedEventHandlers,
 } from "./clickable-behavior";
 import {isClientSideUrl} from "../util/is-client-side-url";
+
+import styles from "./clickable.module.css";
 
 type CommonProps =
     /**
@@ -334,56 +334,3 @@ const Clickable = React.forwardRef(function Clickable(
 });
 
 export default Clickable;
-
-// Source:  https://gist.github.com/MoOx/9137295
-const styles = StyleSheet.create({
-    reset: {
-        border: "none",
-        margin: 0,
-        padding: 0,
-        width: "auto",
-        overflow: "visible",
-
-        background: semanticColor.core.transparent,
-        textDecoration: "none",
-
-        /* inherit font & color from ancestor */
-        color: "inherit",
-        font: "inherit",
-
-        boxSizing: "border-box",
-        // This removes the 300ms click delay on mobile browsers by indicating that
-        // "double-tap to zoom" shouldn't be used on this element.
-        touchAction: "manipulation",
-        userSelect: "none",
-
-        // This is usual frowned upon b/c of accessibility.  We expect users of Clickable
-        // to define their own focus styles.
-        outline: "none",
-
-        /* Normalize `line-height`. Cannot be changed from `normal` in Firefox 4+. */
-        lineHeight: "normal",
-
-        /* Corrects font smoothing for webkit */
-        WebkitFontSmoothing: "inherit",
-        MozOsxFontSmoothing: "inherit",
-    },
-    link: {
-        cursor: "pointer",
-    },
-    focused: {
-        ":focus": {
-            outline: `solid ${border.width.medium} ${semanticColor.focus.outer}`,
-        },
-    },
-    disabled: {
-        color: semanticColor.action.secondary.disabled.foreground,
-        cursor: "not-allowed",
-        ":focus": {
-            outline: "none",
-        },
-        ":focus-visible": {
-            outline: `solid ${border.width.medium} ${semanticColor.focus.outer}`,
-        },
-    },
-});


### PR DESCRIPTION
Migrate `Clickable` from Aphrodite to CSS Modules (CSS Modules Phase 5 of epic WB-2120). Clickable isn't named in any wave, but it's a primitive that Wave B's `Cell` renders, so it lands first as its own PR.

Public API is unchanged — same props, same DOM, same `style` / `className` overrides. The four base rules move to a colocated `clickable.module.css` and compose as class-name strings through the existing `style` prop (`processStyleList` already routes those to `className`, so no `clsx` and no JS change). Same `--wb-*` tokens, so theming needs no plumbing.

Rules are emitted into the nested layer `shared.reset`, which reproduces the precedence Aphrodite gave by putting the caller's `style` prop last — and is what lets `Cell`'s disabled `color` beat Clickable's once Cell migrates.

**Potential impact:**

- Unlayered consumer CSS now wins over Clickable's styles regardless of specificity. Overrides that needed `!important` may no longer; stylesheets that were losing may start applying. `style`-prop overrides are unaffected.
- The package now ships `dist/index.css`, auto-imported by the JS entry — SSR consumers without a CSS loader may need a mock.
- Two declarations carried over verbatim trip WARN-level stylelint (`width: auto`, `line-height: normal`), matching the `icon.module.css` precedent. The focus ring keeps `:focus` rather than `:focus-visible` — that's a behavior change, not a migration, so it's left for a follow-up.

Issue: WB-2330

## Test plan:

Automated, all clean: `tsc --noEmit`, ESLint, stylelint (0 errors, the 2 warnings above), Jest for clickable plus every consumer package, and Storybook story tests including the pseudo-state sheets. The Rollup build was run to confirm the emitted layer nesting and the auto-injected `import "./index.css"`.

Needs a human:

1. **Chromatic is the real gate** — Clickable underpins Cell, Pill and AccordionSectionHeader. Review all three in both themes; expect zero visual change.
2. **Keyboard focus ring**, which story tests can't assert. In Storybook, tab to the trigger and confirm the outline appears, then confirm it does *not* on mouse click: [basic](http://localhost:6061/?path=/story/packages-clickable-clickable--basic), [disabled](http://localhost:6061/?path=/story/packages-clickable-clickable--disabled).
3. **The cascade change can't be tested here** — downstream app stylesheets aren't in Chromatic. Worth grepping webapp for CSS targeting Clickable-rendered elements with `!important` before this ships.

## Review plan:

1. 🚨 [`clickable.module.css`](https://github.com/Khan/wonder-blocks/pull/3199#discussion_r3917532657)
2. 🚨 [`clickable.tsx`](https://github.com/Khan/wonder-blocks/pull/3199#discussion_r3917532669)
