### PR TITLE
MinTarget Style: swap out "after" for "before"

### DIFF
--- a/.changeset/ten-icons-search.md
+++ b/.changeset/ten-icons-search.md
@@ -1,22 +1,7 @@
 ---
-"@khanacademy/wonder-blocks-styles": major
+"@khanacademy/wonder-blocks-styles": minor
 "@khanacademy/wonder-blocks-clickable": patch
 "@khanacademy/wonder-blocks-link": patch
 ---
 
 Swap out the `::after` pseudo-element for `::before` in `minTargetSizeStyles.minTargetSize` so that Cypress doesn't claim the element is obscured by another element. `::before` paints before the element's children, so when a test targets a descendant of a `Clickable` or `Link`, `elementFromPoint` resolves to that descendant rather than to the clickable ancestor. Pointer events on a pseudo-element still target the originating element, so the 24x24 target size guarantee is unchanged.
-
-**Breaking:** `minTargetSizeStyles.minTargetSize` now defines `::before` instead of `::after`. If you spread `minTargetSize["::after"]` into a rule of your own, change both the key you spread from and the rule you spread into to `::before`:
-
-```tsx
-<Clickable
-    style={{
-        "::before": {
-            ...minTargetSizeStyles.minTargetSize["::before"],
-            boxShadow: boxShadow.mid,
-        },
-    }}
->
-```
-
-Note that `:before` and `::before` are the same pseudo-element, so a `style` of your own that defines either form now collides with the hit area where a `::after` rule previously did not. `Cell` is the in-repo example: it draws the left bar indicator for its active and press states with `:before`, so it continues to set `disableMinTargetSize` internally.

--- a/.changeset/ten-icons-search.md
+++ b/.changeset/ten-icons-search.md
@@ -1,8 +1,22 @@
 ---
-"@khanacademy/wonder-blocks-styles": minor
+"@khanacademy/wonder-blocks-styles": major
 "@khanacademy/wonder-blocks-clickable": patch
-"@khanacademy/wonder-blocks-cell": patch
 "@khanacademy/wonder-blocks-link": patch
 ---
 
-Swap out `::after` pseudoelement for `::before` so that Cypress doesn't claim the element is obscured by another element.
+Swap out the `::after` pseudo-element for `::before` in `minTargetSizeStyles.minTargetSize` so that Cypress doesn't claim the element is obscured by another element. `::before` paints before the element's children, so when a test targets a descendant of a `Clickable` or `Link`, `elementFromPoint` resolves to that descendant rather than to the clickable ancestor. Pointer events on a pseudo-element still target the originating element, so the 24x24 target size guarantee is unchanged.
+
+**Breaking:** `minTargetSizeStyles.minTargetSize` now defines `::before` instead of `::after`. If you spread `minTargetSize["::after"]` into a rule of your own, change both the key you spread from and the rule you spread into to `::before`:
+
+```tsx
+<Clickable
+    style={{
+        "::before": {
+            ...minTargetSizeStyles.minTargetSize["::before"],
+            boxShadow: boxShadow.mid,
+        },
+    }}
+>
+```
+
+Note that `:before` and `::before` are the same pseudo-element, so a `style` of your own that defines either form now collides with the hit area where a `::after` rule previously did not. `Cell` is the in-repo example: it draws the left bar indicator for its active and press states with `:before`, so it continues to set `disableMinTargetSize` internally.

--- a/.changeset/ten-icons-search.md
+++ b/.changeset/ten-icons-search.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/wonder-blocks-styles": minor
+"@khanacademy/wonder-blocks-clickable": patch
+"@khanacademy/wonder-blocks-cell": patch
+"@khanacademy/wonder-blocks-link": patch
+---
+
+Swap out `::after` pseudoelement for `::before` so that Cypress doesn't claim the element is obscured by another element.

--- a/__docs__/wonder-blocks-clickable/accessibility.mdx
+++ b/__docs__/wonder-blocks-clickable/accessibility.mdx
@@ -66,7 +66,7 @@ make sure to use `href` and `skipClientNav={true}`.
 
 `Clickable` guarantees a minimum 24x24 pointer target, satisfying
 [WCAG 2.5.8 (Target Size, Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
-The hit area is expanded with a transparent `::after` pseudo-element rather than
+The hit area is expanded with a transparent `::before` pseudo-element rather than
 by growing the element, so the visual layout is unchanged.
 
 Both squares below are 12x12. The first has the default hit area and is
@@ -81,12 +81,11 @@ Set `disableMinTargetSize` when:
 - The expanded hit area would overlap an adjacent target.
 - The `Clickable` wraps its own interactive elements that the hit area would
   otherwise cover.
-- **The element already draws its own `after`.** `:after` and `::after` are
+- **The element already draws its own `before`.** `:before` and `::before` are
   the same pseudo-element, so a style you pass via `style` that defines either
   form collides with the hit area: an Aphrodite style merges with it
-  per-property, while a plain object replaces it outright. `Cell` is the
-  in-repo example: it draws its horizontal rule with `:after` on the
-  `Clickable` element, so it opts out. To keep both, spread the hit area into
+  per-property, while a plain object replaces it outright. To keep both, spread
+  the hit area into
   <LinkTo title="Packages / Styles / Min Target Size Styles" story="docs">your own rule</LinkTo>
   instead.
 - You can guarantee that the size of the clickable element will always be at

--- a/__docs__/wonder-blocks-clickable/accessibility.mdx
+++ b/__docs__/wonder-blocks-clickable/accessibility.mdx
@@ -84,8 +84,10 @@ Set `disableMinTargetSize` when:
 - **The element already draws its own `before`.** `:before` and `::before` are
   the same pseudo-element, so a style you pass via `style` that defines either
   form collides with the hit area: an Aphrodite style merges with it
-  per-property, while a plain object replaces it outright. To keep both, spread
-  the hit area into
+  per-property, while a plain object replaces it outright. `Cell` is the
+  in-repo example: it draws the left bar indicator for its active and press
+  states with `:before` on the `Clickable` element, so it opts out. To keep
+  both, spread the hit area into
   <LinkTo title="Packages / Styles / Min Target Size Styles" story="docs">your own rule</LinkTo>
   instead.
 - You can guarantee that the size of the clickable element will always be at

--- a/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
+++ b/__docs__/wonder-blocks-clickable/accessibility.stories.tsx
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
         borderWidth: border.width.medium,
     },
     pseudoShadow: {
-        "::after": {
+        "::before": {
             boxShadow: boxShadow.mid,
         },
     },

--- a/__docs__/wonder-blocks-clickable/clickable.argtypes.ts
+++ b/__docs__/wonder-blocks-clickable/clickable.argtypes.ts
@@ -255,7 +255,7 @@ export default {
     },
     disableMinTargetSize: {
         description: `Whether to disable the minimum 24x24 hit area applied to
-            this component. By default a transparent \`::after\`
+            this component. By default a transparent \`::before\`
             pseudo-element expands the hit area to at least 24x24 to satisfy
             WCAG 2.5.8 (Target Size, Minimum), without changing the visual
             layout.`,
@@ -268,8 +268,8 @@ export default {
                 detail: `Set this to true when: the expanded hit area would
                 overlap an adjacent target; the Clickable wraps its own
                 interactive elements that the hit area would otherwise cover;
-                or the element already draws its own \`::after\`. That last
-                case matters because \`:after\` and \`::after\` are the same
+                or the element already draws its own \`::before\`. That last
+                case matters because \`:before\` and \`::before\` are the same
                 pseudo-element, so a rule you pass via \`style\` and the hit
                 area cascade together and merge per-property, breaking both.
                 Note that applying the hit area also makes the element a

--- a/__docs__/wonder-blocks-link/link.stories.tsx
+++ b/__docs__/wonder-blocks-link/link.stories.tsx
@@ -596,7 +596,7 @@ export const WithState: StoryComponentType = {
 /**
  * `Link` guarantees a minimum 24x24 pointer target, satisfying
  * [WCAG 2.5.8 (Target Size, Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
- * The hit area is expanded with a transparent `::after` pseudo-element rather
+ * The hit area is expanded with a transparent `::before` pseudo-element rather
  * than by growing the element, so the visual layout is unchanged. Note that
  * this also makes the link a containing block (`position: relative`).
  *

--- a/__docs__/wonder-blocks-styles/min-target-size-styles.stories.tsx
+++ b/__docs__/wonder-blocks-styles/min-target-size-styles.stories.tsx
@@ -23,7 +23,7 @@ import {allThemeModes} from "../../.storybook/modes";
  * 24x24, satisfying
  * [WCAG 2.5.8 (Target Size, Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
  *
- * The hit area is expanded with an `::after` pseudo-element rather than by
+ * The hit area is expanded with an `::before` pseudo-element rather than by
  * growing the element, so **the visual layout is unchanged**. `minTargetSize`
  * is used internally by `Clickable` and `Link`, which apply it by default.
  *
@@ -42,13 +42,12 @@ import {allThemeModes} from "../../.storybook/modes";
  *   by the line-height of the surrounding text, and expanding one would steal
  *   clicks from adjacent lines. `Link` skips the hit area for `inline` links
  *   regardless of `disableMinTargetSize`.
- * - **Elements that draw their own `after`.** `:after` and `::after` are the
+ * - **Elements that draw their own `after`.** `:before` and `::before` are the
  *   same pseudo-element, so a rule of your own collides with the hit area. An
  *   Aphrodite style stays its own class and merges with it per-property; a
  *   plain object is merged into the same class and replaces it outright. To
- *   coexist either way, spread the hit area into your own `::after` (see the
- *   scenarios below); otherwise opt out. `Cell` hits this — it draws its
- *   horizontal rule with `:after` — so it opts out internally.
+ *   coexist either way, spread the hit area into your own `::before` (see the
+ *   scenarios below); otherwise opt out.
  * - **Targets closer than 24px apart.** The hit area extends past the
  *   element's visual box, so neighbouring hit areas overlap and the
  *   later-painted one wins.
@@ -81,12 +80,12 @@ const StyledButton = addStyle("button");
 const styles = StyleSheet.create({
     /**
      * The hit area is transparent, so it is invisible in a screenshot. This
-     * contributes a shadow to the same `::after` to make it visible. It shares
+     * contributes a shadow to the same `::before` to make it visible. It shares
      * no property with the hit area, so the per-property cascade merge leaves
      * both intact.
      */
     visibleHitArea: {
-        "::after": {
+        "::before": {
             boxShadow: boxShadow.mid,
         },
     },
@@ -211,7 +210,7 @@ export const Scenarios: Story = {
                 },
             },
             {
-                name: "Composing with your own ::after",
+                name: "Composing with your own ::before",
                 props: {
                     children: (
                         // eslint-disable-next-line @khanacademy/wonder-blocks/no-raw-button
@@ -224,17 +223,17 @@ export const Scenarios: Story = {
                                 background:
                                     semanticColor.core.background.critical
                                         .default,
-                                "::after": {
+                                "::before": {
                                     // the hit area must be spread in, since
-                                    // `:after` and `::after` are the same
+                                    // `:before` and `::before` are the same
                                     // pseudo-element
                                     ...minTargetSizeStyles.minTargetSize[
-                                        "::after"
+                                        "::before"
                                     ],
                                     boxShadow: boxShadow.mid,
                                 },
                             }}
-                            aria-label="Custom button composing ::after"
+                            aria-label="Custom button composing ::before"
                         />
                     ),
                 },

--- a/__docs__/wonder-blocks-styles/min-target-size-styles.stories.tsx
+++ b/__docs__/wonder-blocks-styles/min-target-size-styles.stories.tsx
@@ -23,7 +23,7 @@ import {allThemeModes} from "../../.storybook/modes";
  * 24x24, satisfying
  * [WCAG 2.5.8 (Target Size, Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html).
  *
- * The hit area is expanded with an `::before` pseudo-element rather than by
+ * The hit area is expanded with a `::before` pseudo-element rather than by
  * growing the element, so **the visual layout is unchanged**. `minTargetSize`
  * is used internally by `Clickable` and `Link`, which apply it by default.
  *
@@ -42,12 +42,14 @@ import {allThemeModes} from "../../.storybook/modes";
  *   by the line-height of the surrounding text, and expanding one would steal
  *   clicks from adjacent lines. `Link` skips the hit area for `inline` links
  *   regardless of `disableMinTargetSize`.
- * - **Elements that draw their own `after`.** `:before` and `::before` are the
+ * - **Elements that draw their own `before`.** `:before` and `::before` are the
  *   same pseudo-element, so a rule of your own collides with the hit area. An
  *   Aphrodite style stays its own class and merges with it per-property; a
  *   plain object is merged into the same class and replaces it outright. To
  *   coexist either way, spread the hit area into your own `::before` (see the
- *   scenarios below); otherwise opt out.
+ *   scenarios below); otherwise opt out. `Cell` hits this — it draws the left
+ *   bar indicator for its active and press states with `:before` — so it opts
+ *   out internally.
  * - **Targets closer than 24px apart.** The hit area extends past the
  *   element's visual box, so neighbouring hit areas overlap and the
  *   later-painted one wins.

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -193,6 +193,11 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
                 onClick={onClick}
                 href={href}
                 hideDefaultFocusRing={true}
+                // Cell draws its own `before` pseudo-element (the left bar
+                // indicator for the active/press states); this would conflict.
+                // Cell is always at least `theme.root.sizing.minHeight` tall,
+                // so no target size guarantee is lost.
+                disableMinTargetSize={true}
                 aria-label={ariaLabel ? ariaLabel : undefined}
                 aria-selected={ariaSelected ? ariaSelected : undefined}
                 aria-checked={ariaChecked}

--- a/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
+++ b/packages/wonder-blocks-cell/src/components/internal/cell-core.tsx
@@ -193,8 +193,6 @@ const CellCore = (props: CellCoreProps): React.ReactElement => {
                 onClick={onClick}
                 href={href}
                 hideDefaultFocusRing={true}
-                // Cell has its own `after` pseudo-element; this would conflict
-                disableMinTargetSize={true}
                 aria-label={ariaLabel ? ariaLabel : undefined}
                 aria-selected={ariaSelected ? ariaSelected : undefined}
                 aria-checked={ariaChecked}

--- a/packages/wonder-blocks-clickable/src/components/clickable.tsx
+++ b/packages/wonder-blocks-clickable/src/components/clickable.tsx
@@ -83,12 +83,12 @@ type CommonProps =
          * Whether to disable the minimum 24x24 hit area applied to this
          * component.
          *
-         * By default a transparent `::after` pseudo-element expands the hit
+         * By default a transparent `::before` pseudo-element expands the hit
          * area to at least 24x24 to satisfy WCAG 2.5.8 (Target Size, Minimum).
          *
          * Set this to `true` when:
          * - the expanded area would overlap an adjacent target
-         * - you need to implement a different 'after' pseudo-element
+         * - you need to implement a different 'before' pseudo-element
          *
          * @defaultValue false
          */

--- a/packages/wonder-blocks-link/src/components/link.tsx
+++ b/packages/wonder-blocks-link/src/components/link.tsx
@@ -32,7 +32,7 @@ type CommonProps = AriaProps & {
     /**
      * Whether to disable the minimum 24x24 hit area applied to this link.
      *
-     * By default a transparent `::after` pseudo-element expands the link's hit
+     * By default a transparent `::before` pseudo-element expands the link's hit
      * area to at least 24x24 to satisfy WCAG 2.5.8 (Target Size, Minimum).
      * Set this to `true` where the expanded area would overlap an adjacent
      * target.

--- a/packages/wonder-blocks-styles/src/styles/min-target-size-styles.ts
+++ b/packages/wonder-blocks-styles/src/styles/min-target-size-styles.ts
@@ -17,9 +17,9 @@ import {sizing} from "@khanacademy/wonder-blocks-tokens";
  *   be applied to inline links.
  */
 export const minTargetSize = {
-    // Establishes the containing block for the ::after hit area below.
+    // Establishes the containing block for the ::before hit area below.
     position: "relative",
-    "::after": {
+    "::before": {
         content: "''",
         position: "absolute",
         insetBlockStart: "50%",


### PR DESCRIPTION
Swaps out "after" for "before" pseudoelement since Cypress flagged these as blocking links / buttons (even though they were technically children of those buttons). Now, the link or button sits on top of the extended target area instead of under it, which is probable even better.

~As a bonus, this no longer conflicts with `Cell`'s styles.~ JK.