### PR TITLE
🚨 [CSS Modules] Migrate Cell to CSS Modules

### DIFF
--- a/.changeset/css-modules-cell.md
+++ b/.changeset/css-modules-cell.md
@@ -1,0 +1,51 @@
+---
+"@khanacademy/wonder-blocks-cell": minor
+---
+
+Migrate `CompactCell` and `DetailCell` from Aphrodite to CSS Modules (WB-2330,
+CSS Modules Phase 5 / Wave B). The public component API is unchanged — same
+props, same DOM structure, and the same `style` / `styles` / `contentStyle`
+overrides — so this is an internal styling refactor.
+
+- `cell-core.module.css`, `common.module.css` and `detail-cell.module.css`
+  replace the three Aphrodite stylesheets. They reference the same `--wb-*`
+  token variables the Aphrodite code read from, so theming (default /
+  thunderblocks / syl-dark) is unchanged.
+- Aphrodite merged the `style` array into a single generated class, so
+  precedence came from array order rather than specificity. The rules are
+  declared in that same order to reproduce it: `wrapper` → `detail` → `active`
+  → `clickable` → `disabled`, and `accessory` → `accessoryLeft` /
+  `accessoryRight` → `accessoryDisabled` → `accessoryActive`. `DetailCell`'s
+  wrapper padding is defined in `cell-core.module.css` (not
+  `detail-cell.module.css`) specifically so it is guaranteed to be emitted
+  after `.wrapper`, which sets the same properties at the same specificity.
+- The subtitle's per-theme font override and the title's `line-height` override
+  stay as React inline styles rather than becoming CSS Module classes.
+  `BodyText`'s own module sets `font-size` / `line-height` on its variant
+  classes, so as classes these overrides would compete at equal specificity
+  across two packages and the winner would depend on stylesheet emission order.
+- `width` / `height` become `inline-size` / `block-size` on the wrapper, the
+  horizontal rule and the two indicator bars. These are equivalent in every
+  writing mode Khan Academy ships (RTL locales are still `horizontal-tb`), and
+  the surrounding declarations were already logical (`inset-inline-start`,
+  `min-block-size`, `padding-block`). Two `inset-block-start` /
+  `inset-block-end` pairs also collapse to `inset-block`.
+- **One deliberate behavior change.** Aphrodite applied `accessoryActive` after
+  the consumer's `styles.rightAccessory`, so on an *active* cell the built-in
+  active colour beat a consumer-supplied `color`. That ordering was
+  inconsistent with every other slot in the component, where custom styles come
+  last. Consumer overrides now win there too. This only affects a consumer that
+  passes an Aphrodite stylesheet with a `color` to `styles.rightAccessory` on an
+  active cell — a plain style object already won before, since it became an
+  inline style.
+- The package now ships its bundled stylesheet at `dist/index.css`, imported
+  automatically as a side-effect of the JS entry. Standard webpack / Vite /
+  Next.js setups pick this up with no changes; SSR consumers that can't process
+  CSS imports may need a CSS loader / mock in their build.
+- Note for consumers who override Cell styles: Aphrodite emitted these rules
+  unlayered, whereas the CSS Modules build emits them in `@layer shared`.
+  Unlayered consumer CSS now wins over Cell's own styles regardless of
+  specificity, so overrides that previously needed `!important` may no longer,
+  and stylesheets that were previously losing to Cell may now start taking
+  effect. Overrides passed through the `style` / `styles` / `contentStyle` props
+  are unaffected — those still route through Aphrodite and continue to win.

--- a/packages/wonder-blocks-cell/src/components/detail-cell.module.css
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.module.css
@@ -1,0 +1,16 @@
+/**
+ * `DetailCell` styles.
+ *
+ * Only the subtitle colour lives here. `BodyText`'s own CSS Module sets
+ * `font-size` / `font-weight` / `line-height` but never `color`, so this rule
+ * has nothing to compete with — whereas the subtitle's per-theme font override
+ * *would* collide with those at equal specificity across two packages, which
+ * is why it stays a React inline style in `detail-cell.tsx`.
+ *
+ * `DetailCell`'s wrapper padding lives in `cell-core.module.css` (`.detail`)
+ * so that it is guaranteed to be emitted after `.wrapper`.
+ */
+
+.subtitle {
+    color: var(--wb-semanticColor-core-foreground-neutral-default);
+}

--- a/packages/wonder-blocks-cell/src/components/detail-cell.tsx
+++ b/packages/wonder-blocks-cell/src/components/detail-cell.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
-import {StyleSheet} from "aphrodite";
 
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import CellCore from "./internal/cell-core";
 
 import type {CellProps, TypographyText} from "../util/types";
 import theme from "../theme";
+
+import coreStyles from "./internal/cell-core.module.css";
+import styles from "./detail-cell.module.css";
 
 type SubtitleProps = {
     subtitle?: TypographyText;
@@ -93,7 +94,10 @@ const DetailCell = function (props: DetailCellProps): React.ReactElement {
     return (
         <CellCore
             {...coreProps}
-            innerStyle={styles.innerWrapper}
+            // This is to override the default padding of the CellCore
+            // innerWrapper. It lives in `cell-core.module.css` so it is
+            // emitted after `.wrapper`, which sets the same properties.
+            innerStyle={coreStyles.detail}
             contentStyle={{
                 gap: theme.root.layout.gap.detail,
             }}
@@ -113,16 +117,5 @@ const DetailCell = function (props: DetailCellProps): React.ReactElement {
         </CellCore>
     );
 };
-
-const styles = StyleSheet.create({
-    subtitle: {
-        color: semanticColor.core.foreground.neutral.default,
-    },
-    // This is to override the default padding of the CellCore innerWrapper.
-    innerWrapper: {
-        paddingBlock: theme.root.layout.padding.block.detail,
-        paddingInline: theme.root.layout.padding.inline.detail,
-    },
-});
 
 export default DetailCell;

--- a/packages/wonder-blocks-cell/src/components/internal/__tests__/common.test.ts
+++ b/packages/wonder-blocks-cell/src/components/internal/__tests__/common.test.ts
@@ -1,5 +1,8 @@
 import {getHorizontalRuleStyles} from "../common";
 
+// NOTE: `*.module.css` is mapped to `identity-obj-proxy` in the Jest config,
+// so a CSS Module class resolves to its own name here rather than the hashed
+// class name the bundler emits.
 describe("getHorizontalRuleStyles", () => {
     it("should get 'inset' styles as an array", () => {
         // Arrange
@@ -9,17 +12,10 @@ describe("getHorizontalRuleStyles", () => {
 
         // Assert
         // Verify that both classes are injected
-        expect(styles).toMatchObject([
-            {
-                _name: /horizontalRule/,
-            },
-            {
-                _name: /horizontalRuleInset/,
-            },
-        ]);
+        expect(styles).toEqual(["horizontalRule", "horizontalRuleInset"]);
     });
 
-    it("should get 'full-width' styles as an object", () => {
+    it("should get 'full-width' styles as a single class", () => {
         // Arrange
 
         // Act
@@ -27,9 +23,7 @@ describe("getHorizontalRuleStyles", () => {
 
         // Assert
         // Verify that only one class is injected
-        expect(styles).toMatchObject({
-            _name: /horizontalRule/,
-        });
+        expect(styles).toBe("horizontalRule");
     });
 
     it("should not inject styles with 'none'", () => {

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.module.css
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.module.css
@@ -1,0 +1,216 @@
+/**
+ * CellCore styles — the skeleton shared by `CompactCell` and `DetailCell`.
+ *
+ * Cascade
+ * -------
+ * Aphrodite merged the `style` array into a single generated class, so
+ * precedence was decided purely by array order, not specificity. The rules
+ * below are declared in that same order so source order reproduces it:
+ *
+ *   wrapper → detail → active → (horizontal rule) → clickable → disabled
+ *
+ * and, for the accessories:
+ *
+ *   accessory → accessoryLeft / accessoryRight → accessoryDisabled →
+ *   accessoryActive
+ *
+ * Everything sits directly in `@layer shared` (the build adds the wrap), so a
+ * consumer's `style` / `styles` overrides — which still route through
+ * Aphrodite and are emitted unlayered — continue to win over all of it.
+ *
+ * The horizontal-rule classes live in `common.module.css` because
+ * `getHorizontalRuleStyles` owns them. They only ever interact with this file
+ * through `::after`, and the focus rule that hides the rule out-specifies them
+ * (0,2,0 vs 0,1,0), so splitting them across files is order-independent.
+ */
+
+/**
+ * Base wrapper. Rendered as either a `<View>` or a `<Clickable>`.
+ */
+.wrapper {
+    background: var(--wb-semanticColor-core-background-base-default);
+    border-radius: var(--wb-c-cell-root-border-radius-default);
+    color: var(--wb-semanticColor-core-foreground-neutral-strong);
+    min-block-size: var(--wb-c-cell-root-sizing-minHeight);
+
+    /* Hide overflow so that if custom styling applies a border radius, the
+       left visual indicator for press/active states does not overflow */
+    overflow: hidden;
+    text-align: start;
+    inline-size: 100%;
+
+    /* layout */
+
+    /* We need to specify flex as the wrapper can be a <View> or a
+       <Clickable> component. */
+    display: flex;
+    flex: 1;
+    flex-direction: row;
+
+    /* The spacing between the left and right accessories. */
+    gap: var(--wb-c-cell-root-layout-gap-default);
+    padding-block: var(--wb-c-cell-root-layout-padding-block-default);
+    padding-inline: var(--wb-c-cell-root-layout-padding-inline-default);
+}
+
+/**
+ * `DetailCell`'s padding, passed in through the internal `innerStyle` prop.
+ * Kept here rather than in `detail-cell.module.css` so that it is guaranteed
+ * to be emitted after `.wrapper`: both rules set `padding-block` /
+ * `padding-inline` at the same specificity, so across two files the winner
+ * would depend on the order the bundler emitted them in.
+ */
+.detail {
+    padding-block: var(--wb-c-cell-root-layout-padding-block-detail);
+    padding-inline: var(--wb-c-cell-root-layout-padding-inline-detail);
+}
+
+/**
+ * Selected. Draws the left bar indicator via `::before`.
+ */
+.active {
+    background: var(--wb-semanticColor-core-background-instructive-subtle);
+    color: var(--wb-c-cell-root-color-selected-foreground);
+    cursor: default;
+    position: relative;
+}
+
+.active::before {
+    /* Styles for the left bar indicator */
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    inline-size: var(--wb-c-cell-root-border-width-selected);
+    background-color: var(--wb-c-cell-root-color-selected-border);
+}
+
+/**
+ * Pressable cell. Only applied when the cell renders a `<Clickable>`.
+ */
+.clickable:hover {
+    background: var(--wb-semanticColor-core-background-instructive-subtle);
+}
+
+.clickable:active {
+    background: var(--wb-semanticColor-core-background-instructive-subtle);
+    border-radius: var(--wb-c-cell-root-border-radius-press);
+}
+
+/* focus (only visible when using keyboard navigation) */
+.clickable:focus-visible {
+    border-radius: var(--wb-c-cell-root-border-radius-focus);
+    outline: var(--wb-border-width-medium) solid
+        var(--wb-semanticColor-focus-outer);
+    outline-offset: calc(var(--wb-c-cell-root-border-width-default) * -1);
+
+    /* We need to use a thicker box-shadow to ensure that the inner ring
+       is visible when the cell is focused. */
+    box-shadow: inset 0 0 0 calc(var(--wb-border-width-medium) * 2)
+        var(--wb-semanticColor-focus-inner);
+
+    /* To hide the internal corners of the cell. */
+    overflow: hidden;
+
+    /* To display the focus ring based on the cell's border. */
+    position: relative;
+}
+
+/* Hide the left bar indicator when focused, so the focus ring
+   doesn't overlap with it. */
+.clickable:focus-visible::after {
+    content: unset;
+}
+
+.clickable:focus-visible:active {
+    border-radius: var(--wb-c-cell-root-border-radius-focusPress);
+}
+
+/**
+ * press + enabled + not currently selected (active prop: false)
+ */
+.clickable:active[aria-disabled="false"]:not([aria-current="true"]) {
+    position: relative;
+}
+
+.clickable:active[aria-disabled="false"]:not([aria-current="true"])::before {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    inline-size: var(--wb-c-cell-root-border-width-default);
+
+    /* We use the border token as this element acts like a border
+       when the cell is pressed. */
+    background-color: var(--wb-c-cell-root-color-press-border);
+}
+
+/**
+ * Disabled. Declared after `.clickable` so each state rule resets its
+ * counterpart at matching specificity. `:focus-visible` is deliberately *not*
+ * reset — a disabled cell keeps its focus ring, since `aria-disabled` leaves
+ * the element in the tab order.
+ */
+.disabled {
+    background: var(--wb-semanticColor-core-background-base-default);
+    border-radius: var(--wb-c-cell-root-border-radius-default);
+    color: var(--wb-c-cell-root-color-disabled-foreground);
+}
+
+.disabled:hover {
+    background: var(--wb-semanticColor-core-background-base-default);
+    cursor: not-allowed;
+}
+
+.disabled:active {
+    background: var(--wb-semanticColor-core-background-base-default);
+    border-radius: var(--wb-c-cell-root-border-radius-default);
+}
+
+.disabled:focus-visible:active {
+    border-radius: var(--wb-c-cell-root-border-radius-default);
+}
+
+/**
+ * Cell contents.
+ */
+.content {
+    align-self: center;
+
+    /* Expand the content to fill the available space. */
+    flex: 1;
+    overflow-wrap: break-word;
+}
+
+/**
+ * Accessories.
+ */
+.accessory {
+    /* Use content width by default. */
+    min-inline-size: auto;
+
+    /* Horizontal alignment of the accessory. */
+    align-items: center;
+
+    /* Vertical alignment. */
+    align-self: center;
+}
+
+.accessoryLeft {
+    color: var(--wb-c-cell-accessoryLeft-color-default-foreground);
+}
+
+.accessoryRight {
+    /* The right accessory will have this color by default. Unless the
+       accessory element overrides that color internally. */
+    color: var(--wb-c-cell-accessoryRight-color-default-foreground);
+}
+
+.accessoryDisabled {
+    color: var(--wb-c-cell-accessoryRight-color-disabled-foreground);
+    opacity: 0.32;
+}
+
+.accessoryActive {
+    color: var(--wb-semanticColor-core-foreground-instructive-default);
+}

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
-import {StyleSheet} from "aphrodite";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 
-import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
-import {focusStyles} from "@khanacademy/wonder-blocks-styles";
 import {getHorizontalRuleStyles} from "./common";
 
 import type {CellProps} from "../../util/types";
-import theme from "../../theme";
+
+import styles from "./cell-core.module.css";
 
 type LeftAccessoryProps = {
     leftAccessory?: CellProps["leftAccessory"];
@@ -230,151 +228,5 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
         </View>
     );
 };
-
-const styles = StyleSheet.create({
-    wrapper: {
-        background: semanticColor.core.background.base.default,
-        borderRadius: theme.root.border.radius.default,
-        color: semanticColor.core.foreground.neutral.strong,
-        minBlockSize: theme.root.sizing.minHeight,
-        // Hide overflow so that if custom styling applies a border radius, the
-        // left visual indicator for press/active states does not overflow
-        overflow: "hidden",
-        textAlign: "start",
-        width: "100%",
-        // layout
-        // We need to specify flex as the wrapper can be a <View> or a
-        // <Clickable> component.
-        display: "flex",
-        flex: 1,
-        flexDirection: "row",
-        // The spacing between the left and right accessories.
-        gap: theme.root.layout.gap.default,
-        paddingBlock: theme.root.layout.padding.block.default,
-        paddingInline: theme.root.layout.padding.inline.default,
-    },
-
-    content: {
-        alignSelf: "center",
-        // Expand the content to fill the available space.
-        flex: 1,
-        overflowWrap: "break-word",
-    },
-
-    accessory: {
-        // Use content width by default.
-        minInlineSize: "auto",
-        // Horizontal alignment of the accessory.
-        alignItems: "center",
-        // Vertical alignment.
-        alignSelf: "center",
-    },
-
-    accessoryLeft: {
-        color: theme.accessoryLeft.color.default.foreground,
-    },
-
-    accessoryRight: {
-        // The right accessory will have this color by default. Unless the
-        // accessory element overrides that color internally.
-        color: theme.accessoryRight.color.default.foreground,
-    },
-
-    /**
-     * States
-     */
-    clickable: {
-        /**
-         * States
-         */
-        ":hover": {
-            background: semanticColor.core.background.instructive.subtle,
-        },
-        ":active": {
-            background: semanticColor.core.background.instructive.subtle,
-            borderRadius: theme.root.border.radius.press,
-        },
-        // focus (only visible when using keyboard navigation)
-        ":focus-visible": {
-            borderRadius: theme.root.border.radius.focus,
-            outline: focusStyles.focus[":focus-visible"].outline,
-            outlineOffset: `calc(${theme.root.border.width.default} * -1)`,
-            // We need to use a thicker box-shadow to ensure that the inner ring
-            // is visible when the cell is focused.
-            boxShadow: `inset 0 0 0 calc(${border.width.medium}*2) ${semanticColor.focus.inner}`,
-            // To hide the internal corners of the cell.
-            overflow: "hidden",
-            // To display the focus ring based on the cell's border.
-            position: "relative",
-
-            // Hide the left bar indicator when focused, so the focus ring
-            // doesn't overlap with it.
-            [":after" as any]: {
-                content: "unset",
-            },
-        },
-        [":focus-visible:active" as any]: {
-            borderRadius: theme.root.border.radius.focusPress,
-        },
-        // press + enabled + not currently selected (active prop: false)
-        [":active[aria-disabled=false]:not([aria-current=true])" as any]: {
-            position: "relative",
-            ":before": {
-                content: "''",
-                position: "absolute",
-                insetBlockStart: 0,
-                insetInlineStart: 0,
-                insetBlockEnd: 0,
-                width: theme.root.border.width.default,
-                // We use the border token as this element acts like a border
-                // when the cell is pressed.
-                backgroundColor: theme.root.color.press.border,
-            },
-        },
-    },
-
-    active: {
-        background: semanticColor.core.background.instructive.subtle,
-        color: theme.root.color.selected.foreground,
-        cursor: "default",
-        position: "relative",
-        ":before": {
-            // Styles for the left bar indicator
-            content: "''",
-            position: "absolute",
-            insetBlockStart: 0,
-            insetInlineStart: 0,
-            insetBlockEnd: 0,
-            width: theme.root.border.width.selected,
-            backgroundColor: theme.root.color.selected.border,
-        },
-    },
-
-    disabled: {
-        background: semanticColor.core.background.base.default,
-        borderRadius: theme.root.border.radius.default,
-        color: theme.root.color.disabled.foreground,
-        ":hover": {
-            background: semanticColor.core.background.base.default,
-            cursor: "not-allowed",
-        },
-        ":active": {
-            background: semanticColor.core.background.base.default,
-            borderRadius: theme.root.border.radius.default,
-        },
-        [":focus-visible:active" as any]: {
-            borderRadius: theme.root.border.radius.default,
-        },
-    },
-
-    accessoryActive: {
-        color: semanticColor.core.foreground.instructive.default,
-    },
-
-    accessoryDisabled: {
-        color: theme.accessoryRight.color.disabled.foreground,
-        opacity: 0.32,
-    },
-});
 
 export default CellCore;

--- a/packages/wonder-blocks-cell/src/components/internal/common.module.css
+++ b/packages/wonder-blocks-cell/src/components/internal/common.module.css
@@ -1,0 +1,37 @@
+/**
+ * Horizontal-rule variants, selected by `getHorizontalRuleStyles`.
+ *
+ * `.horizontalRuleInset` only narrows the rule, so it must be emitted after
+ * `.horizontalRule` — the two are applied together for the `"inset"` variant
+ * and set `width` on the same `::after` at equal specificity. Keeping both in
+ * this one file makes that order deterministic.
+ *
+ * `cell-core.module.css` hides this pseudo-element while the cell is focused
+ * (`.clickable:focus-visible::after`); that rule out-specifies these (0,2,0 vs
+ * 0,1,0), so it wins regardless of which stylesheet the bundler emits first.
+ */
+
+.horizontalRule {
+    position: relative;
+}
+
+.horizontalRule::after {
+    inline-size: 100%;
+    content: "";
+    position: absolute;
+
+    /* align to the bottom of the cell */
+    inset-block-end: 0;
+
+    /* align border to the right of the cell */
+    inset-inline-end: 0;
+    block-size: var(--wb-c-cell-rule-sizing-height);
+    box-shadow: var(--wb-c-cell-rule-shadow);
+}
+
+.horizontalRuleInset::after {
+    /* Inset doesn't include the left padding of the cell. */
+    inline-size: calc(
+        100% - var(--wb-c-cell-root-layout-padding-inline-default)
+    );
+}

--- a/packages/wonder-blocks-cell/src/components/internal/common.ts
+++ b/packages/wonder-blocks-cell/src/components/internal/common.ts
@@ -1,8 +1,8 @@
-import {StyleSheet} from "aphrodite";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import theme from "../../theme";
 
 import type {HorizontalRuleVariant} from "../../util/types";
+
+import styles from "./common.module.css";
 
 /**
  * Gets the horizontalRule style based on the variant.
@@ -22,27 +22,3 @@ export const getHorizontalRuleStyles = (
             return {};
     }
 };
-
-const styles = StyleSheet.create({
-    horizontalRule: {
-        position: "relative",
-        ":after": {
-            width: "100%",
-            content: "''",
-            position: "absolute",
-            // align to the bottom of the cell
-            insetBlockEnd: 0,
-            // align border to the right of the cell
-            insetInlineEnd: 0,
-            height: theme.rule.sizing.height,
-            boxShadow: theme.rule.shadow,
-        },
-    },
-
-    horizontalRuleInset: {
-        ":after": {
-            // Inset doesn't include the left padding of the cell.
-            width: `calc(100% - ${theme.root.layout.padding.inline.default})`,
-        },
-    },
-});


### PR DESCRIPTION
> Stacked on #3199 (Clickable) — review that first; this PR's base is `WB-2330-clickable`.

Migrate `CompactCell` and `DetailCell` from Aphrodite to CSS Modules (Phase 5 / Wave B of epic WB-2120). Stacked on #3199 because `CellCore` renders a `<Clickable>`, whose styles had to move into the `shared.reset` sub-layer first so Cell's own rules outrank them.

Public API is unchanged — same props, DOM and `style` / `styles` / `contentStyle` overrides. Three Aphrodite stylesheets become `cell-core.module.css`, `common.module.css` and `detail-cell.module.css`, referencing the same `--wb-*` tokens, so theming needs no plumbing.

**Ordering is the whole problem here.** Aphrodite merged the `style` array into one generated class, so precedence came from array order and specificity never entered into it. The CSS is declared in that same order so source order reproduces it. Two consequences:

- `DetailCell`'s wrapper padding lives in `cell-core.module.css` (as `.detail`), not `detail-cell.module.css`, so it's *guaranteed* to be emitted after `.wrapper`. Both set padding at equal specificity; across two files the winner would depend on bundler emission order.
- The horizontal-rule classes do live in a separate file, which is only safe because their one cross-file interaction is resolved by specificity, not order: `.clickable:focus-visible::after` (0,2,0) hides `.horizontalRule::after` (0,1,0).

The subtitle's per-theme font override and the title's `line-height` stay as React inline styles — `BodyText`'s own CSS Module sets those on its variant classes, so as classes they'd compete at equal specificity across packages. Inline, they keep winning unconditionally, exactly as today.

`width` / `height` become `inline-size` / `block-size`, and two `inset-block-start` / `-end` pairs collapse to `inset-block` (that longhand collapse was a stylelint *error*, not a warning). Equivalent in every writing mode KA ships. Net effect: this package lints with zero stylelint warnings, unlike #3199.

Issue: WB-2330

## Test plan:

Automated, all clean: `tsc --noEmit`, ESLint, stylelint (zero errors *and* warnings), all 4 Jest suites, and the Storybook story tests — StateSheet and Scenarios for both cells, the three custom-style stories that exercise the consumer-override path, and the active / disabled / horizontal-rule stories. The Rollup build was run and `dist/index.css` inspected to confirm the emitted selector order.

Needs a human:

1. **Chromatic is the real gate.** Both cells, both themes; expect zero visual change. Focus on the two pseudo-element indicators (selected left bar, press bar) and the horizontal rule in its `inset` / `full-width` / `none` variants — those are the rules whose ordering was reasoned about rather than mechanically translated.
2. **RTL spot-check**, since `width` → `inline-size` touched the rule and both bars. Bars should stay on the inline-start edge; the inset rule should still exclude the inline-start padding.
3. **One deliberate behavior change** (also in the changeset): an active cell's built-in right-accessory colour no longer beats a consumer-supplied `color`. Confirm you agree — I can restore the old ordering with a specificity bump if you'd rather keep bug-for-bug parity.
4. **Downstream override audit.** As with #3199, unlayered consumer CSS now wins over Cell's styles. Worth grepping webapp for CSS targeting Cell before this ships.

## Review plan:

1. 🚨 [`cell-core.module.css`](https://github.com/Khan/wonder-blocks/pull/3200#discussion_r3918183691)
2. ⚠️ [`common.module.css`](https://github.com/Khan/wonder-blocks/pull/3200#discussion_r3918183697)
3. ⚠️ [`detail-cell.tsx`](https://github.com/Khan/wonder-blocks/pull/3200#discussion_r3918183706)
4. ⚠️ [`common.test.ts`](https://github.com/Khan/wonder-blocks/pull/3200#discussion_r3918183708)
