### PR TITLE
🚨 [CSS Modules] Migrate LabeledField to CSS Modules

### DIFF
--- a/.changeset/css-modules-phase-5-labeled-field.md
+++ b/.changeset/css-modules-phase-5-labeled-field.md
@@ -1,0 +1,34 @@
+---
+"@khanacademy/wonder-blocks-labeled-field": minor
+---
+
+Migrate `LabeledField` from Aphrodite to CSS Modules (WB-2332, CSS Modules
+Phase 5 / Wave D). The public component API is unchanged — same props, same DOM
+structure, and the same `styles.root` / `styles.label` / `styles.contextLabel` /
+`styles.description` / `styles.error` / `styles.readOnlyMessage` /
+`styles.additionalHelperMessage` overrides — so this is an internal styling
+refactor.
+
+- Styling now lives in `labeled-field.module.css`. Theming (default /
+  thunderblocks / syl-dark) is unchanged: the module reads the same
+  `--wb-c-labeled-field-*` variables that `build:css` already emits from
+  `src/theme/*`, switched on `[data-wb-theme]`.
+- The `error` and `disabled` axes stay in JS as conditional class names — both
+  are derived from the field child's props rather than from the element's own
+  DOM state — and are composed through the existing `style` prop.
+- Every rule in the module is nested inside a `root` marker class, now applied
+  to the outermost element. The component overrides `font-size`, `line-height`,
+  `font-weight` and `flex-direction` on `BodyText`, `View` and `PhosphorIcon`,
+  which ship single-class rules in the same `@layer shared`; Aphrodite's
+  `!important` used to settle that contest, and the compound selector makes the
+  outcome depend on specificity instead of stylesheet load order.
+- This is the first Wonder Blocks stylesheet to use CSS nesting, and nothing in
+  the build flattens it, so `dist/index.css` now ships native nesting. Every
+  nested selector is written with an explicit `&`, which puts the browser floor
+  at Chrome 112 / Safari 16.5 / Firefox 117.
+- The package now ships `dist/index.css` (auto side-effect import) and exposes
+  it via the new `@khanacademy/wonder-blocks-labeled-field/css` subpath.
+- Packaging fixes that come with the migration: `aphrodite` is dropped from
+  `peerDependencies` (the package no longer imports it), and
+  `@khanacademy/wonder-blocks-icon` is added to `dependencies` — it was already
+  imported for the error and read-only icons but missing from the manifest.

--- a/packages/wonder-blocks-labeled-field/package.json
+++ b/packages/wonder-blocks-labeled-field/package.json
@@ -19,12 +19,16 @@
   "main": "dist/index.js",
   "module": "dist/es/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
       "import": "./dist/es/index.js",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./css": "./dist/index.css",
     "./styles.css": "./dist/css/vars.css"
   },
   "scripts": {
@@ -34,13 +38,12 @@
   },
   "dependencies": {
     "@khanacademy/wonder-blocks-core": "workspace:*",
-    "@khanacademy/wonder-blocks-layout": "workspace:*",
+    "@khanacademy/wonder-blocks-icon": "workspace:*",
     "@khanacademy/wonder-blocks-tokens": "workspace:*",
     "@khanacademy/wonder-blocks-typography": "workspace:*"
   },
   "peerDependencies": {
     "@phosphor-icons/core": "catalog:",
-    "aphrodite": "catalog:",
     "react": "catalog:"
   },
   "devDependencies": {

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.module.css
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.module.css
@@ -1,0 +1,171 @@
+/**
+ * LabeledField styles
+ *
+ * Theming
+ * -------
+ * Every value that differs between the default, thunderblocks and syl-dark
+ * themes is already emitted as a `--wb-c-labeled-field-*` custom property by
+ * `build:css` (from `src/theme/{default,thunderblocks,syl-dark}.ts` into
+ * `dist/css/vars.css`, switched on `[data-wb-theme]`), so the rules below read
+ * those variables directly instead of importing the `theme` object in JS.
+ * Values that never varied by theme are written as the plain `--wb-*` token
+ * they resolved to.
+ *
+ * Specificity
+ * -----------
+ * Every rule is nested inside `.root` — the marker class on the outermost
+ * element, which carries no declarations of its own — for two reasons:
+ *
+ * 1. `BodyText` (`.mediumMedium`, `.smallSemi`, …), `View` (`.default`) and
+ *    `PhosphorIcon` (`.small`) ship single-class rules in the same
+ *    `@layer shared`, and this component's job is to override several of the
+ *    properties they set (`font-size`, `line-height`, `font-weight`,
+ *    `flex-direction`). Aphrodite's `!important` used to settle that contest;
+ *    at equal specificity the winner would instead come down to the order the
+ *    packages' stylesheets happen to load in, so the compound selector makes
+ *    the outcome depend on specificity.
+ * 2. It puts every rule below at the same specificity, so source order alone
+ *    decides precedence between them. `&` takes the specificity of its parent
+ *    (`:is(.root)`, or (0,1,0) here), so each nested rule lands at (0,2,0) —
+ *    identical to spelling out `.root .label`.
+ *
+ * Nesting is emitted as-is: nothing in the PostCSS chain
+ * (`postcss.config.cjs`) flattens it, so this ships as native CSS nesting.
+ * Each nested selector is written with an explicit `&` rather than relying on
+ * relaxed parsing of a bare class, which lowers the browser floor to
+ * Chrome 112 / Safari 16.5 / Firefox 117.
+ *
+ * Source order mirrors the order the class names used to appear in the
+ * Aphrodite `style` arrays (where the last entry won): base rules first, then
+ * the disabled and error modifiers that override them. The order between
+ * `.helperText` → `.disabledHelperText` → `.contextLabelWithError` and
+ * `.label` → `.labelWithError` → `.disabledLabel` is load-bearing.
+ *
+ * The `error` and `disabled` axes are selected by conditional class names
+ * composed through the existing `style` prop (Wonder Blocks' `processStyleList`
+ * routes class-name strings to `className`), not by pseudo-classes: both are
+ * derived from the *field child's* props (`field.props.error` /
+ * `field.props.disabled`) rather than from this element's own DOM state.
+ *
+ * The build wraps the rule below in `@layer shared { … }` via the
+ * wrap-in-layer PostCSS plugin.
+ */
+
+.root {
+    /* The label and the context label sit on one row, pushed to opposite
+     * edges. */
+    & .labelContainer {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        gap: var(--wb-c-labeled-field-root-layout-spacingBetweenHelperText);
+    }
+
+    & .label {
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
+        overflow-wrap: break-word;
+
+        /* This enables the wrapping behaviour */
+        min-inline-size: var(--wb-sizing-size_0);
+    }
+
+    & .labelWithDescription {
+        padding-block-end: var(
+            --wb-c-labeled-field-root-layout-paddingBlockEnd-labelWithDescription
+        );
+    }
+
+    & .labelWithNoDescription {
+        padding-block-end: var(
+            --wb-c-labeled-field-root-layout-paddingBlockEnd-labelWithNoDescription
+        );
+    }
+
+    /* Shared by the context label, the description, the read only message, the
+     * error message and the additional helper message. */
+    & .helperText {
+        color: var(--wb-c-labeled-field-helperText-color-default-foreground);
+        font-size: var(--wb-c-labeled-field-helperText-font-size);
+        line-height: var(--wb-c-labeled-field-helperText-font-lineHeight);
+        overflow-wrap: break-word;
+
+        /* This enables the wrapping behaviour on the helper message */
+        min-inline-size: var(--wb-sizing-size_0);
+    }
+
+    & .contextLabel {
+        /* Make the line height match the label so the context label is
+         * aligned with the label */
+        line-height: var(--wb-font-body-lineHeight-medium);
+
+        /* At most, the context label will take up 30% of the width of the
+         * LabeledField */
+        max-inline-size: 30%;
+
+        /* This prevents the context label from shrinking to fit the label */
+        flex-shrink: 0;
+    }
+
+    /* The error and read only messages pair an icon with their text. */
+    & .helperTextWithIcon {
+        flex-direction: row;
+        gap: var(--wb-c-labeled-field-helperText-layout-gap);
+    }
+
+    & .spacingAboveHelperText {
+        padding-block-start: var(
+            --wb-c-labeled-field-root-layout-spacingBetweenHelperText
+        );
+    }
+
+    & .spacingBelowHelperText {
+        padding-block-end: var(
+            --wb-c-labeled-field-root-layout-spacingBetweenHelperText
+        );
+    }
+
+    /* Disabled and error modifiers. Declared after the base rules they
+     * override — see the specificity note above. */
+    & .disabledHelperText {
+        color: var(--wb-c-labeled-field-helperText-color-disabled-foreground);
+    }
+
+    & .contextLabelWithError {
+        color: var(--wb-c-labeled-field-contextLabel-color-error-foreground);
+        font-weight: var(--wb-c-labeled-field-error-font-weight);
+    }
+
+    & .labelWithError {
+        color: var(--wb-c-labeled-field-label-color-error-foreground);
+        font-weight: var(--wb-c-labeled-field-error-font-weight);
+    }
+
+    & .disabledLabel {
+        color: var(--wb-c-labeled-field-label-color-disabled-foreground);
+    }
+
+    & .errorIcon {
+        /* This vertically aligns the icon with the text */
+        margin-block-start: var(--wb-sizing-size_010);
+    }
+
+    & .errorMessage {
+        font-weight: var(--wb-c-labeled-field-error-font-weight);
+
+        /* This aligns the helper text with the icon */
+        margin-block-start: var(
+            --wb-c-labeled-field-error-layout-marginBlockStart
+        );
+    }
+
+    /* Applied to both the error icon and the error message. `PhosphorIcon`
+     * masks its glyph with `background-color: currentColor`, so setting
+     * `color` here tints the icon as well as the text. */
+    & .error {
+        color: var(--wb-semanticColor-core-foreground-critical-default);
+    }
+
+    & .readOnlyIcon {
+        color: var(--wb-semanticColor-core-foreground-neutral-subtle);
+    }
+}

--- a/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
+++ b/packages/wonder-blocks-labeled-field/src/components/labeled-field.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
-import {StyleSheet} from "aphrodite";
 import WarningCircle from "@phosphor-icons/core/bold/warning-circle-bold.svg";
 import LockIcon from "@phosphor-icons/core/bold/lock-bold.svg";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {View, StyleType} from "@khanacademy/wonder-blocks-core";
-import {font, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import theme from "../theme";
+import styles from "./labeled-field.module.css";
 
 type Props = {
     /**
@@ -289,7 +287,9 @@ export default function LabeledField(props: Props) {
                 <PhosphorIcon
                     icon={LockIcon}
                     aria-label={labels.readOnlyIconAriaLabel}
-                    color={semanticColor.core.foreground.neutral.subtle}
+                    // The icon masks its glyph with `currentColor`, so the
+                    // colour is set by the `readOnlyIcon` class.
+                    style={styles.readOnlyIcon}
                 />
                 <BodyText style={styles.helperText}>{readOnlyMessage}</BodyText>
             </View>
@@ -319,7 +319,11 @@ export default function LabeledField(props: Props) {
     }
 
     return (
-        <View style={stylesProp?.root}>
+        // The `root` class carries no styling of its own — every rule in the
+        // module is qualified with it so this component's styles outrank the
+        // single-class rules that `BodyText`, `View` and `PhosphorIcon` ship in
+        // the same `@layer shared`. See `labeled-field.module.css`.
+        <View style={[styles.root, stylesProp?.root]}>
             {renderLabelAndContextLabel()}
             {maybeRenderDescription()}
             {renderField()}
@@ -329,76 +333,3 @@ export default function LabeledField(props: Props) {
         </View>
     );
 }
-
-const styles = StyleSheet.create({
-    labelContainer: {
-        display: "flex",
-        flexDirection: "row",
-        justifyContent: "space-between",
-        gap: theme.root.layout.spacingBetweenHelperText,
-    },
-    label: {
-        color: semanticColor.core.foreground.neutral.strong,
-        overflowWrap: "break-word",
-        minInlineSize: sizing.size_0, // This enables the wrapping behaviour
-    },
-    contextLabel: {
-        // Make the line height match the label so the context label is aligned
-        // with the label
-        lineHeight: font.body.lineHeight.medium,
-        // At most, the context label will take up 30% of the width of the
-        // LabeledField
-        maxInlineSize: "30%",
-        // This prevents the context label from shrinking to fit the label
-        flexShrink: 0,
-    },
-    labelWithError: {
-        color: theme.label.color.error.foreground,
-        fontWeight: theme.error.font.weight,
-    },
-    contextLabelWithError: {
-        color: theme.contextLabel.color.error.foreground,
-        fontWeight: theme.error.font.weight,
-    },
-    disabledLabel: {
-        color: theme.label.color.disabled.foreground,
-    },
-    labelWithDescription: {
-        paddingBlockEnd: theme.root.layout.paddingBlockEnd.labelWithDescription,
-    },
-    labelWithNoDescription: {
-        paddingBlockEnd:
-            theme.root.layout.paddingBlockEnd.labelWithNoDescription,
-    },
-    helperTextWithIcon: {
-        flexDirection: "row",
-        gap: theme.helperText.layout.gap,
-    },
-    spacingAboveHelperText: {
-        paddingBlockStart: theme.root.layout.spacingBetweenHelperText,
-    },
-    spacingBelowHelperText: {
-        paddingBlockEnd: theme.root.layout.spacingBetweenHelperText,
-    },
-    helperText: {
-        color: theme.helperText.color.default.foreground,
-        fontSize: theme.helperText.font.size,
-        lineHeight: theme.helperText.font.lineHeight,
-        minInlineSize: sizing.size_0, // This enables the wrapping behaviour on the helper message
-        overflowWrap: "break-word",
-    },
-    disabledHelperText: {
-        color: theme.helperText.color.disabled.foreground,
-    },
-    error: {
-        color: semanticColor.core.foreground.critical.default,
-    },
-    errorIcon: {
-        marginBlockStart: sizing.size_010, // This vertically aligns the icon with the text
-    },
-    errorMessage: {
-        fontWeight: theme.error.font.weight,
-        // This aligns the helper text with the icon
-        marginBlockStart: theme.error.layout.marginBlockStart,
-    },
-});

--- a/packages/wonder-blocks-labeled-field/tsconfig-build.json
+++ b/packages/wonder-blocks-labeled-field/tsconfig-build.json
@@ -7,7 +7,7 @@
   },
   "references": [
       {"path": "../wonder-blocks-core/tsconfig-build.json"},
-      {"path": "../wonder-blocks-layout/tsconfig-build.json"},
+      {"path": "../wonder-blocks-icon/tsconfig-build.json"},
       {"path": "../wonder-blocks-tokens/tsconfig-build.json"},
       {"path": "../wonder-blocks-typography/tsconfig-build.json"},
       {"path": "../wonder-blocks-form/tsconfig-build.json"},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1195,9 +1195,9 @@ importers:
       '@khanacademy/wonder-blocks-core':
         specifier: workspace:*
         version: link:../wonder-blocks-core
-      '@khanacademy/wonder-blocks-layout':
+      '@khanacademy/wonder-blocks-icon':
         specifier: workspace:*
-        version: link:../wonder-blocks-layout
+        version: link:../wonder-blocks-icon
       '@khanacademy/wonder-blocks-tokens':
         specifier: workspace:*
         version: link:../wonder-blocks-tokens
@@ -1207,9 +1207,6 @@ importers:
       '@phosphor-icons/core':
         specifier: 'catalog:'
         version: 2.1.1
-      aphrodite:
-        specifier: 'catalog:'
-        version: 1.2.5
       react:
         specifier: 'catalog:'
         version: 18.2.0


### PR DESCRIPTION
Migrate `LabeledField` from Aphrodite to CSS Modules — first component of Phase 5 / Wave D. Public API unchanged: same props, DOM structure, and `styles.*` overrides.

- **Specificity:** every rule is nested inside a new `root` marker class. `BodyText`, `View` and `PhosphorIcon` ship single-class rules in the same `@layer shared`, and this component overrides properties they set (`font-size`, `line-height`, `font-weight`, `flex-direction`). Aphrodite's `!important` used to settle that; the qualifier makes it depend on specificity rather than stylesheet load order.
- **State axes stay in JS.** `error` / `disabled` come from the *field child's* props, not this element's DOM state, so there's nothing for CSS to select on.
- **Theming untouched** — the module reads the same `--wb-c-labeled-field-*` vars `build:css` already emits from `src/theme/*`.
- **First WB stylesheet to use CSS nesting.** Nothing flattens it, so `dist/index.css` ships native nesting. Explicit `&` prefixes put the floor at Chrome 112 / Safari 16.5 / Firefox 117.
- **Packaging:** adds `sideEffects` + a `./css` subpath; adds the missing `wonder-blocks-icon` dep; drops the now-unused `aphrodite` peerDep.

Issue: WB-2332

## Test plan:

Automated (all green): labeled-field + dropdown single/multi-select jest suites, `typecheck`, `build:types`, eslint, stylelint, prettier, and a rollup build emitting all 18 `wb-labeled-field-*` selectors into `dist/index.css`. `gen:css-types` output is byte-identical before/after nesting.

Manual (visual — not covered above):

1. Review the Chromatic diff. **Target is zero diff** — every value maps 1:1 and no spacing was refactored.
2. Spot-check in default / thunderblocks / syl-dark at http://localhost:6061/?path=/docs/packages-labeledfield--docs: error state, disabled state, read-only (lock icon colour moved from a `color` prop to inherited `currentColor`), the `CustomStyles` story, and a long label + long context label for wrapping.
3. Confirm nesting renders in each supported browser — the one thing CI can't verify.

## Review plan:

Please review these risky changes

1. 🚨 [`labeled-field.module.css`](https://github.com/Khan/wonder-blocks/pull/3203#discussion_r3927985344)
2. ⚠️ [`package.json`](https://github.com/Khan/wonder-blocks/pull/3203#discussion_r3927985547)
3. ⚠️ [`labeled-field.tsx`](https://github.com/Khan/wonder-blocks/pull/3203#discussion_r3927985693)

### Common patterns:

**1 File:** `StyleSheet.create` → colocated `*.module.css`, with class-name strings composed through the WB `style` prop (`processStyleList` routes them to `className`). Conditional state entries in each array are untouched.

```tsx
// Before
const styles = StyleSheet.create({helperText: {color: theme.helperText.color.default.foreground}});
// After
import styles from "./labeled-field.module.css";
// .root { & .helperText { color: var(--wb-c-labeled-field-helperText-color-default-foreground); } }
```