### PR TITLE
Add controlled state to Accordion

### DIFF
--- a/.changeset/heavy-pumas-count.md
+++ b/.changeset/heavy-pumas-count.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/wonder-blocks-accordion": minor
+---
+
+Accordion: add controlled mode via the `expandedIndices` and `onToggle` props, and fix the `id` prop so it is set on the accordion itself instead of being duplicated onto every list item

--- a/__docs__/wonder-blocks-accordion/accordion.argtypes.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.argtypes.tsx
@@ -33,12 +33,43 @@ export default {
         description: `The index of the AccordionSection that should be expanded
             when the Accordion is first rendered. If not specified, no
             AccordionSections will be expanded when the Accordion is first
-            rendered.`,
+            rendered. This is only read on the first render, so use
+            \`expandedIndices\` instead if you need to control the expanded
+            state after that. Cannot be used with \`expandedIndices\`.`,
         table: {
             category: "State",
             type: {summary: "number"},
         },
         type: {name: "number", required: false},
+    },
+    expandedIndices: {
+        control: {type: "object"},
+        description: `The indices of the AccordionSections that are currently
+            expanded. Passing this prop puts the Accordion into controlled
+            mode: the parent owns the expanded state, and the Accordion only
+            reports changes via \`onToggle\`. Cannot be used with
+            \`initialExpandedIndex\`.`,
+        table: {
+            category: "State",
+            type: {summary: "ReadonlyArray<number>"},
+        },
+        type: {name: "other", required: false, value: "ReadonlyArray<number>"},
+    },
+    onToggle: {
+        control: {type: undefined},
+        description: `Called when a section is toggled. It is passed the index
+            of the section that was toggled, along with the indices of every
+            section that is expanded as a result of the toggle. In controlled
+            mode, the second argument is the value that should be passed back
+            in as \`expandedIndices\`.`,
+        table: {
+            category: "Events",
+            type: {
+                summary:
+                    "(toggledIndex: number, allExpandedIndices: Array<number>) => unknown",
+            },
+        },
+        type: {name: "function", required: false},
     },
     allowMultipleExpanded: {
         control: {type: "boolean"},

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -283,6 +283,63 @@ export const WithInitialExpandedIndex: StoryComponentType = {
 };
 
 /**
+ * An Accordion can be controlled by passing in the `expandedIndices` prop
+ * along with the `onToggle` prop. In controlled mode, the parent owns the
+ * expanded state: clicking a section header does not expand or collapse it
+ * on its own, it calls `onToggle` so the parent can decide what happens.
+ *
+ * `onToggle` is passed the index of the section that was toggled, along with
+ * the indices of every section that would be expanded as a result of the
+ * toggle. That second argument is the value to pass back in as
+ * `expandedIndices`.
+ *
+ * This is useful when something outside of the Accordion needs to change
+ * which sections are expanded, like the "Expand all" and "Collapse all"
+ * buttons in this example.
+ *
+ * NOTE: `expandedIndices` cannot be used with `initialExpandedIndex`. Use
+ * `initialExpandedIndex` when the Accordion should manage its own state.
+ */
+export const Controlled: StoryComponentType = {
+    render: function Render() {
+        const [expandedIndices, setExpandedIndices] = React.useState<
+            Array<number>
+        >([1]);
+
+        return (
+            <View>
+                <View style={styles.controlButtons}>
+                    <Button
+                        kind="secondary"
+                        onClick={() =>
+                            setExpandedIndices(
+                                exampleSections.map((_, index) => index),
+                            )
+                        }
+                    >
+                        Expand all
+                    </Button>
+                    <Button
+                        kind="secondary"
+                        onClick={() => setExpandedIndices([])}
+                    >
+                        Collapse all
+                    </Button>
+                </View>
+                <Accordion
+                    expandedIndices={expandedIndices}
+                    onToggle={(_, allExpandedIndices) =>
+                        setExpandedIndices(allExpandedIndices)
+                    }
+                >
+                    {exampleSections}
+                </Accordion>
+            </View>
+        );
+    },
+};
+
+/**
  * An Accordion can be animated using the `animated` prop. This
  * animation includes the caret, the expansion/collapse, and the last
  * section's border radius. In this example, animated accordions with
@@ -682,6 +739,11 @@ const styles = StyleSheet.create({
     },
     button: {
         width: "fit-content",
+        marginBlockEnd: sizing.size_160,
+    },
+    controlButtons: {
+        flexDirection: "row",
+        gap: sizing.size_080,
         marginBlockEnd: sizing.size_160,
     },
 });

--- a/__docs__/wonder-blocks-accordion/accordion.stories.tsx
+++ b/__docs__/wonder-blocks-accordion/accordion.stories.tsx
@@ -301,6 +301,11 @@ export const WithInitialExpandedIndex: StoryComponentType = {
  * `initialExpandedIndex` when the Accordion should manage its own state.
  */
 export const Controlled: StoryComponentType = {
+    parameters: {
+        chromatic: {
+            disableSnapshot: true,
+        },
+    },
     render: function Render() {
         const [expandedIndices, setExpandedIndices] = React.useState<
             Array<number>

--- a/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
+++ b/packages/wonder-blocks-accordion/src/components/__tests__/accordion.test.tsx
@@ -702,4 +702,446 @@ describe("Accordion", () => {
             },
         );
     });
+
+    describe("controlled mode", () => {
+        it("expands the sections listed in expandedIndices", async () => {
+            // Arrange
+            render(
+                <Accordion expandedIndices={[0, 2]}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 3">
+                        Section 3 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const content = await screen.findByText("Section 3 content");
+
+            // Assert
+            expect(content).toBeVisible();
+        });
+
+        it("collapses the sections that are not listed in expandedIndices", async () => {
+            // Arrange
+            render(
+                <Accordion expandedIndices={[0, 2]}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 3">
+                        Section 3 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const content = await screen.findByText("Section 2 content");
+
+            // Assert
+            expect(content).not.toBeVisible();
+        });
+
+        it("keeps every section collapsed when expandedIndices is empty", async () => {
+            // Arrange
+            render(
+                <Accordion expandedIndices={[]}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Section 1"}),
+            );
+
+            // Assert
+            expect(screen.getByText("Section 1 content")).not.toBeVisible();
+        });
+
+        it("does not change the expanded state when a section is clicked", async () => {
+            // Arrange
+            render(
+                <Accordion expandedIndices={[1]}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Section 2"}),
+            );
+
+            // Assert
+            expect(screen.getByText("Section 2 content")).toBeVisible();
+        });
+
+        it("updates the expanded sections when expandedIndices changes", async () => {
+            // Arrange
+            const {rerender} = render(
+                <Accordion expandedIndices={[0]}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            rerender(
+                <Accordion expandedIndices={[1]}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+            );
+
+            // Assert
+            expect(screen.getByText("Section 2 content")).toBeVisible();
+        });
+
+        it("collapses a section when it is removed from expandedIndices", async () => {
+            // Arrange
+            const {rerender} = render(
+                <Accordion expandedIndices={[0]}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            rerender(
+                <Accordion expandedIndices={[1]}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+            );
+
+            // Assert
+            expect(screen.getByText("Section 1 content")).not.toBeVisible();
+        });
+
+        it("expands the section that the consumer opens in response to onToggle", async () => {
+            // Arrange
+            const ControlledAccordion = () => {
+                const [expandedIndices, setExpandedIndices] = React.useState<
+                    Array<number>
+                >([]);
+                return (
+                    <Accordion
+                        expandedIndices={expandedIndices}
+                        onToggle={(_, allExpandedIndices) =>
+                            setExpandedIndices(allExpandedIndices)
+                        }
+                    >
+                        <AccordionSection header="Section 1">
+                            Section 1 content
+                        </AccordionSection>
+                        <AccordionSection header="Section 2">
+                            Section 2 content
+                        </AccordionSection>
+                    </Accordion>
+                );
+            };
+            render(<ControlledAccordion />, {wrapper: RenderStateRoot});
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Section 2"}),
+            );
+
+            // Assert
+            expect(screen.getByText("Section 2 content")).toBeVisible();
+        });
+    });
+
+    describe("onToggle", () => {
+        it("is called with the index of the section that was toggled", async () => {
+            // Arrange
+            const onToggleSpy = jest.fn();
+            render(
+                <Accordion onToggle={onToggleSpy}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Section 2"}),
+            );
+
+            // Assert
+            expect(onToggleSpy).toHaveBeenCalledWith(1, expect.anything());
+        });
+
+        it("is called with the indices of every expanded section", async () => {
+            // Arrange
+            const onToggleSpy = jest.fn();
+            render(
+                <Accordion initialExpandedIndex={0} onToggle={onToggleSpy}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 3">
+                        Section 3 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Section 3"}),
+            );
+
+            // Assert
+            expect(onToggleSpy).toHaveBeenCalledWith(2, [0, 2]);
+        });
+
+        it("is called with the remaining expanded indices when a section is closed", async () => {
+            // Arrange
+            const onToggleSpy = jest.fn();
+            render(
+                <Accordion expandedIndices={[0, 1]} onToggle={onToggleSpy}>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Section 1"}),
+            );
+
+            // Assert
+            expect(onToggleSpy).toHaveBeenCalledWith(0, [1]);
+        });
+
+        it("is called with only the newly expanded index when allowMultipleExpanded is false", async () => {
+            // Arrange
+            const onToggleSpy = jest.fn();
+            render(
+                <Accordion
+                    expandedIndices={[0]}
+                    allowMultipleExpanded={false}
+                    onToggle={onToggleSpy}
+                >
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Section 2"}),
+            );
+
+            // Assert
+            expect(onToggleSpy).toHaveBeenCalledWith(1, [1]);
+        });
+
+        it("is called alongside the child's own onToggle", async () => {
+            // Arrange
+            const childOnToggleSpy = jest.fn();
+            render(
+                <Accordion onToggle={jest.fn()}>
+                    <AccordionSection
+                        header="Section 1"
+                        onToggle={childOnToggleSpy}
+                    >
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            await userEvent.click(
+                await screen.findByRole("button", {name: "Section 1"}),
+            );
+
+            // Assert
+            expect(childOnToggleSpy).toHaveBeenCalledExactlyOnceWith(true);
+        });
+    });
+
+    describe("ids", () => {
+        it("sets the id on the accordion list", () => {
+            // Arrange
+            render(
+                <Accordion id="test-accordion">
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const list = screen.getByRole("list");
+
+            // Assert
+            expect(list).toHaveAttribute("id", "test-accordion");
+        });
+
+        it.each([0, 1])(
+            "gives the list item at index %i a unique id derived from the accordion id",
+            (index) => {
+                // Arrange
+                render(
+                    <Accordion id="test-accordion">
+                        <AccordionSection header="Section 1">
+                            Section 1 content
+                        </AccordionSection>
+                        <AccordionSection header="Section 2">
+                            Section 2 content
+                        </AccordionSection>
+                    </Accordion>,
+                    {wrapper: RenderStateRoot},
+                );
+
+                // Act
+                const listItem = screen.getAllByRole("listitem")[index];
+
+                // Assert
+                expect(listItem).toHaveAttribute(
+                    "id",
+                    `test-accordion-section-${index}`,
+                );
+            },
+        );
+
+        it("does not set an id on the list items when the accordion has no id", () => {
+            // Arrange
+            render(
+                <Accordion>
+                    <AccordionSection header="Section 1">
+                        Section 1 content
+                    </AccordionSection>
+                    <AccordionSection header="Section 2">
+                        Section 2 content
+                    </AccordionSection>
+                </Accordion>,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const listItem = screen.getAllByRole("listitem")[0];
+
+            // Assert
+            expect(listItem).not.toHaveAttribute("id");
+        });
+    });
+
+    describe("Accessibility", () => {
+        describe("axe", () => {
+            it("should not have any violations when sections are expanded", async () => {
+                // Arrange
+                const {container} = render(
+                    <Accordion id="test-accordion" expandedIndices={[0, 1]}>
+                        <AccordionSection header="Section 1">
+                            Section 1 content
+                        </AccordionSection>
+                        <AccordionSection header="Section 2">
+                            Section 2 content
+                        </AccordionSection>
+                    </Accordion>,
+                    {wrapper: RenderStateRoot},
+                );
+
+                // Act
+
+                // Assert
+                await expect(container).toHaveNoA11yViolations();
+            });
+        });
+
+        describe("ARIA", () => {
+            it.each(["expandedIndices", "initialExpandedIndex"])(
+                "does not forward the %s prop to the DOM",
+                (propName) => {
+                    // Arrange
+                    render(
+                        <Accordion expandedIndices={[0]}>
+                            <AccordionSection header="Section 1">
+                                Section 1 content
+                            </AccordionSection>
+                            <AccordionSection header="Section 2">
+                                Section 2 content
+                            </AccordionSection>
+                        </Accordion>,
+                        {wrapper: RenderStateRoot},
+                    );
+
+                    // Act
+                    const list = screen.getByRole("list");
+
+                    // Assert
+                    expect(list).not.toHaveAttribute(propName.toLowerCase());
+                },
+            );
+        });
+    });
 });

--- a/packages/wonder-blocks-accordion/src/components/accordion.tsx
+++ b/packages/wonder-blocks-accordion/src/components/accordion.tsx
@@ -13,6 +13,32 @@ export type AccordionCornerKindType =
     | "rounded"
     | "rounded-per-section";
 
+type ControlledProps = {
+    /**
+     * The indices of the AccordionSections that are currently expanded.
+     *
+     * Passing this prop puts the Accordion into controlled mode: the parent
+     * owns the expanded state, and the Accordion only reports changes via
+     * `onToggle`. Use `initialExpandedIndex` instead if you want the
+     * Accordion to manage the expanded state itself.
+     */
+    expandedIndices: ReadonlyArray<number>;
+    initialExpandedIndex?: never;
+};
+
+type UncontrolledProps = {
+    /**
+     * The index of the AccordionSection that should be expanded when the
+     * Accordion is first rendered. If not specified, no AccordionSections
+     * will be expanded when the Accordion is first rendered.
+     *
+     * This is only read on the first render. Use `expandedIndices` if you
+     * need to control the expanded state after that.
+     */
+    initialExpandedIndex?: number;
+    expandedIndices?: never;
+};
+
 type Props = AriaProps & {
     /**
      * The unique identifier for the accordion.
@@ -24,12 +50,6 @@ type Props = AriaProps & {
     children: Array<
         React.ReactElement<React.ComponentProps<typeof AccordionSection>>
     >;
-    /**
-     * The index of the AccordionSection that should be expanded when the
-     * Accordion is first rendered. If not specified, no AccordionSections
-     * will be expanded when the Accordion is first rendered.
-     */
-    initialExpandedIndex?: number;
     /**
      * Whether multiple AccordionSections can be expanded at the same time.
      * If not specified, multiple AccordionSections can be expanded at a time.
@@ -73,7 +93,18 @@ type Props = AriaProps & {
      * Custom styles for the overall accordion container.
      */
     style?: StyleType;
-};
+    /**
+     * Called when a section is toggled. It is passed the index of the section
+     * that was toggled, along with the indices of every section that is
+     * expanded as a result of the toggle. In controlled mode, the second
+     * argument is the value that should be passed back in as
+     * `expandedIndices`.
+     */
+    onToggle?: (
+        toggledIndex: number,
+        allExpandedIndices: Array<number>,
+    ) => unknown;
+} & (ControlledProps | UncontrolledProps);
 
 const LANDMARK_PROLIFERATION_THRESHOLD = 6;
 
@@ -113,22 +144,49 @@ const Accordion = React.forwardRef(function Accordion(
     const {
         children,
         id,
-        initialExpandedIndex,
         allowMultipleExpanded = true,
         caretPosition,
         cornerKind = "rounded",
         animated,
         style,
+        onToggle,
+        expandedIndices,
+        initialExpandedIndex,
         ...ariaProps
     } = props;
 
-    // Starting array for the initial expanded state of each section.
-    const startingArray = Array(children.length).fill(false);
-    // If initialExpandedIndex is specified, we want to open that section.
-    if (initialExpandedIndex !== undefined) {
-        startingArray[initialExpandedIndex] = true;
-    }
-    const [sectionsOpened, setSectionsOpened] = React.useState(startingArray);
+    // The Accordion is controlled when the consumer passes expandedIndices.
+    // In that case the expanded state comes from that prop instead of from
+    // our internal state.
+    const isControlled = expandedIndices !== undefined;
+
+    const [internalSectionsOpened, setInternalSectionsOpened] = React.useState(
+        () => {
+            // Starting array for the initial expanded state of each section.
+            const startingArray: Array<boolean> = Array(children.length).fill(
+                false,
+            );
+            // If initialExpandedIndex is specified, we want to open that
+            // section.
+            if (initialExpandedIndex !== undefined) {
+                startingArray[initialExpandedIndex] = true;
+            }
+            return startingArray;
+        },
+    );
+
+    const controlledSectionsOpened = React.useMemo(() => {
+        if (expandedIndices === undefined) {
+            return null;
+        }
+        const openedArray: Array<boolean> = Array(children.length).fill(false);
+        for (const index of expandedIndices) {
+            openedArray[index] = true;
+        }
+        return openedArray;
+    }, [children.length, expandedIndices]);
+
+    const sectionsOpened = controlledSectionsOpened ?? internalSectionsOpened;
 
     //  NOTE: It may seem like we should filter out non-collapsible sections
     //  here as they are effectively disabled. However, we should keep these
@@ -153,17 +211,23 @@ const Accordion = React.forwardRef(function Accordion(
     ) => {
         // If allowMultipleExpanded is false, we want to close all other
         // sections when one is opened.
-        const newSectionsOpened = allowMultipleExpanded
+        const newSectionsOpened: Array<boolean> = allowMultipleExpanded
             ? [...sectionsOpened]
             : Array(children.length).fill(false);
         const newOpenedValueAtIndex = !sectionsOpened[index];
 
         newSectionsOpened[index] = newOpenedValueAtIndex;
-        setSectionsOpened(newSectionsOpened);
-
-        if (childOnToggle) {
-            childOnToggle(newOpenedValueAtIndex);
+        if (!isControlled) {
+            setInternalSectionsOpened(newSectionsOpened);
         }
+
+        childOnToggle?.(newOpenedValueAtIndex);
+        onToggle?.(
+            index,
+            newSectionsOpened.flatMap((isOpened, sectionIndex) =>
+                isOpened ? [sectionIndex] : [],
+            ),
+        );
     };
 
     /**
@@ -233,6 +297,7 @@ const Accordion = React.forwardRef(function Accordion(
     return (
         // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- TODO(WB-1881): Address a11y error
         <StyledUl
+            id={id}
             style={[styles.wrapper, style]}
             onKeyDown={handleKeyDown}
             {...ariaProps}
@@ -258,7 +323,10 @@ const Accordion = React.forwardRef(function Accordion(
                     // If the AccordionSections are rendered within the
                     // Accordion, they are part of a list, so they should
                     // be list items.
-                    <li key={index} id={id}>
+                    <li
+                        key={index}
+                        id={id ? `${id}-section-${index}` : undefined}
+                    >
                         {React.cloneElement(child, {
                             // Prioritize AccordionSection's props when
                             // they're overloading Accordion's props.
@@ -268,7 +336,7 @@ const Accordion = React.forwardRef(function Accordion(
                             // AccordionSection's expanded prop does not get
                             // used here when it's rendered within Accordion
                             // since the expanded state is managed by Accordion.
-                            expanded: sectionsOpened[index],
+                            expanded: sectionsOpened[index] ?? false,
                             onToggle: () =>
                                 handleSectionClick(index, childOnToggle),
                             isFirstSection: isFirstChild,


### PR DESCRIPTION
Adds controlled state to Accordion via `expandedIndices` (mutually exclusive from `initialExpandedIndex`) and `onToggle`. The changes are completely backwards-compatible; purely additive.

Also fixes a bug where every AccordionSection in Accordion got the same `id`, a spec violation.

Issue: WB-2446