### PR TITLE
[WB-2434] Catch headings passed to AccordionSection's header prop

### DIFF
--- a/.changeset/wb-2434-accordion-header-heading.md
+++ b/.changeset/wb-2434-accordion-header-heading.md
@@ -1,0 +1,28 @@
+---
+"@khanacademy/eslint-plugin-wonder-blocks": major
+"@khanacademy/wonder-blocks-accordion": patch
+---
+
+Warn when a heading is passed to `AccordionSection`'s `header` prop
+
+`AccordionSection` wraps its trigger in a heading element containing a
+`<button>`, and the `header` content renders inside that button. A heading in
+there produces `h2 > button > h3`, which is invalid HTML — a `<button>` may only
+contain phrasing content, and nested headings give screen reader users a
+duplicated heading structure. Nothing caught this before.
+
+- **eslint-plugin-wonder-blocks:** new `no-heading-in-accordion-header` rule,
+  enabled at `error` in the `recommended` config. It flags `<h1>`–`<h6>`, Wonder
+  Blocks `Heading` components, and `role="heading"` anywhere inside a literal
+  `header` prop on `AccordionSection`. This is a major bump because projects
+  extending `recommended` will see new lint errors.
+- **wonder-blocks-accordion:** `AccordionSection` now logs a development-only
+  console warning when the rendered header turns out to contain a heading. It
+  inspects the DOM, so it also catches headings rendered inside a consumer's own
+  components, which the lint rule cannot see. It does not fire during
+  server-side rendering. The `header` prop documentation now states the
+  constraint.
+
+To set the heading level, use `AccordionSection`'s `tag` prop. For
+heading-sized text without heading semantics, use `<BodyText tag="span">` with
+the `font.heading.*` tokens.

--- a/.changeset/wb-2434-accordion-header-heading.md
+++ b/.changeset/wb-2434-accordion-header-heading.md
@@ -13,7 +13,8 @@ duplicated heading structure. Nothing caught this before.
 
 - **eslint-plugin-wonder-blocks:** new `no-heading-in-accordion-header` rule,
   enabled at `error` in the `recommended` config. It flags `<h1>`–`<h6>`, Wonder
-  Blocks `Heading` components, and `role="heading"` anywhere inside a literal
+  Blocks `Heading` components, a `tag="h1"`–`tag="h6"` on any component (e.g.
+  `<BodyText tag="h1">`), and `role="heading"` anywhere inside a literal
   `header` prop on `AccordionSection`. This is a major bump because projects
   extending `recommended` will see new lint errors.
 - **wonder-blocks-accordion:** `AccordionSection` now logs a development-only

--- a/__docs__/wonder-blocks-accordion/accessibility.mdx
+++ b/__docs__/wonder-blocks-accordion/accessibility.mdx
@@ -54,6 +54,70 @@ as [advised by W3](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/).
     -   If there are six or fewer sections, each section's content panel
         has the `role` attribute set to "region".
 
+### Don't put a heading in the `header` prop
+
+Because AccordionSection renders the heading and the button for you, whatever
+you pass to `header` ends up **inside** them:
+
+```html
+<h2>
+    <!-- from AccordionSection's `tag` prop -->
+    <button>
+        <!-- your `header` content goes here -->
+    </button>
+</h2>
+```
+
+So passing a heading — an `<h3>`, a `Heading` component, or anything with
+`role="heading"` — produces `h2 > button > h3`, which is invalid twice over:
+
+1. A `<button>` may only contain
+   [phrasing content](https://html.spec.whatwg.org/#phrasing-content), and a
+   heading element is not phrasing content.
+2. Nested headings give screen reader users a duplicated, confusing heading
+   structure.
+
+```jsx
+// ❌ Don't — this nests a heading inside the heading AccordionSection renders
+<AccordionSection header={<Heading size="medium">Section title</Heading>} />
+
+// ✅ Do — set the level with `tag`, and keep the content inline
+<AccordionSection tag="h3" header="Section title" />
+
+// ✅ Do — for custom headers, use inline typography with heading-sized tokens
+<AccordionSection
+    tag="h3"
+    header={
+        <View style={styles.header}>
+            <PhosphorIcon icon={icon} />
+            <BodyText
+                tag="span"
+                weight="bold"
+                style={{
+                    fontSize: font.heading.size.medium,
+                    lineHeight: font.heading.lineHeight.medium,
+                }}
+            >
+                Section title
+            </BodyText>
+        </View>
+    }
+/>
+```
+
+Two things help catch this:
+
+-   The
+    [`no-heading-in-accordion-header`](https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/no-heading-in-accordion-header.md)
+    lint rule flags headings written directly in the `header` prop.
+-   AccordionSection logs a development-only console warning when the rendered
+    header turns out to contain a heading. Because it inspects the DOM, it also
+    catches headings rendered inside your own components, which the lint rule
+    can't see.
+
+The runtime warning needs the DOM, so it does not fire during server-side
+rendering.
+
 ### Considerations for the User
 
 -   The accordion can be animated using the `animated` prop. However,
@@ -62,6 +126,7 @@ as [advised by W3](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/).
 -   PLEASE use AccordionSection's `tag` prop to appropriately set the
     section's heading level! It defaults to `<h2>`, but it needs to be
     set appropriately based on the page's heading structure.
+-   PLEASE don't pass a heading into the `header` prop — see above.
 
 ### References
 

--- a/__docs__/wonder-blocks-accordion/accessibility.mdx
+++ b/__docs__/wonder-blocks-accordion/accessibility.mdx
@@ -68,8 +68,9 @@ you pass to `header` ends up **inside** them:
 </h2>
 ```
 
-So passing a heading — an `<h3>`, a `Heading` component, or anything with
-`role="heading"` — produces `h2 > button > h3`, which is invalid twice over:
+So passing a heading — an `<h3>`, a `Heading` component, a `tag="h3"` on
+something like `BodyText` or `View`, or anything with `role="heading"` —
+produces `h2 > button > h3`, which is invalid twice over:
 
 1. A `<button>` may only contain
    [phrasing content](https://html.spec.whatwg.org/#phrasing-content), and a
@@ -78,8 +79,9 @@ So passing a heading — an `<h3>`, a `Heading` component, or anything with
    structure.
 
 ```jsx
-// ❌ Don't — this nests a heading inside the heading AccordionSection renders
+// ❌ Don't — these nest a heading inside the heading AccordionSection renders
 <AccordionSection header={<Heading size="medium">Section title</Heading>} />
+<AccordionSection header={<BodyText tag="h3">Section title</BodyText>} />
 
 // ✅ Do — set the level with `tag`, and keep the content inline
 <AccordionSection tag="h3" header="Section title" />

--- a/__docs__/wonder-blocks-accordion/accordion-section.argtypes.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.argtypes.tsx
@@ -26,11 +26,18 @@ export default {
     },
     header: {
         control: {type: "text"},
-        description: `The header for this section. If a string is passed in,
-            it will automatically be given Body typography from Wonder Blocks
-            Typography.`,
+        description: `The header for this section. A string is given Heading
+            typography and the standard header spacing; a React element is
+            rendered as-is.
+
+            NOTE: this content renders inside a \`<button>\` that is itself
+            wrapped in a heading, so it must not contain a heading of its own
+            (\`<h1>\`-\`<h6>\`, \`Heading\`, or \`role="heading"\`) — that is
+            invalid HTML. Use the \`tag\` prop to set the heading level, and
+            \`<BodyText tag="span">\` with \`font.heading.*\` tokens for
+            heading-sized text.`,
         table: {
-            type: {summary: "string"},
+            type: {summary: "string | ReactElement"},
         },
         type: {name: "string", required: true},
     },

--- a/__docs__/wonder-blocks-accordion/accordion-section.argtypes.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.argtypes.tsx
@@ -32,8 +32,9 @@ export default {
 
             NOTE: this content renders inside a \`<button>\` that is itself
             wrapped in a heading, so it must not contain a heading of its own
-            (\`<h1>\`-\`<h6>\`, \`Heading\`, or \`role="heading"\`) — that is
-            invalid HTML. Use the \`tag\` prop to set the heading level, and
+            (\`<h1>\`-\`<h6>\`, \`Heading\`, a \`tag="h1"\`-\`tag="h6"\` on any
+            component, or \`role="heading"\`) — that is invalid HTML. Use
+            AccordionSection's own \`tag\` prop to set the heading level, and
             \`<BodyText tag="span">\` with \`font.heading.*\` tokens for
             heading-sized text.`,
         table: {

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -202,88 +202,121 @@ Uncontrolled.parameters = {
  * in as its header. Passing in a React Element means no built in styling
  * will be applied to the header.
  *
- * The first example here shows how a DetailCell can be used as the header.
- * The second example shows how a custom header can be created - note that
- * in this example, a smaller window size will cause the header text to
- * truncate with ellipses.
+ * This example shows how a DetailCell can be used as the header.
+ *
+ * Note that the header content is rendered inside a `<button>` that
+ * AccordionSection wraps in a heading element, so it must not contain a
+ * heading of its own. See the "Custom Header Without A Nested Heading" story
+ * below.
  */
 export const ReactElementInHeader: StoryComponentType = {
     render: function Render() {
         return (
-            <View>
-                <AccordionSection
-                    header={
-                        <DetailCell
-                            title="Header for article item"
-                            leftAccessory={
-                                <PhosphorIcon
-                                    icon={IconMappings.playCircle}
-                                    size="medium"
-                                />
-                            }
-                            horizontalRule="none"
-                        />
-                    }
-                >
-                    This is the information present in the first section
-                </AccordionSection>
-                <Strut size={32} />
-                {/* The following AccordionSection is implemented
-                the same way as the CourseAccordion in the LearnableNodeSidebar
-                that can be found on Khan Academy. It should truncate the
-                text with ellipses when the window size is small.*/}
-                <AccordionSection
-                    header={
+            <AccordionSection
+                header={
+                    <DetailCell
+                        title="Header for article item"
+                        leftAccessory={
+                            <PhosphorIcon
+                                icon={IconMappings.playCircle}
+                                size="medium"
+                            />
+                        }
+                        horizontalRule="none"
+                    />
+                }
+            >
+                This is the information present in the first section
+            </AccordionSection>
+        );
+    },
+};
+
+/**
+ * AccordionSection already renders a heading element wrapping the header
+ * `<button>`, so anything passed to `header` ends up inside both of them.
+ * A heading in there (an `<h3>`, a `Heading` component, or anything with
+ * `role="heading"`) produces `h2 > button > h3`, which is invalid HTML on two
+ * counts: a `<button>` may only contain phrasing content, and nested headings
+ * give screen reader users a duplicated heading structure.
+ *
+ * To get heading-sized text without heading semantics, use
+ * `<BodyText tag="span">` with the `font.heading.*` tokens, and set the real
+ * heading level with AccordionSection's `tag` prop.
+ *
+ * ```jsx
+ * // ❌ Don't
+ * <AccordionSection header={<Heading size="medium">Title</Heading>} />
+ *
+ * // ✅ Do
+ * <AccordionSection tag="h3" header="Title" />
+ * ```
+ *
+ * The `no-heading-in-accordion-header` lint rule flags headings written
+ * directly in the `header` prop, and AccordionSection logs a development-only
+ * console warning when the rendered header turns out to contain a heading.
+ *
+ * This example also shows that a smaller window size will cause the header
+ * text to truncate with ellipses.
+ */
+export const CustomHeaderWithoutNestedHeading: StoryComponentType = {
+    render: function Render() {
+        return (
+            /* This AccordionSection is implemented
+            the same way as the CourseAccordion in the LearnableNodeSidebar
+            that can be found on Khan Academy. It should truncate the
+            text with ellipses when the window size is small.*/
+            <AccordionSection
+                tag="h3"
+                header={
+                    <View
+                        style={{
+                            flexDirection: "row",
+                            margin: sizing.size_160,
+                        }}
+                    >
                         <View
                             style={{
-                                flexDirection: "row",
-                                margin: sizing.size_160,
+                                backgroundSize: "contain",
+                                borderRadius: border.radius.radius_080,
+                                height: 40,
+                                marginInlineEnd: sizing.size_120,
+                                minInlineSize: 40,
+                                padding: sizing.size_080,
+                                width: 40,
                             }}
                         >
-                            <View
-                                style={{
-                                    backgroundSize: "contain",
-                                    borderRadius: border.radius.radius_080,
-                                    height: 40,
-                                    marginInlineEnd: sizing.size_120,
-                                    minInlineSize: 40,
-                                    padding: sizing.size_080,
-                                    width: 40,
-                                }}
-                            >
-                                <PhosphorIcon
-                                    aria-hidden="true"
-                                    icon={magnifyingGlass}
-                                    size="medium"
-                                    style={styles.icon}
-                                />
-                            </View>
-                            <BodyText
-                                weight="bold"
-                                // Rendering as a span here to avoid introducing
-                                // an extra heading level, since h2 is already
-                                // set on the AccordionSection's clickable
-                                // header. This way we can avoid redundancy in
-                                // the a11y tree.
-                                tag="span"
-                                style={{
-                                    whiteSpace: "nowrap",
-                                    overflow: "hidden",
-                                    textOverflow: "ellipsis",
-                                    alignSelf: "center",
-                                    fontSize: font.heading.size.medium,
-                                    lineHeight: font.heading.lineHeight.medium,
-                                }}
-                            >
-                                World History Project - Origins to the Present
-                                (Example of a long title)
-                            </BodyText>
+                            <PhosphorIcon
+                                aria-hidden="true"
+                                icon={magnifyingGlass}
+                                size="medium"
+                            />
                         </View>
-                    }
-                >
-                    This is the information present in the second section
-                </AccordionSection>
-            </View>
+                        <BodyText
+                            weight="bold"
+                            // Rendering as a span here to avoid introducing
+                            // an extra heading level, since h3 is already
+                            // set on the AccordionSection's clickable
+                            // header. This way we can avoid redundancy in
+                            // the a11y tree.
+                            tag="span"
+                            style={{
+                                whiteSpace: "nowrap",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                alignSelf: "center",
+                                fontSize: font.heading.size.medium,
+                                lineHeight: font.heading.lineHeight.medium,
+                            }}
+                        >
+                            World History Project - Origins to the Present
+                            (Example of a long title)
+                        </BodyText>
+                    </View>
+                }
+            >
+                This is the information present in the section
+            </AccordionSection>
         );
     },
 };

--- a/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion-section.stories.tsx
@@ -235,10 +235,11 @@ export const ReactElementInHeader: StoryComponentType = {
 /**
  * AccordionSection already renders a heading element wrapping the header
  * `<button>`, so anything passed to `header` ends up inside both of them.
- * A heading in there (an `<h3>`, a `Heading` component, or anything with
- * `role="heading"`) produces `h2 > button > h3`, which is invalid HTML on two
- * counts: a `<button>` may only contain phrasing content, and nested headings
- * give screen reader users a duplicated heading structure.
+ * A heading in there — an `<h3>`, a `Heading` component, a `tag="h3"` on
+ * something like `BodyText` or `View`, or anything with `role="heading"` —
+ * produces `h2 > button > h3`, which is invalid HTML on two counts: a
+ * `<button>` may only contain phrasing content, and nested headings give
+ * screen reader users a duplicated heading structure.
  *
  * To get heading-sized text without heading semantics, use
  * `<BodyText tag="span">` with the `font.heading.*` tokens, and set the real
@@ -318,6 +319,14 @@ export const CustomHeaderWithoutNestedHeading: StoryComponentType = {
                 This is the information present in the section
             </AccordionSection>
         );
+    },
+    parameters: {
+        chromatic: {
+            // Disabling because this documents a semantics/a11y guideline, and
+            // the custom header rendering is already covered by
+            // ReactElementInHeader.
+            disableSnapshot: true,
+        },
     },
 };
 

--- a/packages/eslint-plugin-wonder-blocks/README.md
+++ b/packages/eslint-plugin-wonder-blocks/README.md
@@ -73,6 +73,7 @@ The following shows what rules are enabled in each config:
 | [`no-custom-tab-role`](docs/no-custom-tab-role.md)| |✅|
 | [`no-excessive-bodytext-children`](docs/no-excessive-bodytext-children.md)| |✅|
 | [`no-hardcoded-color`](docs/no-hardcoded-color.md)| |✅|
+| [`no-heading-in-accordion-header`](docs/no-heading-in-accordion-header.md)|✅|✅|
 | [`no-invalid-bodytext-children`](docs/no-invalid-bodytext-children.md)|✅|✅|
 | [`no-invalid-bodytext-parent`](docs/no-invalid-bodytext-parent.md)| |✅|
 | [`require-logical-properties-for-rtl`](docs/require-logical-properties-for-rtl.md)| opt-in | opt-in |

--- a/packages/eslint-plugin-wonder-blocks/docs/no-heading-in-accordion-header.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-heading-in-accordion-header.md
@@ -1,0 +1,113 @@
+# no-heading-in-accordion-header
+
+Disallow heading elements and heading components inside `AccordionSection`'s
+`header` prop.
+
+## Rule Details
+
+`AccordionSection` already wraps its trigger in a heading element, and that
+heading contains a `<button>`. Whatever you pass to `header` is rendered
+_inside_ that button:
+
+```html
+<h2>
+    <!-- from AccordionSection's `tag` prop -->
+    <button>
+        <!-- your `header` content goes here -->
+    </button>
+</h2>
+```
+
+Passing a heading (`<h3>`, `<Heading>`, or anything with `role="heading"`)
+therefore produces `h2 > button > h3`, which is invalid twice over:
+
+1. A `<button>`'s content model is
+   [phrasing content](https://html.spec.whatwg.org/#phrasing-content) only, so a
+   heading element is never legal inside it.
+2. Nested headings are invalid HTML and give screen reader users a duplicated,
+   confusing heading structure.
+
+To set the heading level, use `AccordionSection`'s `tag` prop. To get
+heading-sized text without heading semantics, use `<BodyText tag="span">` with
+the `font.heading.*` tokens.
+
+Note that non-heading block content such as `View` is **not** flagged. It is
+technically also invalid inside a `<button>`, but it is a long-standing and
+documented Wonder Blocks pattern for custom accordion headers, so this rule
+stays focused on the heading problem.
+
+Examples of **incorrect** code:
+
+```tsx
+/* Raw heading elements */
+<AccordionSection header={<h3>Section title</h3>} />
+
+/* Wonder Blocks heading components */
+<AccordionSection header={<Heading size="medium">Section title</Heading>} />
+
+/* Explicit heading role */
+<AccordionSection header={<View role="heading" aria-level={3}>Title</View>} />
+
+/* Nested anywhere inside the header content */
+<AccordionSection
+    header={
+        <View>
+            <PhosphorIcon icon={icon} />
+            <h3>Section title</h3>
+        </View>
+    }
+/>
+```
+
+Examples of **correct** code:
+
+```tsx
+/* A string header is the common case — AccordionSection styles it for you */
+<AccordionSection header="Section title" tag="h3" />
+
+/* Set the level with `tag`, and use inline typography for the content */
+<AccordionSection
+    tag="h3"
+    header={
+        <View style={styles.header}>
+            <PhosphorIcon icon={icon} />
+            <BodyText
+                tag="span"
+                weight="bold"
+                style={{
+                    fontSize: font.heading.size.medium,
+                    lineHeight: font.heading.lineHeight.medium,
+                }}
+            >
+                Section title
+            </BodyText>
+        </View>
+    }
+/>
+
+/* Non-heading components are fine */
+<AccordionSection header={<DetailCell title="Article item" horizontalRule="none" />} />
+```
+
+## Limitations
+
+This rule is static analysis, so it only sees headings written literally in the
+`header` prop. A component that renders a heading internally is invisible to it:
+
+```tsx
+/* Not flagged — but still wrong if CourseTitle renders an <h3> */
+<AccordionSection header={<CourseTitle />} />
+```
+
+AccordionSection also warns at runtime in development when the rendered header
+turns out to contain a heading, which covers that case.
+
+## When Not To Use It
+
+If you are not using Wonder Blocks' `AccordionSection`, this rule will never
+fire and there is no reason to disable it.
+
+## Further Reading
+
+-   [W3C ARIA Authoring Practices: Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)
+-   [HTML Standard: phrasing content](https://html.spec.whatwg.org/#phrasing-content)

--- a/packages/eslint-plugin-wonder-blocks/docs/no-heading-in-accordion-header.md
+++ b/packages/eslint-plugin-wonder-blocks/docs/no-heading-in-accordion-header.md
@@ -18,8 +18,10 @@ _inside_ that button:
 </h2>
 ```
 
-Passing a heading (`<h3>`, `<Heading>`, or anything with `role="heading"`)
-therefore produces `h2 > button > h3`, which is invalid twice over:
+Passing a heading — `<h3>`, `<Heading>`, a `tag="h3"` on a component that
+renders whatever its `tag` names (`BodyText`, `Text`, `View`, ...), or anything
+with `role="heading"` — therefore produces `h2 > button > h3`, which is invalid
+twice over:
 
 1. A `<button>`'s content model is
    [phrasing content](https://html.spec.whatwg.org/#phrasing-content) only, so a
@@ -44,6 +46,10 @@ Examples of **incorrect** code:
 
 /* Wonder Blocks heading components */
 <AccordionSection header={<Heading size="medium">Section title</Heading>} />
+
+/* A `tag` prop that names a heading element */
+<AccordionSection header={<BodyText tag="h3">Section title</BodyText>} />
+<AccordionSection header={<View tag="h3">Section title</View>} />
 
 /* Explicit heading role */
 <AccordionSection header={<View role="heading" aria-level={3}>Title</View>} />
@@ -92,11 +98,15 @@ Examples of **correct** code:
 ## Limitations
 
 This rule is static analysis, so it only sees headings written literally in the
-`header` prop. A component that renders a heading internally is invisible to it:
+`header` prop. A component that renders a heading internally, or a `tag` that
+can't be resolved statically, is invisible to it:
 
 ```tsx
 /* Not flagged — but still wrong if CourseTitle renders an <h3> */
 <AccordionSection header={<CourseTitle />} />
+
+/* Not flagged — the tag can't be resolved at lint time */
+<AccordionSection header={<BodyText tag={headingTag}>Title</BodyText>} />
 ```
 
 AccordionSection also warns at runtime in development when the rendered header

--- a/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/configs/recommended.ts
@@ -1,6 +1,7 @@
 export default {
     plugins: ["@khanacademy/wonder-blocks"],
     rules: {
+        "@khanacademy/wonder-blocks/no-heading-in-accordion-header": "error",
         "@khanacademy/wonder-blocks/no-invalid-bodytext-children": "error",
         "@khanacademy/wonder-blocks/require-logical-properties-for-rtl":
             "error",

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-heading-in-accordion-header.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-heading-in-accordion-header.test.ts
@@ -51,6 +51,16 @@ ruleTester.run(ruleName, rule, {
         },
         {code: `<AccordionSection header={<View role="presentation" />} />`},
 
+        // Non-heading `tag` values
+        {
+            code: `<AccordionSection header={<View tag="section">Title</View>} />`,
+        },
+        {code: `<AccordionSection header={<Text tag="span">Title</Text>} />`},
+        // A dynamic tag can't be resolved statically, so it isn't flagged
+        {
+            code: `<AccordionSection header={<BodyText tag={tag}>Title</BodyText>} />`,
+        },
+
         // Icons and other inline decorations
         {
             code: `<AccordionSection header={<><PhosphorIcon icon={icon} /><BodyText tag="span">Title</BodyText></>} />`,
@@ -127,6 +137,56 @@ ruleTester.run(ruleName, rule, {
                 {
                     messageId: "headingComponentInHeader",
                     data: {name: "HeadingSmall"},
+                },
+            ],
+        },
+
+        // ---------------------------------------------------------------- //
+        // Heading level supplied via a `tag` prop                          //
+        // ---------------------------------------------------------------- //
+        {
+            code: `<AccordionSection header={<BodyText tag="h1">Title</BodyText>} />`,
+            errors: [
+                {
+                    messageId: "headingTagInHeader",
+                    data: {name: "BodyText", tag: "h1"},
+                },
+            ],
+        },
+        {
+            code: `<AccordionSection header={<View tag="h2">Title</View>} />`,
+            errors: [
+                {
+                    messageId: "headingTagInHeader",
+                    data: {name: "View", tag: "h2"},
+                },
+            ],
+        },
+        {
+            code: `<AccordionSection header={<Text tag="h6">Title</Text>} />`,
+            errors: [
+                {
+                    messageId: "headingTagInHeader",
+                    data: {name: "Text", tag: "h6"},
+                },
+            ],
+        },
+        {
+            code: `<AccordionSection header={<BodyMonospace tag="h3">Title</BodyMonospace>} />`,
+            errors: [
+                {
+                    messageId: "headingTagInHeader",
+                    data: {name: "BodyMonospace", tag: "h3"},
+                },
+            ],
+        },
+        {
+            // Nested inside other markup
+            code: `<AccordionSection header={<View><BodyText tag="h4">Title</BodyText></View>} />`,
+            errors: [
+                {
+                    messageId: "headingTagInHeader",
+                    data: {name: "BodyText", tag: "h4"},
                 },
             ],
         },

--- a/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-heading-in-accordion-header.test.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/__tests__/no-heading-in-accordion-header.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for the no-heading-in-accordion-header ESLint rule.
+ *
+ * Uses ESLint's RuleTester to verify that the rule flags heading elements and
+ * heading components passed to AccordionSection's `header` prop, while leaving
+ * the inline content that belongs there alone.
+ */
+import {RuleTester} from "@typescript-eslint/rule-tester";
+
+import {rules} from "..";
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            ecmaVersion: 2020,
+            ecmaFeatures: {jsx: true},
+            sourceType: "module",
+        },
+    },
+});
+
+const ruleName = "no-heading-in-accordion-header";
+const rule = rules[ruleName];
+
+ruleTester.run(ruleName, rule, {
+    // ------------------------------------------------------------------ //
+    // VALID — strings, inline content, and layout wrappers. The heading   //
+    //         level belongs on the `tag` prop, not in the content.        //
+    // ------------------------------------------------------------------ //
+    valid: [
+        // A plain string header is the common case
+        {code: `<AccordionSection header="First section" />`},
+        {code: `<AccordionSection header="First section" tag="h3" />`},
+        {code: `<AccordionSection header={title} />`},
+
+        // Inline typography is the recommended alternative to a heading
+        {
+            code: `<AccordionSection header={<BodyText tag="span">Title</BodyText>} />`,
+        },
+        {
+            code: `<AccordionSection header={<BodyText tag="span" weight="bold">Title</BodyText>} />`,
+        },
+
+        // View is block content, but it is not a heading — the accordion's
+        // own "React Element in Header" story relies on this being allowed.
+        {
+            code: `<AccordionSection header={<View><BodyText tag="span">Title</BodyText></View>} />`,
+        },
+        {
+            code: `<AccordionSection header={<DetailCell title="Header for article item" horizontalRule="none" />} />`,
+        },
+        {code: `<AccordionSection header={<View role="presentation" />} />`},
+
+        // Icons and other inline decorations
+        {
+            code: `<AccordionSection header={<><PhosphorIcon icon={icon} /><BodyText tag="span">Title</BodyText></>} />`,
+        },
+
+        // Headings elsewhere on AccordionSection are not this rule's concern
+        {
+            code: `<AccordionSection header="Title"><h3>In the panel</h3></AccordionSection>`,
+        },
+        {
+            code: `<AccordionSection header="Title" footer={<h3>Elsewhere</h3>} />`,
+        },
+
+        // A `header` prop on some other component is unconstrained
+        {code: `<SomeOtherComponent header={<h3>Title</h3>} />`},
+        {code: `<Card header={<Heading>Title</Heading>} />`},
+    ],
+
+    // ------------------------------------------------------------------ //
+    // INVALID — anything that renders heading semantics inside the        //
+    //           heading-wrapped <button> AccordionSection already makes.  //
+    // ------------------------------------------------------------------ //
+    invalid: [
+        // ---------------------------------------------------------------- //
+        // Raw HTML heading elements                                        //
+        // ---------------------------------------------------------------- //
+        {
+            code: `<AccordionSection header={<h1>Title</h1>} />`,
+            errors: [{messageId: "headingElementInHeader", data: {name: "h1"}}],
+        },
+        {
+            code: `<AccordionSection header={<h3>Title</h3>} />`,
+            errors: [{messageId: "headingElementInHeader", data: {name: "h3"}}],
+        },
+        {
+            code: `<AccordionSection header={<h6>Title</h6>} />`,
+            errors: [{messageId: "headingElementInHeader", data: {name: "h6"}}],
+        },
+        {
+            // addStyle("h3") wrappers are heading elements too
+            code: `<AccordionSection header={<StyledH3>Title</StyledH3>} />`,
+            errors: [
+                {
+                    messageId: "headingElementInHeader",
+                    data: {name: "StyledH3"},
+                },
+            ],
+        },
+
+        // ---------------------------------------------------------------- //
+        // Wonder Blocks heading components                                 //
+        // ---------------------------------------------------------------- //
+        {
+            code: `<AccordionSection header={<Heading>Title</Heading>} />`,
+            errors: [
+                {
+                    messageId: "headingComponentInHeader",
+                    data: {name: "Heading"},
+                },
+            ],
+        },
+        {
+            code: `<AccordionSection header={<Heading size="medium" tag="h3">Title</Heading>} />`,
+            errors: [
+                {
+                    messageId: "headingComponentInHeader",
+                    data: {name: "Heading"},
+                },
+            ],
+        },
+        {
+            code: `<AccordionSection header={<HeadingSmall>Title</HeadingSmall>} />`,
+            errors: [
+                {
+                    messageId: "headingComponentInHeader",
+                    data: {name: "HeadingSmall"},
+                },
+            ],
+        },
+
+        // ---------------------------------------------------------------- //
+        // Explicit heading role                                            //
+        // ---------------------------------------------------------------- //
+        {
+            code: `<AccordionSection header={<View role="heading" aria-level={3}>Title</View>} />`,
+            errors: [{messageId: "roleHeadingInHeader"}],
+        },
+        {
+            code: `<AccordionSection header={<div role="heading">Title</div>} />`,
+            errors: [{messageId: "roleHeadingInHeader"}],
+        },
+
+        // ---------------------------------------------------------------- //
+        // Nested inside other markup — the walk is not depth-limited       //
+        // ---------------------------------------------------------------- //
+        {
+            code: `<AccordionSection header={<View><h3>Title</h3></View>} />`,
+            errors: [{messageId: "headingElementInHeader", data: {name: "h3"}}],
+        },
+        {
+            code: `<AccordionSection header={<View><PhosphorIcon icon={icon} /><Heading>Title</Heading></View>} />`,
+            errors: [
+                {
+                    messageId: "headingComponentInHeader",
+                    data: {name: "Heading"},
+                },
+            ],
+        },
+        {
+            // Fragments
+            code: `<AccordionSection header={<><Icon /><h2>Title</h2></>} />`,
+            errors: [{messageId: "headingElementInHeader", data: {name: "h2"}}],
+        },
+        {
+            // Conditionals
+            code: `<AccordionSection header={isOpen ? <h3>Open</h3> : <h3>Closed</h3>} />`,
+            errors: [
+                {messageId: "headingElementInHeader", data: {name: "h3"}},
+                {messageId: "headingElementInHeader", data: {name: "h3"}},
+            ],
+        },
+
+        // ---------------------------------------------------------------- //
+        // Several problems in one header                                   //
+        // ---------------------------------------------------------------- //
+        {
+            code: `<AccordionSection header={<View><h3>Title</h3><Heading>Subtitle</Heading></View>} />`,
+            errors: [
+                {messageId: "headingElementInHeader", data: {name: "h3"}},
+                {
+                    messageId: "headingComponentInHeader",
+                    data: {name: "Heading"},
+                },
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/index.ts
@@ -3,6 +3,7 @@ import {TSESLint} from "@typescript-eslint/utils";
 import noCustomTabRole from "./no-custom-tab-role";
 import noExcessiveBodyTextChildren from "./no-excessive-bodytext-children";
 import noHardcodedColor from "./no-hardcoded-color";
+import noHeadingInAccordionHeader from "./no-heading-in-accordion-header";
 import noInvalidBodyTextChildren from "./no-invalid-bodytext-children";
 import noInvalidBodyTextParent from "./no-invalid-bodytext-parent";
 import noRawButton from "./no-raw-button";
@@ -12,6 +13,7 @@ const rules: Record<string, TSESLint.RuleModule<string, readonly unknown[]>> = {
     "no-custom-tab-role": noCustomTabRole,
     "no-excessive-bodytext-children": noExcessiveBodyTextChildren,
     "no-hardcoded-color": noHardcodedColor,
+    "no-heading-in-accordion-header": noHeadingInAccordionHeader,
     "no-invalid-bodytext-children": noInvalidBodyTextChildren,
     "no-invalid-bodytext-parent": noInvalidBodyTextParent,
     "no-raw-button": noRawButton,

--- a/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
@@ -140,6 +140,57 @@ export const HTML_BLOCK_ELEMENTS = new Set([
 ]);
 
 /**
+ * Returns true when a value looks like an AST node.
+ */
+function isNode(value: unknown): value is TSESTree.Node {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        typeof (value as {type?: unknown}).type === "string"
+    );
+}
+
+/**
+ * Calls `callback` for every JSXOpeningElement beneath `node`, including `node`
+ * itself.
+ *
+ * For rules inspecting a prop whose value is JSX (e.g. `header={<Foo />}`),
+ * where the element of interest may be wrapped in a fragment, conditional,
+ * array, or another element. It cannot see through indirection.
+ */
+export function forEachJSXOpeningElement(
+    node: TSESTree.Node,
+    callback: (element: TSESTree.JSXOpeningElement) => void,
+): void {
+    const visit = (current: TSESTree.Node): void => {
+        if (current.type === "JSXOpeningElement") {
+            callback(current);
+        }
+
+        for (const key of Object.keys(current)) {
+            // `parent` points back up the tree and would recurse forever.
+            if (key === "parent") {
+                continue;
+            }
+
+            const value = (current as unknown as Record<string, unknown>)[key];
+
+            if (Array.isArray(value)) {
+                for (const item of value) {
+                    if (isNode(item)) {
+                        visit(item);
+                    }
+                }
+            } else if (isNode(value)) {
+                visit(value);
+            }
+        }
+    };
+
+    visit(node);
+}
+
+/**
  * Returns the string value of a JSX attribute if it is a simple string
  * literal, otherwise null. Returns null for dynamic expressions.
  */

--- a/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/jsx-utils.ts
@@ -100,6 +100,14 @@ export const WB_HEADING_COMPONENTS = new Set([
 ]);
 
 /**
+ * Matches the HTML heading tags h1-h6. Wonder Blocks components that accept a
+ * `tag` prop (Text, View, BodyText, BodyMonospace, ...) render a real heading
+ * element when given one, so the component name alone doesn't say whether it
+ * produces a heading.
+ */
+export const HEADING_TAG_REGEX = /^h[1-6]$/;
+
+/**
  * HTML elements that are block-level and therefore cannot appear inside a <p>.
  * Excludes <div> and <p> which have their own dedicated message IDs in the
  * no-invalid-bodytext-children rule.

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-heading-in-accordion-header.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-heading-in-accordion-header.ts
@@ -1,0 +1,107 @@
+import {ESLintUtils, TSESTree} from "@typescript-eslint/utils";
+
+import type {WonderBlocksPluginDocs} from "../types";
+import {
+    HTML_HEADING_ELEMENTS,
+    WB_HEADING_COMPONENTS,
+    forEachJSXOpeningElement,
+    getAttributeStringValue,
+} from "./jsx-utils";
+
+const createRule = ESLintUtils.RuleCreator<WonderBlocksPluginDocs>(
+    (name) =>
+        `https://github.com/Khan/wonder-blocks/blob/main/packages/eslint-plugin-wonder-blocks/docs/${name}.md`,
+);
+
+type Options = [];
+type MessageIds =
+    | "headingElementInHeader"
+    | "headingComponentInHeader"
+    | "roleHeadingInHeader";
+
+// The fix is always the same, so every message ends with it.
+const ADVICE =
+    'Set the heading level with AccordionSection\'s `tag` prop instead, and use `<BodyText tag="span">` with `font.heading.*` tokens for heading-sized text.';
+
+export default createRule<Options, MessageIds>({
+    name: "no-heading-in-accordion-header",
+    meta: {
+        type: "problem",
+        docs: {
+            description:
+                "Disallow heading elements and components inside AccordionSection's header prop",
+            recommended: true,
+        },
+        schema: [],
+        messages: {
+            headingElementInHeader: `AccordionSection already wraps its header in a heading element containing a <button>, so <{{name}}> here produces nested headings inside a <button>, which is invalid HTML. ${ADVICE}`,
+            headingComponentInHeader: `AccordionSection already wraps its header in a heading element containing a <button>, so {{name}} here produces nested headings inside a <button>, which is invalid HTML. ${ADVICE}`,
+            roleHeadingInHeader: `AccordionSection already wraps its header in a heading element containing a <button>, so role="heading" here produces nested headings. ${ADVICE}`,
+        },
+    },
+    create(context) {
+        return {
+            JSXAttribute(node: TSESTree.JSXAttribute) {
+                // Only AccordionSection — other components' `header` props are
+                // unconstrained.
+                if (
+                    node.name.type !== "JSXIdentifier" ||
+                    node.name.name !== "header"
+                ) {
+                    return;
+                }
+
+                const owner = node.parent;
+                if (
+                    owner?.type !== "JSXOpeningElement" ||
+                    owner.name.type !== "JSXIdentifier" ||
+                    owner.name.name !== "AccordionSection"
+                ) {
+                    return;
+                }
+
+                // Only JSX values can contain headings.
+                if (node.value?.type !== "JSXExpressionContainer") {
+                    return;
+                }
+
+                forEachJSXOpeningElement(node.value.expression, (element) => {
+                    if (element.name.type !== "JSXIdentifier") {
+                        return;
+                    }
+
+                    const name = element.name.name;
+
+                    if (HTML_HEADING_ELEMENTS.has(name)) {
+                        context.report({
+                            node: element,
+                            messageId: "headingElementInHeader",
+                            data: {name},
+                        });
+                        return;
+                    }
+
+                    if (WB_HEADING_COMPONENTS.has(name)) {
+                        context.report({
+                            node: element,
+                            messageId: "headingComponentInHeader",
+                            data: {name},
+                        });
+                        return;
+                    }
+
+                    // Anything can opt into heading semantics via role.
+                    if (
+                        getAttributeStringValue(element, "role") === "heading"
+                    ) {
+                        context.report({
+                            node: element,
+                            messageId: "roleHeadingInHeader",
+                        });
+                    }
+                });
+            },
+        };
+    },
+    defaultOptions: [],
+});

--- a/packages/eslint-plugin-wonder-blocks/src/rules/no-heading-in-accordion-header.ts
+++ b/packages/eslint-plugin-wonder-blocks/src/rules/no-heading-in-accordion-header.ts
@@ -2,6 +2,7 @@ import {ESLintUtils, TSESTree} from "@typescript-eslint/utils";
 
 import type {WonderBlocksPluginDocs} from "../types";
 import {
+    HEADING_TAG_REGEX,
     HTML_HEADING_ELEMENTS,
     WB_HEADING_COMPONENTS,
     forEachJSXOpeningElement,
@@ -17,6 +18,7 @@ type Options = [];
 type MessageIds =
     | "headingElementInHeader"
     | "headingComponentInHeader"
+    | "headingTagInHeader"
     | "roleHeadingInHeader";
 
 // The fix is always the same, so every message ends with it.
@@ -36,6 +38,7 @@ export default createRule<Options, MessageIds>({
         messages: {
             headingElementInHeader: `AccordionSection already wraps its header in a heading element containing a <button>, so <{{name}}> here produces nested headings inside a <button>, which is invalid HTML. ${ADVICE}`,
             headingComponentInHeader: `AccordionSection already wraps its header in a heading element containing a <button>, so {{name}} here produces nested headings inside a <button>, which is invalid HTML. ${ADVICE}`,
+            headingTagInHeader: `{{name}} renders a <{{tag}}> element. AccordionSection already wraps its header in a heading element containing a <button>, so this produces nested headings inside a <button>, which is invalid HTML. ${ADVICE}`,
             roleHeadingInHeader: `AccordionSection already wraps its header in a heading element containing a <button>, so role="heading" here produces nested headings. ${ADVICE}`,
         },
     },
@@ -86,6 +89,19 @@ export default createRule<Options, MessageIds>({
                             node: element,
                             messageId: "headingComponentInHeader",
                             data: {name},
+                        });
+                        return;
+                    }
+
+                    // Components like BodyText, Text and View render whatever
+                    // element their `tag` prop names, so the component name
+                    // alone doesn't say whether it produces a heading.
+                    const tag = getAttributeStringValue(element, "tag");
+                    if (tag !== null && HEADING_TAG_REGEX.test(tag)) {
+                        context.report({
+                            node: element,
+                            messageId: "headingTagInHeader",
+                            data: {name, tag},
                         });
                         return;
                     }

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import {render, screen} from "@testing-library/react";
 import {userEvent} from "@testing-library/user-event";
 
-import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {RenderStateRoot, View} from "@khanacademy/wonder-blocks-core";
+import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
 
 import AccordionSection from "../accordion-section";
 
@@ -171,6 +172,134 @@ describe("AccordionSection", () => {
 
         // Assert
         expect(header).toBeVisible();
+    });
+
+    describe("nested heading warning", () => {
+        // Spies aren't reset between tests in this repo.
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test("warns when a Heading is passed as the header", () => {
+            // Arrange
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+
+            // Act
+            render(
+                // The misuse under test, so the lint rule is disabled here.
+                // eslint-disable-next-line @khanacademy/wonder-blocks/no-heading-in-accordion-header
+                <AccordionSection header={<Heading>Title</Heading>}>
+                    Section content
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    "AccordionSection's header contains a heading",
+                ),
+            );
+        });
+
+        test("warns when a raw heading element is passed as the header", () => {
+            // Arrange
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+
+            // Act
+            render(
+                // The misuse under test, so the lint rule is disabled here.
+                // eslint-disable-next-line @khanacademy/wonder-blocks/no-heading-in-accordion-header
+                <AccordionSection header={<h3>Title</h3>}>
+                    Section content
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+
+        test("warns when the header content uses role=heading", () => {
+            // Arrange
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+
+            // Act
+            render(
+                // The misuse under test, so the lint rule is disabled here.
+                // eslint-disable-next-line @khanacademy/wonder-blocks/no-heading-in-accordion-header
+                <AccordionSection header={<View role="heading">Title</View>}>
+                    Section content
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+
+        test("warns when a Heading is nested inside the header content", () => {
+            // Arrange
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+            const CustomHeader = () => <Heading>Title</Heading>;
+
+            // Act
+            render(
+                <AccordionSection header={<CustomHeader />}>
+                    Section content
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+
+        test("does not warn for a Heading in the content panel", () => {
+            // Arrange
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+
+            // Act
+            render(
+                <AccordionSection header="Title">
+                    <Heading>Panel heading</Heading>
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        test("does not warn for inline typography in the header", () => {
+            // Arrange
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+
+            // Act
+            render(
+                <AccordionSection
+                    header={<BodyText tag="span">Title</BodyText>}
+                >
+                    Section content
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
     });
 
     test("uses the header's testId as button's data-testid", () => {

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion-section.test.tsx
@@ -244,6 +244,26 @@ describe("AccordionSection", () => {
             expect(warnSpy).toHaveBeenCalledTimes(1);
         });
 
+        test("warns when the header content sets a heading tag", () => {
+            // Arrange
+            const warnSpy = jest
+                .spyOn(console, "warn")
+                .mockImplementation(() => {});
+
+            // Act
+            render(
+                // The misuse under test, so the lint rule is disabled here.
+                // eslint-disable-next-line @khanacademy/wonder-blocks/no-heading-in-accordion-header
+                <AccordionSection header={<BodyText tag="h1">Title</BodyText>}>
+                    Section content
+                </AccordionSection>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+        });
+
         test("warns when a Heading is nested inside the header content", () => {
             // Arrange
             const warnSpy = jest

--- a/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section-header.tsx
@@ -13,6 +13,8 @@ import type {AccordionCornerKindType} from "./accordion";
 import type {TagType} from "./accordion-section";
 import {getRoundedValuesForHeader} from "../utils";
 
+const HEADING_SELECTOR = 'h1,h2,h3,h4,h5,h6,[role="heading"]';
+
 type Props = {
     // Unique ID for this section's button.
     id: string;
@@ -73,6 +75,28 @@ const AccordionSectionHeader = React.forwardRef(function AccordionSectionHeader(
 
     const headerIsString = typeof header === "string";
 
+    // Checking the DOM rather than the `header` element also catches headings
+    // rendered inside a consumer's own components, which the
+    // no-heading-in-accordion-header lint rule can't see.
+    const headerContentRef = React.useRef<HTMLElement>(null);
+    React.useEffect(() => {
+        if (process.env.NODE_ENV === "production" || headerIsString) {
+            return;
+        }
+
+        if (headerContentRef.current?.querySelector(HEADING_SELECTOR)) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                "AccordionSection's header contains a heading. It is rendered " +
+                    "inside a <button> that AccordionSection already wraps in " +
+                    "a heading, which is invalid HTML. Set the heading level " +
+                    "with the `tag` prop instead, and use " +
+                    '`<BodyText tag="span">` with `font.heading.*` tokens for ' +
+                    "heading-sized text.",
+            );
+        }
+    }, [header, headerIsString]);
+
     const {roundedTop, roundedBottom} = getRoundedValuesForHeader(
         cornerKind,
         isFirstSection,
@@ -107,6 +131,7 @@ const AccordionSectionHeader = React.forwardRef(function AccordionSectionHeader(
                                 styles.headerContent,
                                 headerIsString && styles.headerString,
                             ]}
+                            ref={headerContentRef}
                         >
                             {headerIsString ? (
                                 <View

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -30,8 +30,9 @@ type Props = AriaProps & {
      *
      * NOTE: this content renders inside a `<button>` that is itself wrapped in
      * a heading, so it must not contain a heading of its own (`<h1>`–`<h6>`,
-     * `Heading`, or `role="heading"`) — that is invalid HTML. Use the `tag`
-     * prop to set the heading level, and `<BodyText tag="span">` with
+     * `Heading`, a `tag="h1"`–`tag="h6"` on any component, or
+     * `role="heading"`) — that is invalid HTML. Use AccordionSection's own
+     * `tag` prop to set the heading level, and `<BodyText tag="span">` with
      * `font.heading.*` tokens for heading-sized text.
      */
     header: string | React.ReactElement;

--- a/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion-section.tsx
@@ -25,8 +25,14 @@ type Props = AriaProps & {
      */
     children: string | React.ReactElement;
     /**
-     * The header for this section. If a string is passed in, it will
-     * automatically be given Body typography from Wonder Blocks Typography.
+     * The header for this section. A string is given Heading typography and
+     * the standard header spacing; a React element is rendered as-is.
+     *
+     * NOTE: this content renders inside a `<button>` that is itself wrapped in
+     * a heading, so it must not contain a heading of its own (`<h1>`–`<h6>`,
+     * `Heading`, or `role="heading"`) — that is invalid HTML. Use the `tag`
+     * prop to set the heading level, and `<BodyText tag="span">` with
+     * `font.heading.*` tokens for heading-sized text.
      */
     header: string | React.ReactElement;
     /**


### PR DESCRIPTION
## Summary

`AccordionSection` wraps its trigger in a heading containing a `<button>`, and `header` renders inside that button. Passing a heading produces `h2 > button > h3` — a `<button>` may only contain phrasing content, and nested headings duplicate the heading structure for screen reader users. Nothing caught this before.

- New `no-heading-in-accordion-header` lint rule — flags `<h1>`–`<h6>`, WB `Heading` components, a `tag="h1"`–`tag="h6"` on any component (e.g. `<BodyText tag="h1">`), and `role="heading"` in a literal `header` prop. Enabled at `error` in `recommended`.
- Dev-only console warning in `AccordionSection` when the rendered header contains a heading. It checks the DOM, so it also catches headings inside a consumer's own components, which lint can't see. Does not fire during SSR.
- Constraint documented in the prop JSDoc, argtypes, and the a11y page. The custom-header example is now its own `CustomHeaderWithoutNestedHeading` story.

The fix is always `tag` for the heading level plus `<BodyText tag="span">` with `font.heading.*` tokens for heading-sized text.

## Notes

- `eslint-plugin-wonder-blocks` is a **major** bump: a new `error` rule in `recommended` will surface new lint errors downstream.
- Non-heading block content (`View`, `DetailCell`) is deliberately not flagged — technically also invalid inside a `<button>`, but it's a long-standing documented pattern.
- A dynamic `tag={x}` can't be resolved at lint time, so it isn't flagged; the runtime check catches it.
- A type-level restriction isn't possible: `JSX.Element` is `ReactElement<any, any>`, so the element type is erased and any conditional-type check collapses.

## Test plan

- Rule: 21 valid / 19 invalid cases, plus verified against real violations through the built plugin.
- Runtime warning: covers `Heading`, raw `<h3>`, `BodyText tag="h1"`, `role="heading"`, and a heading nested inside a custom component; negative cases for panel headings and inline typography.
- Full suite green — 237 suites, lint, typecheck.

Issue: WB-2434