### PR TITLE
Update graphics role background tokens to use the 60 palette value

### DIFF
--- a/.changeset/role-background-60.md
+++ b/.changeset/role-background-60.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-tokens": patch
+---
+
+Update graphics role background tokens (administrator, parent, teacher) to use the `60` palette value for consistency across roles

--- a/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
+++ b/packages/wonder-blocks-tokens/src/build/__tests__/__snapshots__/generate-token-docs.test.ts.snap
@@ -375,13 +375,13 @@ import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 | \`semanticColor.graphics.progress.complete.foreground.strong\` | \`--wb-semanticColor-graphics-progress-complete-foreground-strong\` | \`#2C5037\` | \`#2C5037\` | \`#2C5037\` |
 | \`semanticColor.graphics.role.all.current.background\` | \`--wb-semanticColor-graphics-role-all-current-background\` | \`#F8F9FB\` | \`#F8F9FB\` | \`#151521\` |
 | \`semanticColor.graphics.role.all.current.foreground\` | \`--wb-semanticColor-graphics-role-all-current-foreground\` | \`#EBF1FD\` | \`#EBF1FD\` | \`#222149\` |
-| \`semanticColor.graphics.role.administrator.background\` | \`--wb-semanticColor-graphics-role-administrator-background\` | \`#CCE9FE\` | \`#CCE9FE\` | \`#1D3F58\` |
+| \`semanticColor.graphics.role.administrator.background\` | \`--wb-semanticColor-graphics-role-administrator-background\` | \`#A9DAFD\` | \`#A9DAFD\` | \`#1D3F58\` |
 | \`semanticColor.graphics.role.administrator.foreground\` | \`--wb-semanticColor-graphics-role-administrator-foreground\` | \`#57BAFD\` | \`#57BAFD\` | \`#20628F\` |
 | \`semanticColor.graphics.role.learner.background\` | \`--wb-semanticColor-graphics-role-learner-background\` | \`#FEBFB1\` | \`#FEBFB1\` | \`#672912\` |
 | \`semanticColor.graphics.role.learner.foreground\` | \`--wb-semanticColor-graphics-role-learner-foreground\` | \`#F8551A\` | \`#F8551A\` | \`#983C1A\` |
-| \`semanticColor.graphics.role.parent.background\` | \`--wb-semanticColor-graphics-role-parent-background\` | \`#D5F3D5\` | \`#D5F3D5\` | \`#24432D\` |
+| \`semanticColor.graphics.role.parent.background\` | \`--wb-semanticColor-graphics-role-parent-background\` | \`#BCEBBB\` | \`#BCEBBB\` | \`#24432D\` |
 | \`semanticColor.graphics.role.parent.foreground\` | \`--wb-semanticColor-graphics-role-parent-foreground\` | \`#72BB82\` | \`#72BB82\` | \`#2C5037\` |
-| \`semanticColor.graphics.role.teacher.background\` | \`--wb-semanticColor-graphics-role-teacher-background\` | \`#FDD673\` | \`#FDD673\` | \`#5F4500\` |
+| \`semanticColor.graphics.role.teacher.background\` | \`--wb-semanticColor-graphics-role-teacher-background\` | \`#FEE7AD\` | \`#FEE7AD\` | \`#5F4500\` |
 | \`semanticColor.graphics.role.teacher.foreground\` | \`--wb-semanticColor-graphics-role-teacher-foreground\` | \`#FCB706\` | \`#FCB706\` | \`#966B00\` |
 | \`semanticColor.graphics.streaks.background.subtle\` | \`--wb-semanticColor-graphics-streaks-background-subtle\` | \`#FEE9E5\` | \`#FEE9E5\` | \`#3E1F19\` |
 | \`semanticColor.graphics.streaks.background.default\` | \`--wb-semanticColor-graphics-streaks-background-default\` | \`#FEDFD8\` | \`#FEDFD8\` | \`#672912\` |

--- a/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
+++ b/packages/wonder-blocks-tokens/src/theme/semantic/semantic-color.ts
@@ -305,7 +305,7 @@ const graphics = {
             },
         },
         administrator: {
-            background: graphicsPalette.cyan_70,
+            background: graphicsPalette.cyan_60,
             foreground: graphicsPalette.cyan_40,
         },
         learner: {
@@ -313,11 +313,11 @@ const graphics = {
             foreground: graphicsPalette.orange_30,
         },
         parent: {
-            background: graphicsPalette.green_70,
+            background: graphicsPalette.green_60,
             foreground: graphicsPalette.green_40,
         },
         teacher: {
-            background: graphicsPalette.yellow_50,
+            background: graphicsPalette.yellow_60,
             foreground: graphicsPalette.yellow_30,
         },
     },


### PR DESCRIPTION
Set the administrator, parent, and teacher role background tokens to the `60` value of their respective palette colors (cyan, green, yellow) so all role backgrounds use a consistent palette step. Learner was already at orange_60. Dark-theme values are unchanged.


Claude-Session: https://claude.ai/code/session_01LVrAjVRSb6p3g8ePtBriM6