### PR TITLE
Add typed ErrorResultGqlError and RespondWith.graphQLPartialData for partial GraphQL results

### DIFF
--- a/.changeset/respond-with-graphql.md
+++ b/.changeset/respond-with-graphql.md
@@ -2,4 +2,4 @@
 "@khanacademy/wonder-blocks-testing-core": minor
 ---
 
-Add `RespondWith.graphQL` for mocking a GraphQL response body that carries both partial `data` and `errors`, and extend `GraphQLJson` with that shape along with the new `GraphQLPartialData` and `GraphQLResponseError` types.
+Add `RespondWith.graphQLPartialData` for mocking a GraphQL response that carries both partial `data` and `errors`, and extend `GraphQLJson` with that shape along with the new `GraphQLPartialData` and `GraphQLResponseError` types.

--- a/.changeset/respond-with-graphql.md
+++ b/.changeset/respond-with-graphql.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-testing-core": minor
+---
+
+Add `RespondWith.graphQL` for mocking a GraphQL response body that carries both partial `data` and `errors`, and extend `GraphQLJson` with that shape along with the new `GraphQLPartialData` and `GraphQLResponseError` types.

--- a/.changeset/typed-gql-error-result.md
+++ b/.changeset/typed-gql-error-result.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-data": minor
+---
+
+Add `ErrorResultGqlError`, a typed `GqlError` thrown when a GraphQL response reports errors, exposing `statusCode` and the parsed `result` payload (partial `data` plus `errors`) so consumers can use partial results without type suppression. Also adds the `isErrorResultGqlError` type guard and the `GqlPartialData`, `GqlResponseError`, and `GqlErrorResultPayload` types.

--- a/packages/wonder-blocks-data/src/index.ts
+++ b/packages/wonder-blocks-data/src/index.ts
@@ -37,10 +37,15 @@ export {toGqlOperation} from "./util/to-gql-operation";
 export {GqlRouter} from "./components/gql-router";
 export {useGql} from "./hooks/use-gql";
 export {GqlError, GqlErrors} from "./util/gql-error";
+export {ErrorResultGqlError} from "./util/error-result-gql-error";
+export {isErrorResultGqlError} from "./util/is-error-result-gql-error";
 export type {
     GqlContext,
     GqlOperation,
     GqlOperationType,
     GqlFetchOptions,
     GqlFetchFn,
+    GqlPartialData,
+    GqlResponseError,
+    GqlErrorResultPayload,
 } from "./util/gql-types";

--- a/packages/wonder-blocks-data/src/util/__tests__/error-result-gql-error.test.ts
+++ b/packages/wonder-blocks-data/src/util/__tests__/error-result-gql-error.test.ts
@@ -1,0 +1,65 @@
+import {ErrorResultGqlError} from "../error-result-gql-error";
+import {GqlError} from "../gql-error";
+
+describe("ErrorResultGqlError", () => {
+    it("should be a GqlError", () => {
+        // Arrange
+        const payload = {errors: [{message: "GraphQL error"}]};
+
+        // Act
+        const error = new ErrorResultGqlError(200, payload);
+
+        // Assert
+        expect(error).toBeInstanceOf(GqlError);
+    });
+
+    it("should have the ErrorResult kind", () => {
+        // Arrange
+        const payload = {errors: [{message: "GraphQL error"}]};
+
+        // Act
+        const error = new ErrorResultGqlError(200, payload);
+
+        // Assert
+        expect(error.kind).toBe("ErrorResult");
+    });
+
+    it("should expose the status code", () => {
+        // Arrange
+        const payload = {errors: [{message: "GraphQL error"}]};
+
+        // Act
+        const error = new ErrorResultGqlError(200, payload);
+
+        // Assert
+        expect(error.statusCode).toBe(200);
+    });
+
+    it("should expose the result payload", () => {
+        // Arrange
+        const payload = {
+            data: {thing: null, other: "value"},
+            errors: [{message: "GraphQL error", path: ["thing"]}],
+        };
+
+        // Act
+        const error = new ErrorResultGqlError(200, payload);
+
+        // Assert
+        expect(error.result).toBe(payload);
+    });
+
+    it("should attach the status code and result as metadata", () => {
+        // Arrange
+        const payload = {
+            data: {thing: null},
+            errors: [{message: "GraphQL error"}],
+        };
+
+        // Act
+        const error = new ErrorResultGqlError(200, payload);
+
+        // Assert
+        expect(error.metadata).toEqual({statusCode: 200, result: payload});
+    });
+});

--- a/packages/wonder-blocks-data/src/util/__tests__/get-gql-data-from-response.test.ts
+++ b/packages/wonder-blocks-data/src/util/__tests__/get-gql-data-from-response.test.ts
@@ -1,3 +1,4 @@
+import {ErrorResultGqlError} from "../error-result-gql-error";
 import {getGqlDataFromResponse} from "../get-gql-data-from-response";
 
 describe("#getGqlDataFromReponse", () => {
@@ -156,6 +157,54 @@ describe("#getGqlDataFromReponse", () => {
             result: {
                 data: {},
                 errors: [{message: "GraphQL error"}],
+            },
+        });
+    });
+
+    it("should throw an ErrorResultGqlError when the response has GraphQL errors", async () => {
+        // Arrange
+        const response: any = {
+            status: 200,
+            text: jest.fn(() =>
+                Promise.resolve(
+                    JSON.stringify({
+                        data: {thing: null, other: "value"},
+                        errors: [{message: "GraphQL error", path: ["thing"]}],
+                    }),
+                ),
+            ),
+        };
+
+        // Act
+        const result = getGqlDataFromResponse(response);
+
+        // Assert
+        await expect(result).rejects.toBeInstanceOf(ErrorResultGqlError);
+    });
+
+    it("should expose the partial data and errors on the ErrorResultGqlError", async () => {
+        // Arrange
+        const response: any = {
+            status: 200,
+            text: jest.fn(() =>
+                Promise.resolve(
+                    JSON.stringify({
+                        data: {thing: null, other: "value"},
+                        errors: [{message: "GraphQL error", path: ["thing"]}],
+                    }),
+                ),
+            ),
+        };
+
+        // Act
+        const result = getGqlDataFromResponse(response);
+
+        // Assert
+        await expect(result).rejects.toMatchObject({
+            statusCode: 200,
+            result: {
+                data: {thing: null, other: "value"},
+                errors: [{message: "GraphQL error", path: ["thing"]}],
             },
         });
     });

--- a/packages/wonder-blocks-data/src/util/__tests__/is-error-result-gql-error.test.ts
+++ b/packages/wonder-blocks-data/src/util/__tests__/is-error-result-gql-error.test.ts
@@ -1,0 +1,65 @@
+import {DataError, DataErrors} from "../data-error";
+import {ErrorResultGqlError} from "../error-result-gql-error";
+import {GqlError, GqlErrors} from "../gql-error";
+import {isErrorResultGqlError} from "../is-error-result-gql-error";
+
+describe("#isErrorResultGqlError", () => {
+    it("should return true for an ErrorResultGqlError", () => {
+        // Arrange
+        const error = new ErrorResultGqlError(200, {
+            errors: [{message: "GraphQL error"}],
+        });
+
+        // Act
+        const result = isErrorResultGqlError(error);
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("should return false for a GqlError of a different kind", () => {
+        // Arrange
+        const error = new GqlError("Bad response", GqlErrors.BadResponse, {
+            metadata: {statusCode: 200, result: {}},
+        });
+
+        // Act
+        const result = isErrorResultGqlError(error);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+
+    it("should return false for a DataError", () => {
+        // Arrange
+        const error = new DataError("Network", DataErrors.Network);
+
+        // Act
+        const result = isErrorResultGqlError(error);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+
+    it("should return false for a plain Error", () => {
+        // Arrange
+        const error = new Error("Boom!");
+
+        // Act
+        const result = isErrorResultGqlError(error);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+
+    it("should return false for a non-error value", () => {
+        // Arrange
+        const value = {statusCode: 200, result: {errors: []}};
+
+        // Act
+        const result = isErrorResultGqlError(value);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+});

--- a/packages/wonder-blocks-data/src/util/error-result-gql-error.ts
+++ b/packages/wonder-blocks-data/src/util/error-result-gql-error.ts
@@ -1,0 +1,42 @@
+import type {Metadata} from "@khanacademy/wonder-stuff-core";
+
+import {GqlError, GqlErrors} from "./gql-error";
+import type {GqlErrorResultPayload} from "./gql-types";
+
+/**
+ * A GraphQL response that completed but reported errors.
+ *
+ * GraphQL servers can return a valid response payload that carries both an
+ * `errors` array and a `data` object. Fields that failed are nulled, with the
+ * null propagating up to the nearest nullable ancestor, so the `data` that
+ * comes back is a partial version of the requested `TData`, or null if the
+ * whole result failed. This error exposes that payload with types so callers
+ * can make use of the partial data without guessing at the shape.
+ *
+ * The payload is also attached as `metadata` so that logging sees the same
+ * details it always did.
+ */
+export class ErrorResultGqlError<TData> extends GqlError {
+    /**
+     * The HTTP status code of the response.
+     */
+    readonly statusCode: number;
+
+    /**
+     * The parsed response payload, including the partial data and errors.
+     */
+    readonly result: GqlErrorResultPayload<TData>;
+
+    constructor(statusCode: number, result: GqlErrorResultPayload<TData>) {
+        super("GraphQL errors", GqlErrors.ErrorResult, {
+            metadata: {
+                statusCode,
+                // The payload is parsed JSON, so it is valid metadata even
+                // though TypeScript cannot prove that from the generic type.
+                result: result as unknown as Metadata,
+            },
+        });
+        this.statusCode = statusCode;
+        this.result = result;
+    }
+}

--- a/packages/wonder-blocks-data/src/util/get-gql-data-from-response.ts
+++ b/packages/wonder-blocks-data/src/util/get-gql-data-from-response.ts
@@ -1,4 +1,5 @@
 import {DataError, DataErrors} from "./data-error";
+import {ErrorResultGqlError} from "./error-result-gql-error";
 import {GqlError, GqlErrors} from "./gql-error";
 
 /**
@@ -52,12 +53,7 @@ export const getGqlDataFromResponse = async <TData>(
         Array.isArray(result.errors) &&
         result.errors.length > 0
     ) {
-        throw new GqlError("GraphQL errors", GqlErrors.ErrorResult, {
-            metadata: {
-                statusCode: response.status,
-                result,
-            },
-        });
+        throw new ErrorResultGqlError<TData>(response.status, result);
     }
 
     // We got here, so return the data.

--- a/packages/wonder-blocks-data/src/util/gql-types.ts
+++ b/packages/wonder-blocks-data/src/util/gql-types.ts
@@ -62,3 +62,36 @@ export type GqlFetchOptions<
     variables?: TVariables;
     context?: Partial<TContext>;
 };
+
+/**
+ * The data of a GraphQL response that reported errors.
+ *
+ * Each top-level field is either the requested value or null. A field that
+ * errored is nulled, and that null propagates to the nearest nullable
+ * ancestor, so the top level of the result is the only level whose shape we
+ * can state with certainty.
+ */
+export type GqlPartialData<TData> = {
+    [K in keyof TData]: TData[K] | null;
+};
+
+/**
+ * An error entry from the `errors` array of a GraphQL response.
+ */
+export type GqlResponseError = {
+    message: string;
+    locations?: ReadonlyArray<{line: number; column: number}>;
+    path?: ReadonlyArray<string | number>;
+    extensions?: Record<string, unknown>;
+};
+
+/**
+ * The payload of a GraphQL response that reported errors.
+ *
+ * `data` is absent or null when the whole operation failed; otherwise it is
+ * the partial data the server was able to resolve.
+ */
+export type GqlErrorResultPayload<TData> = {
+    data?: GqlPartialData<TData> | null;
+    errors: ReadonlyArray<GqlResponseError>;
+};

--- a/packages/wonder-blocks-data/src/util/is-error-result-gql-error.ts
+++ b/packages/wonder-blocks-data/src/util/is-error-result-gql-error.ts
@@ -1,0 +1,15 @@
+import {ErrorResultGqlError} from "./error-result-gql-error";
+
+/**
+ * Determine if an error is an `ErrorResultGqlError`.
+ *
+ * The runtime check cannot verify the shape of the partial data, so `TData`
+ * is asserted rather than proven. Callers should only supply a `TData` that
+ * matches the operation whose response produced the error.
+ *
+ * @param error The value to check.
+ * @returns True if the error is an `ErrorResultGqlError`; otherwise, false.
+ */
+export const isErrorResultGqlError = <TData>(
+    error: unknown,
+): error is ErrorResultGqlError<TData> => error instanceof ErrorResultGqlError;

--- a/packages/wonder-blocks-testing-core/src/__tests__/respond-with.test.ts
+++ b/packages/wonder-blocks-testing-core/src/__tests__/respond-with.test.ts
@@ -180,15 +180,15 @@ describe("RespondWith", () => {
         });
     });
 
-    describe("#graphQL", () => {
+    describe("#graphQLPartialData", () => {
         it("should respond with the given partial data and errors", async () => {
             // Arrange
 
             // Act
-            const response = await RespondWith.graphQL({
-                data: {some: "json", failed: null},
-                errors: [{message: "BOOM!"}],
-            }).toPromise();
+            const response = await RespondWith.graphQLPartialData(
+                {some: "json", failed: null},
+                ["BOOM!"],
+            ).toPromise();
             const result = await response.json();
 
             // Assert
@@ -198,24 +198,29 @@ describe("RespondWith", () => {
             });
         });
 
-        it("should respond with data only when no errors are given", async () => {
+        it("should respond with null data and errors", async () => {
             // Arrange
 
             // Act
-            const response = await RespondWith.graphQL({
-                data: {some: "json"},
-            }).toPromise();
+            const response = await RespondWith.graphQLPartialData(null, [
+                "BOOM!",
+                "BANG!",
+            ]).toPromise();
             const result = await response.json();
 
             // Assert
-            expect(result).toStrictEqual({data: {some: "json"}});
+            expect(result).toStrictEqual({
+                data: null,
+                errors: [{message: "BOOM!"}, {message: "BANG!"}],
+            });
         });
 
         it("should not settle if the signal is not raised", async () => {
             // Arrange
             const settleController = new SettleController();
-            const settleableResponse = RespondWith.graphQL(
-                {data: {result: "SIGNALLED"}, errors: [{message: "BOOM!"}]},
+            const settleableResponse = RespondWith.graphQLPartialData(
+                {result: "SIGNALLED"},
+                ["BOOM!"],
                 settleController.signal,
             ).toPromise();
             const otherResponse = RespondWith.text("NO SIGNAL").toPromise();
@@ -234,8 +239,9 @@ describe("RespondWith", () => {
         it("should settle if the signal is raised", async () => {
             // Arrange
             const settleController = new SettleController();
-            const settleableResponse = RespondWith.graphQL(
-                {data: {result: "SIGNALLED"}, errors: [{message: "BOOM!"}]},
+            const settleableResponse = RespondWith.graphQLPartialData(
+                {result: "SIGNALLED"},
+                ["BOOM!"],
                 settleController.signal,
             ).toPromise();
             const otherResponse = RespondWith.text("NO SIGNAL").toPromise();

--- a/packages/wonder-blocks-testing-core/src/__tests__/respond-with.test.ts
+++ b/packages/wonder-blocks-testing-core/src/__tests__/respond-with.test.ts
@@ -180,6 +180,82 @@ describe("RespondWith", () => {
         });
     });
 
+    describe("#graphQL", () => {
+        it("should respond with the given partial data and errors", async () => {
+            // Arrange
+
+            // Act
+            const response = await RespondWith.graphQL({
+                data: {some: "json", failed: null},
+                errors: [{message: "BOOM!"}],
+            }).toPromise();
+            const result = await response.json();
+
+            // Assert
+            expect(result).toStrictEqual({
+                data: {some: "json", failed: null},
+                errors: [{message: "BOOM!"}],
+            });
+        });
+
+        it("should respond with data only when no errors are given", async () => {
+            // Arrange
+
+            // Act
+            const response = await RespondWith.graphQL({
+                data: {some: "json"},
+            }).toPromise();
+            const result = await response.json();
+
+            // Assert
+            expect(result).toStrictEqual({data: {some: "json"}});
+        });
+
+        it("should not settle if the signal is not raised", async () => {
+            // Arrange
+            const settleController = new SettleController();
+            const settleableResponse = RespondWith.graphQL(
+                {data: {result: "SIGNALLED"}, errors: [{message: "BOOM!"}]},
+                settleController.signal,
+            ).toPromise();
+            const otherResponse = RespondWith.text("NO SIGNAL").toPromise();
+
+            // Act
+            const firstResponse = await Promise.race([
+                settleableResponse,
+                otherResponse,
+            ]);
+            const result = await firstResponse.text();
+
+            // Assert
+            expect(result).toBe("NO SIGNAL");
+        });
+
+        it("should settle if the signal is raised", async () => {
+            // Arrange
+            const settleController = new SettleController();
+            const settleableResponse = RespondWith.graphQL(
+                {data: {result: "SIGNALLED"}, errors: [{message: "BOOM!"}]},
+                settleController.signal,
+            ).toPromise();
+            const otherResponse = RespondWith.text("NO SIGNAL").toPromise();
+
+            // Act
+            settleController.settle();
+            const firstResponse = await Promise.race([
+                settleableResponse,
+                otherResponse,
+            ]);
+            const result = await firstResponse.json();
+
+            // Assert
+            expect(result).toStrictEqual({
+                data: {result: "SIGNALLED"},
+                errors: [{message: "BOOM!"}],
+            });
+        });
+    });
+
     describe("#unparseableBody", () => {
         it("should reject JSON as unparseable", async () => {
             // Arrange

--- a/packages/wonder-blocks-testing-core/src/index.ts
+++ b/packages/wonder-blocks-testing-core/src/index.ts
@@ -7,6 +7,8 @@ export type {MockResponse} from "./respond-with";
 export type {FetchMockFn, FetchMockOperation} from "./fetch/types";
 export type {
     GraphQLJson,
+    GraphQLPartialData,
+    GraphQLResponseError,
     MockFn,
     OperationMock,
     OperationMatcher,

--- a/packages/wonder-blocks-testing-core/src/respond-with.ts
+++ b/packages/wonder-blocks-testing-core/src/respond-with.ts
@@ -125,6 +125,23 @@ export const RespondWith = Object.freeze({
         ),
 
     /**
+     * Response with the given GraphQL JSON body and status code 200.
+     *
+     * Use this to mock a response that carries both partial data and errors.
+     * For data-only or errors-only responses, `graphQLData` and
+     * `graphQLErrors` are more succinct.
+     */
+    graphQL: <TData extends Record<any, any>>(
+        result: GraphQLJson<TData>,
+        signal: SettleSignal | null = null,
+    ): MockResponse<GraphQLJson<TData>> =>
+        textResponse<GraphQLJson<TData>>(
+            () => JSON.stringify(result),
+            200,
+            signal,
+        ),
+
+    /**
      * Response with body that will not parse as JSON and status code 200.
      */
     unparseableBody: (signal: SettleSignal | null = null): MockResponse<any> =>

--- a/packages/wonder-blocks-testing-core/src/respond-with.ts
+++ b/packages/wonder-blocks-testing-core/src/respond-with.ts
@@ -1,6 +1,6 @@
 import {SettleSignal} from "./settle-signal";
 
-import type {GraphQLJson} from "./types";
+import type {GraphQLJson, GraphQLPartialData} from "./types";
 
 /**
  * This symbol is used so we can create an opaque type, using a custom field
@@ -125,18 +125,26 @@ export const RespondWith = Object.freeze({
         ),
 
     /**
-     * Response with the given GraphQL JSON body and status code 200.
+     * Response with GraphQL partial data and errors and status code 200.
      *
-     * Use this to mock a response that carries both partial data and errors.
-     * For data-only or errors-only responses, `graphQLData` and
-     * `graphQLErrors` are more succinct.
+     * This mocks a response where some fields resolved and others failed:
+     * the body carries both `data`, with the failed fields set to null, and
+     * `errors`. Use `graphQLData` for a data-only response and
+     * `graphQLErrors` for an errors-only response.
      */
-    graphQL: <TData extends Record<any, any>>(
-        result: GraphQLJson<TData>,
+    graphQLPartialData: <TData extends Record<any, any>>(
+        data: GraphQLPartialData<TData> | null,
+        errorMessages: ReadonlyArray<string>,
         signal: SettleSignal | null = null,
     ): MockResponse<GraphQLJson<TData>> =>
         textResponse<GraphQLJson<TData>>(
-            () => JSON.stringify(result),
+            () =>
+                JSON.stringify({
+                    data,
+                    errors: errorMessages.map((e) => ({
+                        message: e,
+                    })),
+                }),
             200,
             signal,
         ),

--- a/packages/wonder-blocks-testing-core/src/types.ts
+++ b/packages/wonder-blocks-testing-core/src/types.ts
@@ -4,14 +4,39 @@ import type {MockResponse} from "./respond-with";
  * A valid GraphQL response as supported by our mocking framework.
  * Note that we don't currently support both data and errors being set.
  */
+/**
+ * An error entry from the `errors` array of a GraphQL response.
+ */
+export type GraphQLResponseError = {
+    message: string;
+};
+
+/**
+ * The data of a GraphQL response that also reported errors.
+ *
+ * A field that errored is nulled, so each top-level field is either the
+ * requested value or null.
+ */
+export type GraphQLPartialData<TData extends Record<any, any>> = {
+    [K in keyof TData]: TData[K] | null;
+};
+
+/**
+ * The JSON body of a GraphQL response.
+ *
+ * A response carries data, errors, or both. When both are present, the data
+ * is partial: the fields that failed are null.
+ */
 export type GraphQLJson<TData extends Record<any, any>> =
     | {
           data: TData;
       }
     | {
-          errors: Array<{
-              message: string;
-          }>;
+          errors: Array<GraphQLResponseError>;
+      }
+    | {
+          data: GraphQLPartialData<TData> | null;
+          errors: Array<GraphQLResponseError>;
       };
 
 export interface MockFn<TOperationType, TResponseData> {


### PR DESCRIPTION
## Summary

When a GraphQL response succeeds at the HTTP level but reports `errors`, `getGqlDataFromResponse` throws a `GqlError` whose metadata carries the whole parsed payload, including any partial `data` the server resolved. Nothing in the types said so, which forced consumers to suppress TypeScript to reach it, and that unchecked access crashed on every other failure mode.

**wonder-blocks-data:** adds `ErrorResultGqlError<TData>`, thrown in that case, which exposes a typed `statusCode` and `result` payload (partial data plus errors), along with the `isErrorResultGqlError` type guard and the `GqlPartialData`, `GqlResponseError`, and `GqlErrorResultPayload` types. The error is still a `GqlError` of kind `ErrorResult` and its `metadata` is unchanged, so logging and existing consumers are unaffected.

Partial data is typed as nullable top-level fields rather than `Partial<TData>`, because a failed field is nulled and the null propagates to the nearest nullable ancestor. The typed payload lives on a dedicated `result` field rather than narrowing `metadata`, since wonder-stuff-core's `Metadata` type cannot carry an arbitrary `TData`.

**wonder-blocks-testing-core:** adds `RespondWith.graphQLPartialData(data, errorMessages)` so tests can mock a response carrying both partial `data` and `errors` with types. `graphQLData` and `graphQLErrors` each produce only one of the two, which previously forced a hand-built `RespondWith.json(...)` body. `GraphQLJson` gains the data-plus-errors variant, and `GraphQLPartialData` and `GraphQLResponseError` are exported.

Issue: FEI-8254

## Test plan

- `pnpm jest packages/wonder-blocks-data packages/wonder-blocks-testing-core` passes, including new tests for the error class, the type guard, the response parser, and `RespondWith.graphQLPartialData`.
- `pnpm typecheck` and `pnpm lint:ci` on both packages pass.
- In a consumer, catch the rejection from `useGql`'s fetch for a response mocked with `RespondWith.graphQLPartialData({...}, ["message"])`, and confirm `isErrorResultGqlError(error)` narrows so `error.result.data` is typed without suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqB3n5dwtwE8TsX88qfSbT